### PR TITLE
Small fixes to micromamba environment files 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
   os: ubuntu-24.04
   tools:
     nodejs: "20" # keep in sync with environment.yml
-    python: "3.13" # keep in sync with environment.yml
+    python: "3.12" # keep in sync with environment.yml
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/environment-readthedocs.yml
+++ b/environment-readthedocs.yml
@@ -9,13 +9,13 @@
 # chgrp -R staff .micromamba/
 #
 ##############
-name: default
+name: readthedocs
 
 channels:
   - conda-forge
 
 dependencies:
-  - python=3.13 # keep in sync with .readthedocs.yaml
+  - python=3.12 # keep in sync with .readthedocs.yaml
   - nodejs=20 # keep in sync with .readthedocs.yaml
   - pip:
      - -r ./docs/requirements.txt

--- a/environment-ros-jazzy.yml
+++ b/environment-ros-jazzy.yml
@@ -1,0 +1,32 @@
+##############
+name: ros-jazzy
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.12 # keep in sync with .readthedocs.yaml
+  - nodejs=20 # keep in sync with .readthedocs.yaml
+  - pip:
+     - colcon-common-extensions
+     - colcon-coveragepy-result
+     - colcon-lcov-result
+     - colcon-mixin
+     - coverage
+     - flake8
+     - flake8-blind-except
+     - flake8-class-newline
+     - flake8-deprecated
+     - mypy
+     - pytest
+     - pytest-cov
+     - pytest-mock
+     - pytest-repeat
+     - pytest-rerunfailures
+     - pytest-runner
+     - pytest-timeout
+     - rosdep
+     - setuptools
+     - vcstool
+     - -r ./docs/requirements.txt
+     - esbonio # reStructuredText language server for preview


### PR DESCRIPTION
Rename readthedocs env file to let extension pick it up
Add env file for ros env

Downgrade python to 3.12 to match the system wide one compatible with ros