### PR TITLE
Implement broadcast commands in driver

### DIFF
--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -155,6 +155,10 @@
   "settings": {
     "cmake.configureOnEdit": false,
     "cmake.configureOnOpen": false,
+    "cmake.cmakePath": "cmake",
+    "cmake.generator": "Ninja",
+    "cmake.exportCompileCommandsFile": true,
+
     "ros.distro": "humble",
     "ament-task-provider.envSetup": "source /opt/ros/humble/setup.bash",
     "python.autoComplete.extraPaths": [
@@ -174,6 +178,7 @@
       "/log/**": true,
     },
     "clangd.enable": true,
+    "clangd.path": "clangd",
     "C_Cpp.intelliSenseEngine": "disabled",
     "[cpp]": {
       "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"

--- a/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
+++ b/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
@@ -24,8 +24,6 @@
 #include <cstdint>
 #include <iostream>
 
-#include <boost/endian/buffers.hpp>
-
 #include "drqp_serial/Stream.h"
 
 /// The possible communication errors that can happen when reading the
@@ -194,7 +192,7 @@ struct XYZrobotServoStatus
 
 struct IJogData
 {
-  boost::endian::little_uint16_buf_t goal;
+  uint16_t goal;
   uint8_t type;
   uint8_t id;
   uint8_t playtime;
@@ -211,22 +209,22 @@ public:
   /// before sending the next command to this servo, since writing to EEPROM
   /// takes some time and the servo cannot receive more commands until it is
   /// done.
-  void eepromWrite(uint8_t startAddress, const uint8_t*, uint8_t dataSize);
+  void eepromWrite(uint8_t startAddress, const void* data, uint8_t dataSize);
 
   /// Reads data from the servo's EEPROM and stores it in the specified buffer.
   ///
   /// The data size should be 35 or less: otherwise the A1-16 seems to return a
   /// response with an invalid CRC.
-  void eepromRead(uint8_t startAddress, uint8_t* data, uint8_t dataSize);
+  void eepromRead(uint8_t startAddress, void* data, uint8_t dataSize);
 
   /// Writes data from the specified buffer to the servo's RAM.
-  void ramWrite(uint8_t startAddress, const uint8_t*, uint8_t dataSize);
+  void ramWrite(uint8_t startAddress, const void* data, uint8_t dataSize);
 
   /// Reads data from the servo's RAM and stores it in the specified buffer.
   ///
   /// The data size should be 35 or less: otherwise the A1-16 seems to return a
   /// response with an invalid CRC.
-  void ramRead(uint8_t startAddress, uint8_t* data, uint8_t dataSize);
+  void ramRead(uint8_t startAddress, void* data, uint8_t dataSize);
 
   /// Write the Baud_Rate parameter byte in EEPROM, which determines which baud
   /// rate the servo uses on its serial interface.
@@ -424,17 +422,17 @@ private:
   void flushRead();
 
   void sendRequest(
-    uint8_t headerId, uint8_t cmd, const uint8_t* data1, uint8_t data1Size, const uint8_t* data2 = NULL,
+    uint8_t headerId, uint8_t cmd, const void* data1, uint8_t data1Size, const void* data2 = nullptr,
     uint8_t data2Size = 0);
 
   void readAck(
-    uint8_t cmd, uint8_t* data1, uint8_t data1Size, uint8_t* data2 = NULL, uint8_t data2Size = 0);
+    uint8_t cmd, void* data1, uint8_t data1Size, void* data2 = nullptr, uint8_t data2Size = 0);
 
-  void memoryWrite(uint8_t cmd, uint8_t startAddress, const uint8_t* data, uint8_t dataSize);
+  void memoryWrite(uint8_t cmd, uint8_t startAddress, const void* data, uint8_t dataSize);
 
-  void memoryRead(uint8_t cmd, uint8_t startAddress, uint8_t* data, uint8_t dataSize);
+  void memoryRead(uint8_t cmd, uint8_t startAddress, void* data, uint8_t dataSize);
 
-  void sendIJog(uint16_t goal, uint8_t type, uint8_t playtime);
+  void sendIJog(IJogData data);
 
   XYZrobotServoError lastError;
 

--- a/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
+++ b/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
@@ -201,6 +201,8 @@ struct IJogData
 class XYZrobotServo
 {
 public:
+  static constexpr uint8_t kBroadcastId = 0xFE;
+
   XYZrobotServo(Stream&, uint8_t id);
 
   /// Writes data from the specified buffer to the servo's EEPROM.
@@ -351,6 +353,7 @@ public:
   /// 10 ms.  For example, a playtime of 50 would correspond to 500 ms or 0.5
   /// seconds.
   void setPosition(uint16_t position, uint8_t playtime = 0);
+  void setPositions(IJogData* data, uint8_t count);
 
   /// Sends an I-JOG command to set the speed for this servo.
   ///

--- a/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
+++ b/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
@@ -433,6 +433,7 @@ private:
   void memoryRead(uint8_t cmd, uint8_t startAddress, void* data, uint8_t dataSize);
 
   void sendIJog(IJogData data);
+  void sendMultiIJog(IJogData* data, uint8_t count);
 
   XYZrobotServoError lastError;
 

--- a/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
+++ b/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
@@ -24,6 +24,8 @@
 #include <cstdint>
 #include <iostream>
 
+#include <boost/endian/buffers.hpp>
+
 #include "drqp_serial/Stream.h"
 
 /// The possible communication errors that can happen when reading the
@@ -188,6 +190,14 @@ struct XYZrobotServoStatus
   uint16_t posRef;
   uint16_t position;
   uint16_t iBus;
+} __attribute__((packed));
+
+struct IJogData
+{
+  boost::endian::little_uint16_buf_t goal;
+  uint8_t type;
+  uint8_t id;
+  uint8_t playtime;
 } __attribute__((packed));
 
 class XYZrobotServo
@@ -414,7 +424,7 @@ private:
   void flushRead();
 
   void sendRequest(
-    uint8_t cmd, const uint8_t* data1, uint8_t data1Size, const uint8_t* data2 = NULL,
+    uint8_t headerId, uint8_t cmd, const uint8_t* data1, uint8_t data1Size, const uint8_t* data2 = NULL,
     uint8_t data2Size = 0);
 
   void readAck(

--- a/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
+++ b/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <array>
 
 #include "drqp_serial/Stream.h"
 
@@ -190,6 +191,20 @@ struct XYZrobotServoStatus
   uint16_t iBus;
 } __attribute__((packed));
 
+struct SJogData
+{
+  uint16_t goal;
+  uint8_t type;
+  uint8_t id;
+} __attribute__((packed));
+
+template<size_t ServoCount>
+struct SJogCommand
+{
+  uint8_t playtime;
+  std::array<SJogData, ServoCount> data;
+};
+
 struct IJogData
 {
   uint16_t goal;
@@ -197,6 +212,21 @@ struct IJogData
   uint8_t id;
   uint8_t playtime;
 } __attribute__((packed));
+
+#define SET_POSITION_CONTROL 0
+#define SET_SPEED_CONTROL 1
+#define SET_TORQUE_OFF 2
+#define SET_POSITION_CONTROL_SERVO_ON 3
+
+#define CMD_EEPROM_WRITE 0x01
+#define CMD_EEPROM_READ 0x02
+#define CMD_RAM_WRITE 0x03
+#define CMD_RAM_READ 0x04
+#define CMD_I_JOG 0x05
+#define CMD_S_JOG 0x06
+#define CMD_STAT 0x07
+#define CMD_ROLLBACK 0x08
+#define CMD_REBOOT 0x09
 
 class XYZrobotServo
 {
@@ -421,6 +451,11 @@ public:
     return id;
   }
 
+  template<size_t ServoCount>
+  void sendSJogCommand(SJogCommand<ServoCount>& cmd)
+  {
+    sendRequest(kBroadcastId, CMD_S_JOG, &cmd, sizeof(cmd));
+  }
 private:
   void flushRead();
 

--- a/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
+++ b/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
@@ -213,6 +213,12 @@ struct IJogData
   uint8_t playtime;
 } __attribute__((packed));
 
+template<size_t ServoCount>
+struct IJogCommand
+{
+  std::array<IJogData, ServoCount> data;
+};
+
 #define SET_POSITION_CONTROL 0
 #define SET_SPEED_CONTROL 1
 #define SET_TORQUE_OFF 2
@@ -383,7 +389,6 @@ public:
   /// 10 ms.  For example, a playtime of 50 would correspond to 500 ms or 0.5
   /// seconds.
   void setPosition(uint16_t position, uint8_t playtime = 0);
-  void setPositions(IJogData* data, uint8_t count);
 
   /// Sends an I-JOG command to set the speed for this servo.
   ///
@@ -452,9 +457,15 @@ public:
   }
 
   template<size_t ServoCount>
-  void sendSJogCommand(SJogCommand<ServoCount>& cmd)
+  void sendJogCommand(SJogCommand<ServoCount>& cmd)
   {
     sendRequest(kBroadcastId, CMD_S_JOG, &cmd, sizeof(cmd));
+  }
+
+  template<size_t ServoCount>
+  void sendJogCommand(IJogCommand<ServoCount>& cmd)
+  {
+    sendRequest(kBroadcastId, CMD_I_JOG, &cmd, sizeof(cmd));
   }
 private:
   void flushRead();
@@ -471,7 +482,6 @@ private:
   void memoryRead(uint8_t cmd, uint8_t startAddress, void* data, uint8_t dataSize);
 
   void sendIJog(IJogData data);
-  void sendMultiIJog(IJogData* data, uint8_t count);
 
   XYZrobotServoError lastError;
 

--- a/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
+++ b/packages/drqp_a1_16_driver/include/drqp_a1_16_driver/XYZrobotServo.h
@@ -198,7 +198,7 @@ struct SJogData
   uint8_t id;
 } __attribute__((packed));
 
-template<size_t ServoCount>
+template <size_t ServoCount>
 struct SJogCommand
 {
   uint8_t playtime;
@@ -213,7 +213,7 @@ struct IJogData
   uint8_t playtime;
 } __attribute__((packed));
 
-template<size_t ServoCount>
+template <size_t ServoCount>
 struct IJogCommand
 {
   std::array<IJogData, ServoCount> data;
@@ -456,23 +456,24 @@ public:
     return id;
   }
 
-  template<size_t ServoCount>
+  template <size_t ServoCount>
   void sendJogCommand(SJogCommand<ServoCount>& cmd)
   {
     sendRequest(kBroadcastId, CMD_S_JOG, &cmd, sizeof(cmd));
   }
 
-  template<size_t ServoCount>
+  template <size_t ServoCount>
   void sendJogCommand(IJogCommand<ServoCount>& cmd)
   {
     sendRequest(kBroadcastId, CMD_I_JOG, &cmd, sizeof(cmd));
   }
+
 private:
   void flushRead();
 
   void sendRequest(
-    uint8_t headerId, uint8_t cmd, const void* data1, uint8_t data1Size, const void* data2 = nullptr,
-    uint8_t data2Size = 0);
+    uint8_t headerId, uint8_t cmd, const void* data1, uint8_t data1Size,
+    const void* data2 = nullptr, uint8_t data2Size = 0);
 
   void readAck(
     uint8_t cmd, void* data1, uint8_t data1Size, void* data2 = nullptr, uint8_t data2Size = 0);

--- a/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
+++ b/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
@@ -23,9 +23,8 @@
 #include <cassert>
 #include <cstdio>
 
-static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
-              "This code assumes little-endian byte order.");
-
+static_assert(
+  __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__, "This code assumes little-endian byte order.");
 
 XYZrobotServo::XYZrobotServo(Stream& stream, uint8_t id)
 {

--- a/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
+++ b/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
@@ -41,7 +41,6 @@ static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
 #define SET_TORQUE_OFF 2
 #define SET_POSITION_CONTROL_SERVO_ON 3
 
-constexpr uint8_t kBroadcastId = 0xFE;
 
 XYZrobotServo::XYZrobotServo(Stream& stream, uint8_t id)
 {
@@ -160,6 +159,14 @@ XYZrobotServoStatus XYZrobotServo::readStatus()
 void XYZrobotServo::setPosition(uint16_t position, uint8_t playtime)
 {
   sendIJog({position, SET_POSITION_CONTROL, id, playtime});
+}
+
+void XYZrobotServo::setPositions(IJogData* data, uint8_t count)
+{
+  for (uint8_t i = 0; i < count; i++) {
+    data[i].type = SET_POSITION_CONTROL;
+  }
+  sendMultiIJog(data, count);
 }
 
 void XYZrobotServo::setSpeed(int16_t speed, uint8_t playtime)

--- a/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
+++ b/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
@@ -349,22 +349,12 @@ void XYZrobotServo::memoryRead(uint8_t cmd, uint8_t startAddress, void* data, ui
   }
 }
 
-#define LOW_BYTE(x) (char)((x) & 0xFF)
-#define HIGH_BYTE(x) (char)(((x) & 0xFF00) >> 8)
-
 void XYZrobotServo::sendIJog(IJogData data)
 {
   sendRequest(id, CMD_I_JOG, &data, sizeof(data));
 }
 
-// void XYZrobotServo::sendMultiIJog(uint16_t goal, uint8_t type, uint8_t playtime)
-// {
-//   IJogData data;
-//   data.goalLow = LOW_BYTE(goal);
-//   data.goalHigh = HIGH_BYTE(goal);
-//   data.type = type;
-//   data.id = id;
-//   data.playtime = playtime;
-
-//   sendRequest(0xFE, CMD_I_JOG, &data, sizeof(data));
-// }
+void XYZrobotServo::sendMultiIJog(IJogData* data, uint8_t count)
+{
+  sendRequest(kBroadcastId, CMD_I_JOG, data, sizeof(IJogData) * count);
+}

--- a/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
+++ b/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
@@ -26,21 +26,6 @@
 static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
               "This code assumes little-endian byte order.");
 
-#define CMD_EEPROM_WRITE 0x01
-#define CMD_EEPROM_READ 0x02
-#define CMD_RAM_WRITE 0x03
-#define CMD_RAM_READ 0x04
-#define CMD_I_JOG 0x05
-#define CMD_S_JOG 0x06
-#define CMD_STAT 0x07
-#define CMD_ROLLBACK 0x08
-#define CMD_REBOOT 0x09
-
-#define SET_POSITION_CONTROL 0
-#define SET_SPEED_CONTROL 1
-#define SET_TORQUE_OFF 2
-#define SET_POSITION_CONTROL_SERVO_ON 3
-
 
 XYZrobotServo::XYZrobotServo(Stream& stream, uint8_t id)
 {

--- a/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
+++ b/packages/drqp_a1_16_driver/src/XYZrobotServo.cpp
@@ -146,14 +146,6 @@ void XYZrobotServo::setPosition(uint16_t position, uint8_t playtime)
   sendIJog({position, SET_POSITION_CONTROL, id, playtime});
 }
 
-void XYZrobotServo::setPositions(IJogData* data, uint8_t count)
-{
-  for (uint8_t i = 0; i < count; i++) {
-    data[i].type = SET_POSITION_CONTROL;
-  }
-  sendMultiIJog(data, count);
-}
-
 void XYZrobotServo::setSpeed(int16_t speed, uint8_t playtime)
 {
   sendIJog({static_cast<uint16_t>(speed), SET_SPEED_CONTROL, id, playtime});
@@ -344,9 +336,4 @@ void XYZrobotServo::memoryRead(uint8_t cmd, uint8_t startAddress, void* data, ui
 void XYZrobotServo::sendIJog(IJogData data)
 {
   sendRequest(id, CMD_I_JOG, &data, sizeof(data));
-}
-
-void XYZrobotServo::sendMultiIJog(IJogData* data, uint8_t count)
-{
-  sendRequest(kBroadcastId, CMD_I_JOG, data, sizeof(IJogData) * count);
 }

--- a/packages/drqp_control/include/drqp_control/DrQp.h
+++ b/packages/drqp_control/include/drqp_control/DrQp.h
@@ -44,8 +44,9 @@ enum LegId {
 constexpr size_t kServosPerLeg = 3;
 constexpr const ServoId kServoMinId = 1;
 constexpr const ServoId kServoMaxId = kServoMinId + kServosPerLeg * kLegIdCount;
+constexpr const size_t kServoCount = kServoMaxId - kServoMinId;
 
-using ServoIdsArray = std::array<ServoId, kServoMaxId - kServoMinId>;
+using ServoIdsArray = std::array<ServoId, kServoCount>;
 
 static inline ServoIdsArray servoIdsRange()
 {

--- a/packages/drqp_control/src/Control.cpp
+++ b/packages/drqp_control/src/Control.cpp
@@ -110,12 +110,13 @@ int main(const int argc, const char* const argv[])
     return kNeutralPose;
   }();
 
-  forEachServo(100, [&kPoseSet, &servoSerial](ServoId servoId, int servoIndexInLeg) {
-    XYZrobotServo servo(servoSerial, servoId);
-
-    const ServoPosition position = kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg];
-    servo.setPosition(position, 150);
+  std::array<IJogData, kServoCount> posData;
+  size_t servoIndex = 0;
+  forEachServo(0, [&kPoseSet, &posData, &servoIndex](ServoId servoId, int servoIndexInLeg) {
+    posData[servoIndex++] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], 1, servoId, 150};
   });
+  XYZrobotServo servo(servoSerial, XYZrobotServo::kBroadcastId);
+  servo.setPositions(posData.data(), posData.size());
 
   return 0;
 }

--- a/packages/drqp_control/src/Control.cpp
+++ b/packages/drqp_control/src/Control.cpp
@@ -115,12 +115,15 @@ int main(const int argc, const char* const argv[])
   sposCmd.playtime = 150;
 
   size_t servoIndex = 0;
-  forEachServo(0, [&kPoseSet, &iposCmd, &sposCmd, &servoIndex](ServoId servoId, int servoIndexInLeg) {
-    iposCmd.data[servoIndex] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId, 150};
-    sposCmd.data[servoIndex] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId};
+  forEachServo(
+    0, [&kPoseSet, &iposCmd, &sposCmd, &servoIndex](ServoId servoId, int servoIndexInLeg) {
+      iposCmd.data[servoIndex] = {
+        kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId, 150};
+      sposCmd.data[servoIndex] = {
+        kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId};
 
-    servoIndex++;
-  });
+      servoIndex++;
+    });
   XYZrobotServo servo(servoSerial, XYZrobotServo::kBroadcastId);
   // servo.sendJogCommand(sposCmd);
   servo.sendJogCommand(iposCmd);

--- a/packages/drqp_control/src/Control.cpp
+++ b/packages/drqp_control/src/Control.cpp
@@ -110,20 +110,20 @@ int main(const int argc, const char* const argv[])
     return kNeutralPose;
   }();
 
-  std::array<IJogData, kServoCount> posData;
-  SJogCommand<kServoCount> posCmd;
-  posCmd.playtime = 150;
+  IJogCommand<kServoCount> iposCmd;
+  SJogCommand<kServoCount> sposCmd;
+  sposCmd.playtime = 150;
 
   size_t servoIndex = 0;
-  forEachServo(0, [&kPoseSet, &posData, &posCmd, &servoIndex](ServoId servoId, int servoIndexInLeg) {
-    posData[servoIndex] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId, 150};
-    posCmd.data[servoIndex] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId};
+  forEachServo(0, [&kPoseSet, &iposCmd, &sposCmd, &servoIndex](ServoId servoId, int servoIndexInLeg) {
+    iposCmd.data[servoIndex] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId, 150};
+    sposCmd.data[servoIndex] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId};
 
     servoIndex++;
   });
   XYZrobotServo servo(servoSerial, XYZrobotServo::kBroadcastId);
-  // servo.setPositions(posData.data(), posData.size());
-  servo.sendSJogCommand(posCmd);
+  // servo.sendJogCommand(sposCmd);
+  servo.sendJogCommand(iposCmd);
 
   return 0;
 }

--- a/packages/drqp_control/src/Control.cpp
+++ b/packages/drqp_control/src/Control.cpp
@@ -111,12 +111,19 @@ int main(const int argc, const char* const argv[])
   }();
 
   std::array<IJogData, kServoCount> posData;
+  SJogCommand<kServoCount> posCmd;
+  posCmd.playtime = 150;
+
   size_t servoIndex = 0;
-  forEachServo(0, [&kPoseSet, &posData, &servoIndex](ServoId servoId, int servoIndexInLeg) {
-    posData[servoIndex++] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], 1, servoId, 150};
+  forEachServo(0, [&kPoseSet, &posData, &posCmd, &servoIndex](ServoId servoId, int servoIndexInLeg) {
+    posData[servoIndex] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId, 150};
+    posCmd.data[servoIndex] = {kPoseSet[kServoIdToLeg[servoId]][servoIndexInLeg], SET_POSITION_CONTROL, servoId};
+
+    servoIndex++;
   });
   XYZrobotServo servo(servoSerial, XYZrobotServo::kBroadcastId);
-  servo.setPositions(posData.data(), posData.size());
+  // servo.setPositions(posData.data(), posData.size());
+  servo.sendSJogCommand(posCmd);
 
   return 0;
 }

--- a/packages/drqp_rapidjson/update.sh
+++ b/packages/drqp_rapidjson/update.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -e
+
+test $(git status --porcelain | head -255 | wc -l) -eq 0 || (echo "There are uncommited changes. Commit/stash all and rerun" && exit 1)
+
 script_dir=$(dirname "$0")
 
 cd $script_dir
@@ -7,12 +11,12 @@ cd $(git rev-parse --show-toplevel)
 
 prefix=packages/drqp_rapidjson/include/
 
+
 if [[ -d $prefix ]]; then
     rm -rf "$prefix"
     git add "$prefix" && git commit -m "Remove old rapidjson"
 fi
 git subtree add --prefix="$prefix" https://github.com/Dr-QP/rapidjson.git drqp_rapidjson --squash
-git subtree pull --prefix="$prefix" https://github.com/Dr-QP/rapidjson.git drqp_rapidjson --squash
 
 touch "$prefix/AMENT_IGNORE"
 git add "$prefix/AMENT_IGNORE" && git commit -m "Ignore rapidjson for ament clang format"

--- a/packages/drqp_rapidjson/update.sh
+++ b/packages/drqp_rapidjson/update.sh
@@ -13,3 +13,6 @@ if [[ -d $prefix ]]; then
 fi
 git subtree add --prefix="$prefix" https://github.com/Dr-QP/rapidjson.git drqp_rapidjson --squash
 git subtree pull --prefix="$prefix" https://github.com/Dr-QP/rapidjson.git drqp_rapidjson --squash
+
+touch "$prefix/AMENT_IGNORE"
+git add "$prefix/AMENT_IGNORE" && git commit -m "Ignore rapidjson for ament clang format"

--- a/packages/drqp_serial/include/drqp_serial/SerialDecorator.h
+++ b/packages/drqp_serial/include/drqp_serial/SerialDecorator.h
@@ -37,6 +37,9 @@ public:
   uint8_t peek() override;
   uint8_t read() override;
 
+  size_t write(const void* data, size_t size) override;
+  size_t readBytes(void* buffer, size_t size) override;
+
 private:
   SerialProtocol& decorated_;
 };

--- a/packages/drqp_serial/include/drqp_serial/SerialPlayer.h
+++ b/packages/drqp_serial/include/drqp_serial/SerialPlayer.h
@@ -41,8 +41,8 @@ public:
   uint8_t peek() override;
   uint8_t read() override;
   void flushRead() override;
-  size_t write(const uint8_t* data, size_t size) override;
-  size_t readBytes(uint8_t* buffer, size_t size) override;
+  size_t write(const void* data, size_t size) override;
+  size_t readBytes(void* buffer, size_t size) override;
 
   void load(const std::string& fileName);
 

--- a/packages/drqp_serial/include/drqp_serial/Stream.h
+++ b/packages/drqp_serial/include/drqp_serial/Stream.h
@@ -32,8 +32,8 @@ public:
   virtual uint8_t peek() = 0;
   virtual uint8_t read() = 0;
   virtual size_t write(uint8_t byte) = 0;
-  virtual size_t write(const uint8_t* data, size_t size) = 0;
-  virtual size_t readBytes(uint8_t* buffer, size_t size) = 0;
+  virtual size_t write(const void* data, size_t size) = 0;
+  virtual size_t readBytes(void* buffer, size_t size) = 0;
 
   virtual ~Stream() {}
 };

--- a/packages/drqp_serial/include/drqp_serial/TcpSerial.h
+++ b/packages/drqp_serial/include/drqp_serial/TcpSerial.h
@@ -42,8 +42,8 @@ public:
   uint8_t peek() override;
   uint8_t read() override;
 
-  size_t write(const uint8_t* data, size_t size) override;
-  size_t readBytes(uint8_t* buffer, size_t size) override;
+  size_t write(const void* data, size_t size) override;
+  size_t readBytes(void* buffer, size_t size) override;
 
 private:
   boost::asio::io_service ioService_;

--- a/packages/drqp_serial/include/drqp_serial/UnixSerial.h
+++ b/packages/drqp_serial/include/drqp_serial/UnixSerial.h
@@ -39,8 +39,8 @@ public:
   uint8_t peek() override;
   uint8_t read() override;
 
-  size_t write(const uint8_t* data, size_t size) override;
-  size_t readBytes(uint8_t* buffer, size_t size) override;
+  size_t write(const void* data, size_t size) override;
+  size_t readBytes(void* buffer, size_t size) override;
 
 private:
   struct Impl;

--- a/packages/drqp_serial/src/SerialDecorator.cpp
+++ b/packages/drqp_serial/src/SerialDecorator.cpp
@@ -48,3 +48,13 @@ uint8_t SerialDecorator::read()
 {
   return decorated_.read();
 }
+
+size_t SerialDecorator::write(const void* data, size_t size)
+{
+  return decorated_.write(data, size);
+}
+
+size_t SerialDecorator::readBytes(void* buffer, size_t size)
+{
+  return decorated_.readBytes(buffer, size);
+}

--- a/packages/drqp_serial/src/SerialPlayer.cpp
+++ b/packages/drqp_serial/src/SerialPlayer.cpp
@@ -30,10 +30,12 @@ namespace RecordingProxy
 {
 void SerialPlayer::begin(const uint32_t baudRate, const uint8_t transferConfig) {}
 
-size_t SerialPlayer::write(const uint8_t* data, size_t size)
+size_t SerialPlayer::write(const void* buffer, size_t size)
 {
   size_t result = 0;
-  assert(data);
+  assert(buffer);
+
+  const uint8_t *data = static_cast<const uint8_t*>(buffer);
   while (size) {
     result += write(*data);
 
@@ -63,16 +65,17 @@ uint8_t SerialPlayer::peek()
   return currentRecord().response.bytes.front();
 }
 
-size_t SerialPlayer::readBytes(uint8_t* buffer, size_t size)
+size_t SerialPlayer::readBytes(void* buffer, size_t size)
 {
   assert(buffer);
+  uint8_t *data = static_cast<uint8_t*>(buffer);
 
   const size_t result = size;
   while (size) {
-    *buffer = read();
+    *data = read();
 
     --size;
-    ++buffer;
+    ++data;
   }
   return result;
 }

--- a/packages/drqp_serial/src/SerialPlayer.cpp
+++ b/packages/drqp_serial/src/SerialPlayer.cpp
@@ -35,7 +35,7 @@ size_t SerialPlayer::write(const void* buffer, size_t size)
   size_t result = 0;
   assert(buffer);
 
-  const uint8_t *data = static_cast<const uint8_t*>(buffer);
+  const uint8_t* data = static_cast<const uint8_t*>(buffer);
   while (size) {
     result += write(*data);
 
@@ -68,7 +68,7 @@ uint8_t SerialPlayer::peek()
 size_t SerialPlayer::readBytes(void* buffer, size_t size)
 {
   assert(buffer);
-  uint8_t *data = static_cast<uint8_t*>(buffer);
+  uint8_t* data = static_cast<uint8_t*>(buffer);
 
   const size_t result = size;
   while (size) {

--- a/packages/drqp_serial/src/TcpSerial.cpp
+++ b/packages/drqp_serial/src/TcpSerial.cpp
@@ -50,7 +50,7 @@ size_t TcpSerial::write(uint8_t byte)
   return write(&byte, 1);
 }
 
-size_t TcpSerial::write(const uint8_t* data, size_t size)
+size_t TcpSerial::write(const void* data, size_t size)
 {
   return boost::asio::write(socket_, boost::asio::buffer(data, size));
 }
@@ -158,7 +158,7 @@ uint8_t TcpSerial::read()
   return lastRead_;
 }
 
-size_t TcpSerial::readBytes(uint8_t* buffer, size_t size)
+size_t TcpSerial::readBytes(void* buffer, size_t size)
 {
   everRead_ = true;
   return read_with_timeout(ioService_, socket_, boost::asio::buffer(buffer, size));

--- a/packages/drqp_serial/src/UnixSerial.cpp
+++ b/packages/drqp_serial/src/UnixSerial.cpp
@@ -52,7 +52,7 @@ std::size_t get_bytes_available(
   int value = 0;
 #if defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
   COMSTAT status;
-  if (0 != ::ClearCommError(serial_port.lowest_layer().native_handle(), NULL, &status)) {
+  if (0 != ::ClearCommError(serial_port.lowest_layer().native_handle(), nullptr, &status)) {
     value = status.cbInQue;
   } else {
     // On error, set the error code.
@@ -101,7 +101,7 @@ size_t UnixSerial::write(uint8_t byte)
   return write(&byte, 1);
 }
 
-size_t UnixSerial::write(const uint8_t* data, size_t size)
+size_t UnixSerial::write(const void* data, size_t size)
 {
   return boost::asio::write(impl_->serial_, boost::asio::buffer(data, size));
 }
@@ -142,7 +142,7 @@ uint8_t UnixSerial::read()
   return impl_->lastRead_;
 }
 
-size_t UnixSerial::readBytes(uint8_t* buffer, size_t size)
+size_t UnixSerial::readBytes(void* buffer, size_t size)
 {
   impl_->everRead_ = true;
   return boost::asio::read(impl_->serial_, boost::asio::buffer(buffer, size));

--- a/scripts/ros/cpp-reformat.sh
+++ b/scripts/ros/cpp-reformat.sh
@@ -4,3 +4,7 @@ script_dir=$(dirname $0)
 source "$script_dir/__utils.sh"
 
 ament_clang_format --config .clang-format --reformat "$sources_dir/"
+
+# It runs, but doesn't fix anything and is very slow
+# ament_clang_tidy --fix-errors "$root_dir/build/compile_commands.json"
+# --config .clang-tidy

--- a/scripts/ros/cpp-reformat.sh
+++ b/scripts/ros/cpp-reformat.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir=$(dirname $0)
+source "$script_dir/__utils.sh"
+
+ament_clang_format --config .clang-format --reformat "$sources_dir/"


### PR DESCRIPTION
Implements #18 

Implement S-JOG and I-JOG commands with full broadcast support

Update Stream interface to take `void*` as generic memory buffer to eliminate
the need for `reinterpret_casts` all over
Switch all `NULL` to `nullptr`
Add missing `writeData`/`readData` overrides in the `StreamDecorator`

Move folder settings to workspace. Clangd doesn't support per folder
settings in mult-iroot workspaces, even if there is only one folder in
the list

Add `cpp-reformat.sh` script to easily apply clang-format changes to entire
project
