### PR TITLE
gitleaks fails in merge queue

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - main
       - v*
-  merge_group:
-    types:
-      - checks_requested
 
 jobs:
   scan:


### PR DESCRIPTION
remove gitleaks from merge_group (merge queue request) to bypass error:
`ERROR: The [merge_group] event is not yet supported`

