### PR TITLE
Switch CodeQL workflow image to multiarch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/dr-qp/ros-desktop:edge-amd64
+      image: ghcr.io/dr-qp/ros-desktop:edge
       options: --user rosdev # Mandatory! Sets user:group matching the one of the runner, allowing access to mounted paths
     permissions:
       # required for all workflows


### PR DESCRIPTION
Use `ghcr.io/dr-qp/ros-desktop:edge` instead of `ghcr.io/dr-qp/ros-desktop:edge-amd64`