### PR TITLE
Collect and report code coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ on:
 
 env:
   ROS_DISTRO: humble
-  CC: clang
-  CXX: clang++
+  # CC: clang # clang coverage is not compatible with ROS tooling
+  # CXX: clang++
   REGISTRY: ghcr.io
   REGISTRY_USERNAME: ${{ github.actor == 'nektos/act' && 'anton-matosov' || github.actor }}
   # CACHE_FROM: ${{ github.actor == 'nektos/act' && 'type=local,src=./docker-cache' || 'type=gha' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,24 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc", "coverage-pytest"]
+              },
+              "test": {
+                "mixin": ["coverage-pytest"]
+              }
+            }
+          # pin the repository in the workflow to a specific commit to avoid
+          # changes in colcon-mixin-repository from breaking your tests.
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/b8436aa16c0bdbc01081b12caa253cbf16e0fb82/index.yaml
 
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ros_ws/lcov/total_coverage.info,ros_ws/coveragepy/.coverage
+          flags: unittests
+          name: codecov-umbrella

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ros_ws/lcov/total_coverage.info,ros_ws/coveragepy/.coverage
+          disable_search: true
           flags: unittests
           name: codecov-umbrella
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ on:
 
 env:
   ROS_DISTRO: humble
-  # CC: clang # clang coverage is not compatible with ROS tooling
-  # CXX: clang++
+  CC: clang
+  CXX: clang++
   REGISTRY: ghcr.io
   REGISTRY_USERNAME: ${{ github.actor == 'nektos/act' && 'anton-matosov' || github.actor }}
   # CACHE_FROM: ${{ github.actor == 'nektos/act' && 'type=local,src=./docker-cache' || 'type=gha' }}
@@ -86,6 +86,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ros-tooling/action-ros-ci@v0.3
         id: action_ros_ci_step
+        env:
+          GCOV_COMMAND: "${{ github.workspace }}/scripts/gcov"
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           colcon-defaults: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ros-tooling/action-ros-ci@v0.3
+        id: action_ros_ci_step
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           colcon-defaults: |
@@ -108,3 +109,10 @@ jobs:
           files: ros_ws/lcov/total_coverage.info,ros_ws/coveragepy/.coverage
           flags: unittests
           name: codecov-umbrella
+
+      - uses: actions/upload-artifact@v1
+        # upload the logs even when the build fails
+        if: always()
+        with:
+          name: colcon-logs
+          path: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           flags: unittests
           name: codecov-umbrella
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         # upload the logs even when the build fails
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 install/
 log/
+lcov/
 
 build.vscode/
 bin/

--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -75,12 +75,13 @@
         "name": "drqp_a1_16_driver_tests",
         "program": "build/drqp_a1_16_driver/test/drqp_a1_16_driver_tests",
         "args": [
-          "--use-real-hardware"
+          "--use-real-hardware",
+          // "[focus]"
         ],
         "cwd": "${workspaceFolder:Dr.QP}/build/drqp_a1_16_driver/test/",
         "preLaunchTask": "Dr.QP colcon build",
       },
-{
+      {
         "type": "lldb",
         "request": "launch",
         "name": "drqp pose_reader",

--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -43,6 +43,7 @@
       "rogalmic.bash-debug",
       "mads-hartmann.bash-ide-vscode",
       "anjali.clipboard-history",
+      "ryanluker.vscode-coverage-gutters",
     ]
   },
   "launch": {
@@ -124,11 +125,8 @@
           " -GNinja",
           " -DCMAKE_BUILD_TYPE=Debug",
 
-          // "-DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage'",
-          // "-DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'",
           // " --debugger",
           // " --debugger-pipe=/tmp/drqp_serial"
-
         ],
         "problemMatcher": [
           "$catkin-gcc"
@@ -141,8 +139,8 @@
         "options": {
           "env": {
             "CMAKE_EXPORT_COMPILE_COMMANDS": "1",
-            // "CC": "clang",
-            // "CXX": "clang++"
+            "CC": "clang",
+            "CXX": "clang++"
           }
         }
       },
@@ -167,6 +165,18 @@
           "isDefault": true
         },
         "label": "Dr.QP colcon test"
+      },
+      {
+        "label": "Dr.QP colcon lcov-result",
+        "type": "shell",
+        "command": "colcon lcov-result",
+        "options": {
+          "cwd": "${workspaceFolder}",
+          "env": {
+            "GCOV_COMMAND": "${workspaceFolder}/scripts/gcov"
+          }
+        },
+        "problemMatcher": [],
       },
       {
         "label": "Dr.QP clean",
@@ -234,5 +244,14 @@
     "[cpp]": {
       "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
     },
+
+    "coverage-gutters.coverageBaseDir": "lcov",
+    "coverage-gutters.coverageFileNames": [
+      "total_coverage.info",
+    ],
+    "coverage-gutters.showLineCoverage": true,
+    "coverage-gutters.highlightdark": "rgba(0, 122, 30, 0.1)",
+    "coverage-gutters.partialHighlightDark": "rgba(163, 149, 0, 0.1)",
+    "coverage-gutters.noHighlightDark": "rgba(163, 0, 0, 0.1)"
   },
 }

--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -116,11 +116,19 @@
           // "--packages-up-to",
           // "drqp_serial",
           // "--executor=sequential",
+          "--mixin",
+          "coverage-gcc",
+          "coverage-pytest",
+
           "--cmake-args",
           " -GNinja",
           " -DCMAKE_BUILD_TYPE=Debug",
+
+          // "-DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage'",
+          // "-DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage'",
           // " --debugger",
           // " --debugger-pipe=/tmp/drqp_serial"
+
         ],
         "problemMatcher": [
           "$catkin-gcc"
@@ -133,8 +141,8 @@
         "options": {
           "env": {
             "CMAKE_EXPORT_COMPILE_COMMANDS": "1",
-            "CC": "clang",
-            "CXX": "clang++"
+            // "CC": "clang",
+            // "CXX": "clang++"
           }
         }
       },
@@ -146,6 +154,8 @@
           "console_cohesion+",
           "summary+",
           "status+",
+          "--mixin",
+          "coverage-pytest",
           // "--packages-up-to",
           // "drqp_serial",
         ],

--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -161,7 +161,7 @@
       {
         "label": "Dr.QP clean",
         "type": "shell",
-        "command": "rm -rf build install log",
+        "command": "rm -rf build install log lcov",
         "options": {
           "cwd": "${workspaceFolder}"
         },

--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -76,7 +76,8 @@
         "program": "build/drqp_a1_16_driver/test/drqp_a1_16_driver_tests",
         "args": [
           "--use-real-hardware",
-          // "[focus]"
+          // "--device", "192.168.0.181:2022",
+          // "[focus]",
         ],
         "cwd": "${workspaceFolder:Dr.QP}/build/drqp_a1_16_driver/test/",
         "preLaunchTask": "Dr.QP colcon build",

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 fixes:
-  - "ros_ws/src/*/Dr.QP/::"
+  - "**/ros_ws/src/*/Dr.QP/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "ros_ws/src/*/Dr.QP/::"

--- a/packages/cmake/Catch2Extras.cmake
+++ b/packages/cmake/Catch2Extras.cmake
@@ -15,7 +15,7 @@ function(add_catch2_unit_test TARGET)
   if(ARG_RESULT_FILE)
     set(RESULT_FILE "${ARG_RESULT_FILE}")
   else()
-    set(RESULT_FILE "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TARGET}.catch2.xml")
+    set(RESULT_FILE "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TARGET}-catch2.xunit.xml")
   endif()
 
   if(ARG_OUTPUT_FILE)

--- a/packages/drqp_a1_16_driver/test/TestXYZrobotServo.cpp
+++ b/packages/drqp_a1_16_driver/test/TestXYZrobotServo.cpp
@@ -26,11 +26,12 @@
 #define CATCH_CONFIG_RUNNER  // For custom main
 #include <catch_ros2/catch.hpp>
 
+#include "drqp_serial/SerialProtocol.h"
+#include "drqp_a1_16_driver/SerialFactory.h"
 #include "drqp_a1_16_driver/XYZrobotServo.h"
 
 #include "drqp_serial/SerialPlayer.h"
 #include "drqp_serial/SerialRecordingProxy.h"
-#include "drqp_serial/UnixSerial.h"
 
 using ServoId = uint8_t;
 constexpr uint8_t kServoCount = 2;
@@ -48,6 +49,7 @@ constexpr uint16_t kTestGoal = 812;
 // TODO(anton-matosov): Add command line options for these options
 struct TestOptions
 {
+  std::string serialAddress = "/dev/ttySC0";
   bool useRealHardware = false;
   bool resetTorque = false;
   bool skipReturnToNeutral = false;
@@ -63,6 +65,8 @@ int main(int argc, char* argv[])
   cli |= Opt(testOptions.useRealHardware)["--use-real-hardware"]("Use real hardware servos");
   cli |= Opt(testOptions.resetTorque)["--reset-torque"]("reset torque");
   cli |= Opt(testOptions.skipReturnToNeutral)["--no-neutral"]("Skip return to neutral");
+  cli |= Opt(
+    testOptions.serialAddress, "device")["--device"]("UART device or IP:PORT for ser2net device");
 
   session.cli(cli);
 
@@ -217,7 +221,7 @@ std::unique_ptr<SerialProtocol> makeSerial(const std::string& suffix)
   const auto filename = makeRecordingName(suffix);
 
   if (testOptions.useRealHardware) {
-    std::unique_ptr<UnixSerial> serial = std::make_unique<UnixSerial>("/dev/ttySC0");
+    std::unique_ptr<SerialProtocol> serial = makeSerialForDevice(testOptions.serialAddress);
     serial->begin(115200);
     if (testOptions.resetTorque) {
       torqueOff(*serial);

--- a/packages/drqp_a1_16_driver/test/TestXYZrobotServo.cpp
+++ b/packages/drqp_a1_16_driver/test/TestXYZrobotServo.cpp
@@ -323,7 +323,7 @@ TEST_CASE("A1-16 servo set I-JOG")
   neutralPoseIJog(*serial);
 }
 
-TEST_CASE("A1-16 servo set dynamic I-JOG", "[focus]")
+TEST_CASE("A1-16 servo set dynamic I-JOG")
 {
   std::unique_ptr<SerialProtocol> serial = makeSerial("set-neutral-pose-dynamic-i-jog");
 
@@ -337,7 +337,7 @@ TEST_CASE("A1-16 servo set S-JOG")
   neutralPoseSJog(*serial);
 }
 
-TEST_CASE("A1-16 servo set dynamic S-JOG", "[focus]")
+TEST_CASE("A1-16 servo set dynamic S-JOG")
 {
   std::unique_ptr<SerialProtocol> serial = makeSerial("set-neutral-pose-dynamic-s-jog");
 

--- a/scripts/gcov
+++ b/scripts/gcov
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Hackaround the colcon lcov-result trying to use GCOV_COMMAND= as GENHTML_COMMAND=
+# This also speeds up CI by skipping the html generation that is thrown away later
+if [[ $@ =~ --quiet ]]; then
+  exit 0
+fi
+
+exec llvm-cov gcov "$@"

--- a/scripts/ros/ros-2-prep.sh
+++ b/scripts/ros/ros-2-prep.sh
@@ -66,7 +66,11 @@ sudo apt install -y -q --no-install-recommends \
   git \
   libbullet-dev \
   python3-colcon-common-extensions \
+  python3-colcon-mixin \
   python3-colcon-coveragepy-result \
+  python3-coverage \
+  python3-colcon-lcov-result \
+  lcov \
   python3-flake8 \
   python3-pip \
   python3-pytest-cov \


### PR DESCRIPTION
Enable codecov for Dr.QP org and repo
Update CI as per https://github.com/ros-tooling/action-ros-ci/tree/v0.3/?tab=readme-ov-file#integrate-action-ros-ci-with-codecov

Add lcov-report and lcov packages
Enable coverage mixins
Override gcov with hacked `llvm-cov gcov` to enable lcov generation
Integrate Coverage Gutters extension
Add attaching of colcon logs to the build

Other changes:
add option to use TCP servo for tests
use xunit.xml as double extension for catch2 tests to match other reporters