### PR TITLE
Rework paths filtering to still allow PRs to be merged

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -1,0 +1,34 @@
+name: Shared paths filters
+description: A set of filters to be used to fitler jobs
+inputs:
+  extra-filter:
+    description: Extra filters
+    required: false
+    default: '[]'
+outputs:
+  filter:
+    description: Filters
+    value: ${{ steps.filter.outputs }}
+runs:
+  using: composite
+  steps:
+  - name: Filter
+    id: filter
+    uses: dorny/paths-filter@v2.2.1
+    with:
+      filters: |
+        md:
+          - '**/*.md'
+        js:
+          - '**/*.js'
+        json:
+          - '**/*.json'
+        ros:
+          - .github/actions/**
+          - docker/ros/**
+          - packages/**
+          - scripts/**
+          - .clang-format
+          - codecov.yml
+        extra: ${{ inputs.extra-filter }}
+

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -23,10 +23,10 @@ runs:
       base: ${{ inputs.base-branch }}
       filters: |
         ros:
-          # - .github/actions/**
-          # - docker/ros/**
-          # - packages/**
-          # - scripts/**
+          - .github/actions/**
+          - docker/ros/**
+          - packages/**
+          - scripts/**
           - .clang-format
-          # - codecov.yml
-          # - ${{ inputs.extra-filter }}
+          - codecov.yml
+          - ${{ inputs.extra-filter }}

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -1,34 +1,32 @@
 name: Shared paths filters
 description: A set of filters to be used to fitler jobs
 inputs:
+  base-branch:
+    description: Base branch
+    required: false
+    default: main
   extra-filter:
     description: Extra filters
     required: false
-    default: '[]'
+    default: 'default-path-that-will-never-match'
 outputs:
-  filter:
-    description: Filters
-    value: ${{ steps.filter.outputs }}
+  pass:
+    description: Filtered file present
+    value: ${{ steps.filter.outputs.ros }}
 runs:
   using: composite
   steps:
   - name: Filter
     id: filter
-    uses: dorny/paths-filter@v2.2.1
+    uses: dorny/paths-filter@v3.0.2
     with:
+      base: ${{ inputs.base-branch }}
       filters: |
-        md:
-          - '**/*.md'
-        js:
-          - '**/*.js'
-        json:
-          - '**/*.json'
         ros:
-          - .github/actions/**
-          - docker/ros/**
-          - packages/**
-          - scripts/**
+          # - .github/actions/**
+          # - docker/ros/**
+          # - packages/**
+          # - scripts/**
           - .clang-format
-          - codecov.yml
-        extra: ${{ inputs.extra-filter }}
-
+          # - codecov.yml
+          # - ${{ inputs.extra-filter }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,8 @@ jobs:
     needs: [merge-dev-image, ros-ci, merge-deploy-image]
     runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     permissions: {}
-    if: success() || ((!cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && fromjson('throw'))
+    if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:
-      - run: echo "All jobs finished successfully"
+      - run: |
+          echo "Some workflows have failed!"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,27 +5,11 @@ on:
     types:
       - published
   push:
-    paths:
-      - .github/workflows/ci.yml
-      - .github/actions/**
-      - docker/ros/**
-      - packages/**
-      - scripts/**
-      - .clang-format
-      - codecov.yml
     branches:
       - main
     tags:
       - v*
   pull_request:
-    paths:
-      - .github/workflows/ci.yml
-      - .github/actions/**
-      - docker/ros/**
-      - packages/**
-      - scripts/**
-      - .clang-format
-      - codecov.yml
     branches:
       - main
       - v*
@@ -45,9 +29,26 @@ env:
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
 
 jobs:
+  paths-filter:
+    name: Paths filter
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    outputs:
+      pass: ${{ steps.filter.outputs.pass }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Filters
+        uses: ./.github/actions/paths-filter
+        id: filter
+        with:
+          extra-filter: .github/workflows/ci.yml
+
   build-dev-image:
     name: Development image
     timeout-minutes: 35
+    needs: paths-filter
+    if: needs.paths-filter.outputs.pass == 'true'
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,8 +228,6 @@ jobs:
     needs: [merge-dev-image, ros-ci, merge-deploy-image]
     runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     permissions: {}
-    if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+    if: success() || ((!cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && fromjson('throw'))
     steps:
-      - run: |
-          echo "Some workflows have failed!"
-          exit 1
+      - run: echo "All jobs finished successfully"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -183,8 +183,6 @@ jobs:
     needs: [analyze]
     runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     permissions: {}
-    if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+    if: success() || ((!cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && fromjson('throw'))
     steps:
-      - run: |
-          echo "Some workflows have failed!"
-          exit 1
+      - run: echo "All jobs finished successfully"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,27 +14,11 @@ name: "CodeQL Advanced"
 on:
   workflow_dispatch:
   push:
-    paths:
-      - .github/workflows/codeql.yml
-      - .github/actions/**
-      - docker/ros/**
-      - packages/**
-      - scripts/**
-      - .clang-format
-      - codecov.yml
     branches:
       - main
     tags:
       - v*
   pull_request:
-    paths:
-      - .github/workflows/codeql.yml
-      - .github/actions/**
-      - docker/ros/**
-      - packages/**
-      - scripts/**
-      - .clang-format
-      - codecov.yml
     branches:
       - main
       - v*
@@ -56,8 +40,21 @@ env:
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
 
 jobs:
+  paths-filter:
+    name: Paths filter
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Filters
+        uses: ./.github/actions/paths-filter
+        with:
+          extra-filter: .github/workflows/codeql.yml
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: paths-filter
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - .github/workflows/ci.yml
+      - .github/workflows/codeql.yml
       - .github/actions/**
       - docker/ros/**
       - packages/**
@@ -28,7 +28,7 @@ on:
       - v*
   pull_request:
     paths:
-      - .github/workflows/ci.yml
+      - .github/workflows/codeql.yml
       - .github/actions/**
       - docker/ros/**
       - packages/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,18 +43,22 @@ jobs:
   paths-filter:
     name: Paths filter
     runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    outputs:
+      pass: ${{ steps.filter.outputs.pass }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Filters
         uses: ./.github/actions/paths-filter
+        id: filter
         with:
           extra-filter: .github/workflows/codeql.yml
 
   analyze:
     name: Analyze (${{ matrix.language }})
     needs: paths-filter
+    if: needs.paths-filter.outputs.pass == 'true'
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -183,6 +183,8 @@ jobs:
     needs: [analyze]
     runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     permissions: {}
-    if: success() || ((!cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && fromjson('throw'))
+    if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:
-      - run: echo "All jobs finished successfully"
+      - run: |
+          echo "Some workflows have failed!"
+          exit 1

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -5,27 +5,11 @@ on:
     types:
       - published
   push:
-    paths:
-      - .github/workflows/devcontainer.yml
-      - .github/actions/**
-      - docker/ros/**
-      - packages/**
-      - scripts/**
-      - .clang-format
-      - codecov.yml
     branches:
       - main
     tags:
       - v*
   pull_request:
-    paths:
-      - .github/workflows/devcontainer.yml
-      - .github/actions/**
-      - docker/ros/**
-      - packages/**
-      - scripts/**
-      - .clang-format
-      - codecov.yml
     branches:
       - main
       - v*
@@ -45,9 +29,26 @@ env:
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
 
 jobs:
+  paths-filter:
+    name: Paths filter
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    outputs:
+      pass: ${{ steps.filter.outputs.pass }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Filters
+        uses: ./.github/actions/paths-filter
+        id: filter
+        with:
+          extra-filter: .github/workflows/devcontainer.yml
+
   dev-container-ci:
       name: Devcontainer image
       timeout-minutes: 35
+      needs: paths-filter
+      if: needs.paths-filter.outputs.pass == 'true'
       strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -126,8 +126,6 @@ jobs:
     needs: [dev-container-ci]
     runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     permissions: {}
-    if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+    if: success() || ((!cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && fromjson('throw'))
     steps:
-      - run: |
-          echo "Some workflows have failed!"
-          exit 1
+      - run: echo "All jobs finished successfully"

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -6,7 +6,7 @@ on:
       - published
   push:
     paths:
-      - .github/workflows/ci.yml
+      - .github/workflows/devcontainer.yml
       - .github/actions/**
       - docker/ros/**
       - packages/**
@@ -19,7 +19,7 @@ on:
       - v*
   pull_request:
     paths:
-      - .github/workflows/ci.yml
+      - .github/workflows/devcontainer.yml
       - .github/actions/**
       - docker/ros/**
       - packages/**

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -126,6 +126,8 @@ jobs:
     needs: [dev-container-ci]
     runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     permissions: {}
-    if: success() || ((!cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && fromjson('throw'))
+    if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:
-      - run: echo "All jobs finished successfully"
+      - run: |
+          echo "Some workflows have failed!"
+          exit 1


### PR DESCRIPTION
Switch paths filters to a dedicated job instead of using workflow filtering as it results in workflow not running at all
Migrate CI, devcontainer and codeql workflows to use new paths filter
Use workaround from https://github.com/actions/runner/issues/2566#issuecomment-1523814835 to handle skipped finished step