### PR TITLE
169 fix figure sizes for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -24,6 +24,7 @@ sphinx-copybutton
 sphinx-design
 sphinx-togglebutton
 sphinxext-rediraffe # Redirect from deleted files https://github.com/sphinx-doc/sphinxext-rediraffe
+sphinxcontrib-lightbox2
 
 -c constraints.txt
 

--- a/docs/source/_static/styles/custom.css
+++ b/docs/source/_static/styles/custom.css
@@ -1,0 +1,9 @@
+/* Make all notebook output and figures fluid */
+.cell_output img,
+.cell_output video,
+.jupyter-widgets canvas {
+    display: block;
+    width: 100% !important;
+    max-width: 100% !important;
+    height: auto !important;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -120,7 +120,7 @@ if not os.environ.get('READTHEDOCS'):
     sitemap_locales = [None]
     sitemap_url_scheme = '{link}'
 
-# -- Options for HTML output
+# -- Options for HTML output ---------------------------------------------------
 
 html_theme = 'pydata_sphinx_theme'
 html_theme_options = {
@@ -133,6 +133,12 @@ html_theme_options = {
     'footer_start': ['copyright'],
     'footer_center': ['sphinx-version'],
 }
+html_static_path = ['_static']
+html_css_files = [
+    'styles/custom.css',
+]
+
+# -- Edit on GitHub -------------------------------------------------------------
 
 github_user = 'dr-qp'
 github_repo = 'Dr.QP'
@@ -168,7 +174,7 @@ html_context = {
     'doc_path': '/docs/source/',
 }
 
-# -- Options for EPUB output
+# -- Options for EPUB output ---------------------------------------------------
 epub_show_urls = 'footnote'
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,6 +64,7 @@ extensions = [
     'sphinx.ext.duration',
     'sphinx.ext.intersphinx',
     'sphinxext.rediraffe',
+    'sphinxcontrib.lightbox2',
     'myst_nb',  # for embedding jupyter notebooks
     # Disabled for now due to conflict with myst_nb
     # see https://github.com/executablebooks/MyST-NB/issues/421
@@ -104,6 +105,9 @@ intersphinx_mapping = {
 intersphinx_disabled_domains = ['std']
 
 templates_path = ['_templates']
+
+lightbox2_wrap_around = False
+lightbox2_fit_images_in_viewport = True
 
 # -- Redirects -----------------------------------------------------------------
 

--- a/docs/source/notebooks/1_getting_started_with_robot_ik.md
+++ b/docs/source/notebooks/1_getting_started_with_robot_ik.md
@@ -190,6 +190,7 @@ with plt.ioff():
         model, 'Lifted up (coxa) and bent down (femur, tibia)', link_labels='legend'
     )
     display(plt.gcf())
+    plt.close()
 ```
 
 ```{code-cell} ipython3
@@ -199,6 +200,7 @@ model = forward_kinematics(coxa_length, femur_length, tibia_length, 45, -55, -14
 with plt.ioff():
     _ = plot_leg_with_points(model, 'Foot on the ground', link_labels='legend')
     display(plt.gcf())
+    plt.close()
 ```
 
 ## Exercise 1. Forward kinematics. Find angles at which the leg is on the ground
@@ -234,7 +236,7 @@ fig, _, plot_data = plot_leg_with_points(
 )
 
 
-def animate(frame, alpha=alpha, beta=beta, gamma=gamma):
+def animate(frame=0, alpha=alpha, beta=beta, gamma=gamma):
     if frame > 0:
         beta = np.interp(frame, [0, frames_to_animate / 2], [35, 55])
         gamma = np.interp(frame, [frames_to_animate / 2, frames_to_animate], [-110, -140])
@@ -337,6 +339,8 @@ model = forward_kinematics_xy(coxa_len, femur_len, tibia_len, 30)
 with plt.ioff():
     plot_leg_with_points_xy(model, 'XY plane (top view)')
     display(plt.gcf())
+
+plt.close()
 ```
 
 Finding angle $\alpha$ is a trivial problem, since we are dealing with a right triangle.
@@ -363,6 +367,7 @@ model = forward_kinematics_xy(coxa_len, femur_len, tibia_len, 30)
 with plt.ioff():
     plot_leg_with_points_xy_ik(model, 'Coxa (alpha) IK')
     display(plt.gcf())
+plt.close()
 ```
 
 Our right triangle is formed by lines $target_y$ and $target_x$ and hypotenuse $X'$ which is the leg itself. Therefore a simple $arctan$ will give us the angle:
@@ -390,6 +395,7 @@ def plot_xtick(alpha):
 plot_xtick(0)
 plot_xtick(15)
 plot_xtick(30)
+plt.close()
 ```
 
 Putting all of this in code will look as follows
@@ -425,6 +431,7 @@ foot_target_3d = Point3D(13, 15, -6)
 with plt.ioff():
     plot_leg_ik_xy(foot_target_3d.xy)
     display(plt.gcf())
+plt.close()
 ```
 
 As you can see on the diagram above, coxa IK was solved correctly and leg is now aligned with the target foot position. However leg's foot is not at the target foot position. That will be solved by femur and tibia IK described below.
@@ -469,6 +476,7 @@ with plt.ioff():
     plot_ik_lines(ax, femur, tibia)
 
     display(plt.gcf())
+plt.close()
 ```
 
 As you can see on the diagram above, there are 2 triangles formed by leg links and additional lines `D`, `T` and `L`.
@@ -616,12 +624,14 @@ If math is working correctly, foot (magenta dot) should always overlap with the 
 with plt.ioff():
     _ = solve_and_plot_at_target_xz(Point(20.61, 6.14), verbose=True)
     display(plt.gcf())
+plt.close()
 ```
 
 ```{code-cell} ipython3
 with plt.ioff():
     _ = solve_and_plot_at_target_xz(Point(15, 0), verbose=True)
     display(plt.gcf())
+plt.close()
 ```
 
 ### Putting it all together
@@ -831,6 +841,7 @@ def safe_solve_and_plot_at_target(
 with plt.ioff():
     safe_solve_and_plot_at_target(1, 1, 1, Point3D(5, 0, -2), verbose=False)
     display(plt.gcf())
+plt.close()
 ```
 
-The chart above is a nice demonstration of how the safe algorithm works. Even though leg is clearly not reaching the target (leg foot is magenta dot), it is pointing exactly at the target as seen by the dotted line.
+The chart above is a nice demonstration of how the safe algorithm works. Even though leg is clearly not reaching the target (foot is the magenta dot), it is pointing exactly at the target as shown by the dotted line.

--- a/docs/source/notebooks/1_getting_started_with_robot_ik.md
+++ b/docs/source/notebooks/1_getting_started_with_robot_ik.md
@@ -700,6 +700,7 @@ with plt.ioff():
             foot = solved_foot[frame]
             ax.scatter(foot.x, foot.y, color='m', alpha=0.5, zorder=100)
 
+
 _ = animate_plot(
     fig,
     animate,
@@ -777,7 +778,6 @@ With the safe capped version of acos function not only not throwing, but also pr
 Let's plot it to have better intuition about what's going on.
 
 ```{code-cell} ipython3
-
 def safe_solve_and_plot_at_target(
     coxa,
     femur,

--- a/docs/source/notebooks/1_getting_started_with_robot_ik.md
+++ b/docs/source/notebooks/1_getting_started_with_robot_ik.md
@@ -175,9 +175,9 @@ from plotting import plot_leg_with_points
 
 model = forward_kinematics(coxa_length, femur_length, tibia_length, alpha, beta, gamma)
 
-with plt.ioff():
-    _ = plot_leg_with_points(model, 'Neutral position (straight leg)')
-    display(plt.gcf())
+_ = plot_leg_with_points(model, 'Neutral position (straight leg)')
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 Now lets try changing some angles to see how it behaves. Feel free to experiment with different values.
@@ -185,22 +185,20 @@ Now lets try changing some angles to see how it behaves. Feel free to experiment
 ```{code-cell} ipython3
 model = forward_kinematics(coxa_length, femur_length, tibia_length, 50, -60, -10)
 
-with plt.ioff():
-    _ = plot_leg_with_points(
-        model, 'Lifted up (coxa) and bent down (femur, tibia)', link_labels='legend'
-    )
-    display(plt.gcf())
-    plt.close()
+_ = plot_leg_with_points(
+    model, 'Lifted up (coxa) and bent down (femur, tibia)', link_labels='legend'
+)
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 ```{code-cell} ipython3
 # Lifted up (coxa) and bent down (femur), with foot on the ground (guessed angle)
 model = forward_kinematics(coxa_length, femur_length, tibia_length, 45, -55, -14)
 
-with plt.ioff():
-    _ = plot_leg_with_points(model, 'Foot on the ground', link_labels='legend')
-    display(plt.gcf())
-    plt.close()
+_ = plot_leg_with_points(model, 'Foot on the ground', link_labels='legend')
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 ## Exercise 1. Forward kinematics. Find angles at which the leg is on the ground
@@ -329,18 +327,15 @@ def plot_leg_with_points_xy(model: list[Line], title: str):
 
 model = forward_kinematics_xy(coxa_len, femur_len, tibia_len, 0)
 
-with plt.ioff():
-    plot_leg_with_points_xy(model, 'XY plane (top view, neutral position)')
-    display(plt.gcf())
-
+plot_leg_with_points_xy(model, 'XY plane (top view, neutral position)')
+display(plt.gcf())
+plt.close(plt.gcf())
 
 model = forward_kinematics_xy(coxa_len, femur_len, tibia_len, 30)
 
-with plt.ioff():
-    plot_leg_with_points_xy(model, 'XY plane (top view)')
-    display(plt.gcf())
-
-plt.close()
+plot_leg_with_points_xy(model, 'XY plane (top view)')
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 Finding angle $\alpha$ is a trivial problem, since we are dealing with a right triangle.
@@ -364,10 +359,9 @@ def plot_leg_with_points_xy_ik(model: list[Line], title: str):
 
 model = forward_kinematics_xy(coxa_len, femur_len, tibia_len, 30)
 
-with plt.ioff():
-    plot_leg_with_points_xy_ik(model, 'Coxa (alpha) IK')
-    display(plt.gcf())
-plt.close()
+plot_leg_with_points_xy_ik(model, 'Coxa (alpha) IK')
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 Our right triangle is formed by lines $target_y$ and $target_x$ and hypotenuse $X'$ which is the leg itself. Therefore a simple $arctan$ will give us the angle:
@@ -383,19 +377,18 @@ import math
 
 
 def plot_xtick(alpha):
-    with plt.ioff():
-        model = forward_kinematics_xy(coxa_len, femur_len, tibia_len, alpha)
-        ax = plot_leg_with_points_xy(model, "Translating X to X'")
+    model = forward_kinematics_xy(coxa_len, femur_len, tibia_len, alpha)
+    ax = plot_leg_with_points_xy(model, "Translating X to X'")
 
-        foot = model[-1].end
-        ax.text(foot.x, foot.y + 1, f"X={foot.x:.2f}\nX'={math.hypot(foot.x, foot.y):.2f}")
+    foot = model[-1].end
+    ax.text(foot.x, foot.y + 1, f"X={foot.x:.2f}\nX'={math.hypot(foot.x, foot.y):.2f}")
     display(plt.gcf())
+    plt.close(plt.gcf())
 
 
 plot_xtick(0)
 plot_xtick(15)
 plot_xtick(30)
-plt.close()
 ```
 
 Putting all of this in code will look as follows
@@ -428,10 +421,9 @@ def plot_leg_ik_xy(foot_target: Point, plot_title='Inverse Kinematics solved'):
 
 foot_target_3d = Point3D(13, 15, -6)
 
-with plt.ioff():
-    plot_leg_ik_xy(foot_target_3d.xy)
-    display(plt.gcf())
-plt.close()
+plot_leg_ik_xy(foot_target_3d.xy)
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 As you can see on the diagram above, coxa IK was solved correctly and leg is now aligned with the target foot position. However leg's foot is not at the target foot position. That will be solved by femur and tibia IK described below.
@@ -461,22 +453,21 @@ model = forward_kinematics(
     body_length=0,
 )
 
-with plt.ioff():
-    fig, ax, _ = plot_leg_with_points(
-        model,
-        'Inverse Kinematics trigonometry',
-        joint_labels='points',
-        link_labels='label',
-        no_cartesian_ticks=True,
-        x_label="X'",
-        y_label='Z',
-    )
+fig, ax, _ = plot_leg_with_points(
+    model,
+    'Inverse Kinematics trigonometry',
+    joint_labels='points',
+    link_labels='label',
+    no_cartesian_ticks=True,
+    x_label="X'",
+    y_label='Z',
+)
 
-    body, coxa, femur, tibia = model
-    plot_ik_lines(ax, femur, tibia)
+body, coxa, femur, tibia = model
+plot_ik_lines(ax, femur, tibia)
 
-    display(plt.gcf())
-plt.close()
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 As you can see on the diagram above, there are 2 triangles formed by leg links and additional lines `D`, `T` and `L`.
@@ -592,11 +583,11 @@ def solve_and_plot_at_target_xz(
 
 alpha_ik, X_tick = coxa_ik(foot_target_3d.xy)
 
-with plt.ioff():
-    beta_ik, gamma_ik = solve_and_plot_at_target_xz(
-        Point(X_tick, foot_target_3d.z), 'Foot_target_3D in XZ plane', verbose=True
-    )
-    display(plt.gcf())
+beta_ik, gamma_ik = solve_and_plot_at_target_xz(
+    Point(X_tick, foot_target_3d.z), 'Foot_target_3D in XZ plane', verbose=True
+)
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 And that is all. We have solved inverse kinematics for a 3DOF leg.
@@ -610,28 +601,26 @@ print(f'gamma = {gamma_ik:.2f}')
 To understand where the offset values for beta and gamma in the computation above are coming from, let's plot straight leg and see what theta and phi are.
 
 ```{code-cell} ipython3
-with plt.ioff():
-    _ = solve_and_plot_at_target_xz(
-        Point(coxa_len + femur_len + tibia_len, 0), 'Straight leg out', verbose=True
-    )
-    display(plt.gcf())
+_ = solve_and_plot_at_target_xz(
+    Point(coxa_len + femur_len + tibia_len, 0), 'Straight leg out', verbose=True
+)
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 Now once we have the solution, let's play with it a little bit and solve for various target points.
 If math is working correctly, foot (magenta dot) should always overlap with the target (black dot).
 
 ```{code-cell} ipython3
-with plt.ioff():
-    _ = solve_and_plot_at_target_xz(Point(20.61, 6.14), verbose=True)
-    display(plt.gcf())
-plt.close()
+_ = solve_and_plot_at_target_xz(Point(20.61, 6.14), verbose=True)
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 ```{code-cell} ipython3
-with plt.ioff():
-    _ = solve_and_plot_at_target_xz(Point(15, 0), verbose=True)
-    display(plt.gcf())
-plt.close()
+_ = solve_and_plot_at_target_xz(Point(15, 0), verbose=True)
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 ### Putting it all together
@@ -689,27 +678,25 @@ for target in sequence_xz_little_circle:
 
 model = solved_model[0]
 
-with plt.ioff():
-    fig, ax, plot_data = plot_leg_with_points(
-        model,
-        'IK Circle',
-        link_labels='none',
-        joint_labels='points',
-    )
+fig, ax, plot_data = plot_leg_with_points(
+    model,
+    'IK Circle',
+    link_labels='none',
+    joint_labels='points',
+)
 
-    def animate(frame):
-        even = not frame % 2
-        if even:
-            frame = frame // 2
-            target = sequence_xz_little_circle[frame]
-            ax.scatter(target.x, target.z, color='k', zorder=-100)
-        else:
-            frame = frame // 2
-            model = solved_model[frame]
-            plot_leg_update_lines(model, plot_data)
-            foot = solved_foot[frame]
-            ax.scatter(foot.x, foot.y, color='m', alpha=0.5, zorder=100)
-
+def animate(frame):
+    even = not frame % 2
+    if even:
+        frame = frame // 2
+        target = sequence_xz_little_circle[frame]
+        ax.scatter(target.x, target.z, color='k', zorder=-100)
+    else:
+        frame = frame // 2
+        model = solved_model[frame]
+        plot_leg_update_lines(model, plot_data)
+        foot = solved_foot[frame]
+        ax.scatter(foot.x, foot.y, color='m', alpha=0.5, zorder=100)
 
 _ = animate_plot(
     fig,
@@ -838,10 +825,9 @@ def safe_solve_and_plot_at_target(
     ax.legend().remove()
 
 
-with plt.ioff():
-    safe_solve_and_plot_at_target(1, 1, 1, Point3D(5, 0, -2), verbose=False)
-    display(plt.gcf())
-plt.close()
+safe_solve_and_plot_at_target(1, 1, 1, Point3D(5, 0, -2), verbose=False)
+display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 The chart above is a nice demonstration of how the safe algorithm works. Even though leg is clearly not reaching the target (foot is the magenta dot), it is pointing exactly at the target as shown by the dotted line.

--- a/docs/source/notebooks/1_getting_started_with_robot_ik.md
+++ b/docs/source/notebooks/1_getting_started_with_robot_ik.md
@@ -45,6 +45,7 @@ The first step is to enable live python modules reloading, so changes in the pyt
 The next step is configuring matplotlib backend. Widget backend allows to interact with the plots in the notebook and is supported in Google Colab and VSCode.
 
 ```{code-cell} ipython3
+%config InlineBackend.figure_formats = ['svg']
 %matplotlib widget
 
 from IPython.display import display
@@ -675,10 +676,6 @@ for target in sequence_xz_little_circle:
 ```{code-cell} ipython3
 # Plot IK solutions and targets into an animation
 
-from matplotlib.animation import FuncAnimation
-import matplotlib.pyplot as plt
-
-plt.rcParams['animation.html'] = 'jshtml'
 
 model = solved_model[0]
 
@@ -703,7 +700,13 @@ with plt.ioff():
             foot = solved_foot[frame]
             ax.scatter(foot.x, foot.y, color='m', alpha=0.5, zorder=100)
 
-    display(FuncAnimation(fig, animate, frames=total_targets * 2, interval=50))
+_ = animate_plot(
+    fig,
+    animate,
+    _interactive=False,
+    _frames=total_targets * 2,
+    _interval=50,
+)
 ```
 
  Woohoo! The entire IK chain works as expected and we can put the foot on a target!
@@ -774,10 +777,6 @@ With the safe capped version of acos function not only not throwing, but also pr
 Let's plot it to have better intuition about what's going on.
 
 ```{code-cell} ipython3
-import matplotlib.pyplot as plt
-
-plt.rcParams['animation.html'] = 'none'
-
 
 def safe_solve_and_plot_at_target(
     coxa,
@@ -829,8 +828,9 @@ def safe_solve_and_plot_at_target(
     ax.legend().remove()
 
 
-with plt.ion():
+with plt.ioff():
     safe_solve_and_plot_at_target(1, 1, 1, Point3D(5, 0, -2), verbose=False)
+    display(plt.gcf())
 ```
 
 The chart above is a nice demonstration of how the safe algorithm works. Even though leg is clearly not reaching the target (leg foot is magenta dot), it is pointing exactly at the target as seen by the dotted line.

--- a/docs/source/notebooks/1_getting_started_with_robot_ik.md
+++ b/docs/source/notebooks/1_getting_started_with_robot_ik.md
@@ -685,6 +685,7 @@ fig, ax, plot_data = plot_leg_with_points(
     joint_labels='points',
 )
 
+
 def animate(frame):
     even = not frame % 2
     if even:
@@ -697,6 +698,7 @@ def animate(frame):
         plot_leg_update_lines(model, plot_data)
         foot = solved_foot[frame]
         ax.scatter(foot.x, foot.y, color='m', alpha=0.5, zorder=100)
+
 
 _ = animate_plot(
     fig,

--- a/docs/source/notebooks/2_affine_transforms.md
+++ b/docs/source/notebooks/2_affine_transforms.md
@@ -34,6 +34,7 @@ The first step is to enable live python modules reloading, so changes in the pyt
 The next step is configuring matplotlib backend. Widget backend allows to interact with the plots in the notebook and is supported in Google Colab and VSCode.
 
 ```{code-cell} ipython3
+%config InlineBackend.figure_formats = ['svg']
 %matplotlib widget
 
 from IPython.display import display

--- a/docs/source/notebooks/2_affine_transforms.md
+++ b/docs/source/notebooks/2_affine_transforms.md
@@ -241,9 +241,17 @@ _ = plot_leg_with_points(
     subplot=223,
     fig=fig,
 )
-fig, ax, plot_data = plot_leg3d(model, 'Foot in 3D', link_labels='none', joint_labels='points', subplot=224, fig=fig, hide_grid=False)
-ax.plot(*zip([0, -5, 0], [0, 5, 0]), 'w:') # add depth
-ax.set_aspect('equal') # Upset the aspect ratio
+fig, ax, plot_data = plot_leg3d(
+    model,
+    'Foot in 3D',
+    link_labels='none',
+    joint_labels='points',
+    subplot=224,
+    fig=fig,
+    hide_grid=False,
+)
+ax.plot(*zip([0, -5, 0], [0, 5, 0]), 'w:')  # add depth
+ax.set_aspect('equal')  # Upset the aspect ratio
 display(fig)
 plt.close(fig)
 ```

--- a/docs/source/notebooks/2_affine_transforms.md
+++ b/docs/source/notebooks/2_affine_transforms.md
@@ -241,7 +241,9 @@ _ = plot_leg_with_points(
     subplot=223,
     fig=fig,
 )
-_ = plot_leg3d(model, 'Foot in 3D', link_labels='none', joint_labels='points', subplot=224, fig=fig)
+fig, ax, plot_data = plot_leg3d(model, 'Foot in 3D', link_labels='none', joint_labels='points', subplot=224, fig=fig, hide_grid=False)
+ax.plot(*zip([0, -5, 0], [0, 5, 0]), 'w:') # add depth
+ax.set_aspect('equal') # Upset the aspect ratio
 display(fig)
 plt.close(fig)
 ```

--- a/docs/source/notebooks/2_affine_transforms.md
+++ b/docs/source/notebooks/2_affine_transforms.md
@@ -244,7 +244,6 @@ _ = plot_leg_with_points(
 _ = plot_leg3d(model, 'Foot in 3D', link_labels='none', joint_labels='points', subplot=224, fig=fig)
 display(fig)
 plt.close(fig)
-
 ```
 
 With full 3D kinematics model and plotting support lets setup a 6 legged robot.

--- a/docs/source/notebooks/2_affine_transforms.md
+++ b/docs/source/notebooks/2_affine_transforms.md
@@ -126,11 +126,13 @@ _ = plot_leg_with_points(
     model.xy, 'Foot on the ground (XY)', link_labels='none', x_label="X'", y_label='Y'
 )
 display(plt.gcf())
+plt.close(plt.gcf())
 
 _ = plot_leg_with_points(
     model.xz, 'Foot on the ground (XZ)', link_labels='none', x_label="X'", y_label='Z'
 )
 display(plt.gcf())
+plt.close(plt.gcf())
 ```
 
 This was a good start, but code is hard to read and understand due to excessive repetitions. Let's introduce a transform system, similar to the one used in ROS TF2 library.
@@ -241,7 +243,8 @@ _ = plot_leg_with_points(
 )
 _ = plot_leg3d(model, 'Foot in 3D', link_labels='none', joint_labels='points', subplot=224, fig=fig)
 display(fig)
-# print("foot position: ", model.lines[-1].end)
+plt.close(fig)
+
 ```
 
 With full 3D kinematics model and plotting support lets setup a 6 legged robot.
@@ -395,6 +398,7 @@ drqp = DrQP()
 drqp.forward_kinematics(0, -25, 110)
 fig, ax, plot_data = plot_drqp(drqp)
 display(fig)
+plt.close(fig)
 ```
 
 With the ability to do forward kinematics for a full robot, we can now start to work on the inverse kinematics. 1_getting_started_with_robot_ik.ipynb notebook covers the full 3D case of a single leg IK, however it works in the leg's local coordinate frame. In order to use it for the full robot, each leg global target position needs to be converted to the leg's local coordinate frame. Since we used matrix transformations for the forward kinematics, we can use the inverse of the body transform to convert the global target to the local coordinate frame.
@@ -424,6 +428,7 @@ for leg in drqp.legs:
 
 fig, ax, plot_data = plot_drqp(drqp, targets)
 display(fig)
+plt.close(fig)
 ```
 
 With the ability to position all legs, its time to work on the inverse kinematics for the body.
@@ -457,6 +462,7 @@ for leg, target in zip(drqp.legs, targets):
 
 fig, ax, plot_data = plot_drqp(drqp, unreachable_targets)
 display(fig)
+plt.close(fig)
 ```
 
 ```{code-cell} ipython3
@@ -589,4 +595,5 @@ hexapod.body_transform = Transform.from_translation([0.05, 0, -0.01]) @ Transfor
 hexapod.move_legs_to(leg_tips)
 update_hexapod_plot(hexapod, plot_data)
 display(fig)
+plt.close(fig)
 ```

--- a/docs/source/notebooks/3_1_appendix_smoothing_splines.md
+++ b/docs/source/notebooks/3_1_appendix_smoothing_splines.md
@@ -582,8 +582,8 @@ def update_spline(new_waypoint):
         ax.set_ylabel('Y')
         ax.set_zlabel('Z')
         ax.legend()
-        plt.draw()
-        plt.pause(0.1)
+        display(fig)
+        plt.close()
 
 
 # Simulate incoming new waypoints dynamically
@@ -655,8 +655,8 @@ def update_spline(new_waypoint):
     ax.set_ylabel('Y')
     ax.set_zlabel('Z')
     ax.legend()
-    plt.draw()
-    plt.pause(0.1)
+    display(fig)
+    plt.close()
 
 
 # Simulate incoming waypoints dynamically

--- a/docs/source/notebooks/3_1_appendix_smoothing_splines.md
+++ b/docs/source/notebooks/3_1_appendix_smoothing_splines.md
@@ -672,66 +672,36 @@ x = np.array([0, 2, 3, 5, 8])  # X trajectory
 y = np.array([1, 3, 1, 4, 6])  # Y trajectory
 control_points = np.array([x, y, t]).T
 
+def plot_with_legend(plot: callable):
+  fig, ax = plt.subplots(1, 1)
+  fig.set_figheight(4, forward=True)
+  ax.scatter(x, y, c='k', label='Control points')
+  plot(ax)
+  ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+  display(fig)
+  plt.close()
 
-fig, ax = plt.subplots(1, 1)
-fig.set_figheight(4, forward=True)
-ax.scatter(x, y, c='k', label='Control points')
-plot_spline(ax, 0, control_points, 3, derivatives=2)
-ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
-display(fig)
-plt.close()
+plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 3, derivatives=2))
 
-fig, ax = plt.subplots(1, 1)
-fig.set_figheight(4, forward=True)
-ax.scatter(x, y, c='k', label='Control points')
-plot_spline(ax, 0, control_points, 3, derivatives=2, bc_type='natural')
-ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
-display(fig)
-plt.close()
+plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 3, derivatives=2, bc_type='natural'))
 
-fig, ax = plt.subplots(1, 1)
-fig.set_figheight(4, forward=True)
-ax.scatter(x, y, c='k', label='Control points')
-plot_spline(ax, 0, control_points, 3, derivatives=2, bc_type='clamped')
-ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
-display(fig)
-plt.close()
+plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 3, derivatives=2, bc_type='clamped'))
 
-fig, ax = plt.subplots(1, 1)
-fig.set_figheight(4, forward=True)
-ax.scatter(x, y, c='k', label='Control points')
-plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.smoothing)
-ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
-display(fig)
-plt.close()
+plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.smoothing))
 
-fig, ax = plt.subplots(1, 1)
-fig.set_figheight(4, forward=True)
-ax.scatter(x, y, c='k', label='Control points')
-plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.splrep)
-ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
-display(fig)
-plt.close()
+plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.splrep))
 
-fig, ax = plt.subplots(1, 1)
-fig.set_figheight(4, forward=True)
-ax.scatter(x, y, c='k', label='Control points')
-plot_spline(ax, 0, control_points, 0.01, spline_type=SplineType.smoothing)
-plot_spline(ax, 0, control_points, 0.5, spline_type=SplineType.splprep)
-plot_spline(ax, 0, control_points, 1, spline_type=SplineType.splprep)
-ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
-display(fig)
-plt.close()
+plot_with_legend(lambda ax: (
+  plot_spline(ax, 0, control_points, 0.01, spline_type=SplineType.smoothing),
+  plot_spline(ax, 0, control_points, 0.5, spline_type=SplineType.splprep),
+  plot_spline(ax, 0, control_points, 1, spline_type=SplineType.splprep),
+))
 
-fig, ax = plt.subplots(1, 1)
-fig.set_figheight(4, forward=True)
-ax.scatter(x, y, c='k', label='Control points')
-plot_spline(ax, 0, control_points, 1, mix=1)
-plot_spline(ax, 0, control_points, 3, mix=0.5)
-plot_spline(ax, 0, control_points, 3, mix=1)
-ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
-display(fig)
-plt.close()
+plot_with_legend(lambda ax: (
+  plot_spline(ax, 0, control_points, 1, mix=1),
+  plot_spline(ax, 0, control_points, 3, mix=0.5),
+  plot_spline(ax, 0, control_points, 3, mix=1),
+))
 ```
 
 ## An abandoned attempt to use smoothing splines for gait generation

--- a/docs/source/notebooks/3_1_appendix_smoothing_splines.md
+++ b/docs/source/notebooks/3_1_appendix_smoothing_splines.md
@@ -672,14 +672,16 @@ x = np.array([0, 2, 3, 5, 8])  # X trajectory
 y = np.array([1, 3, 1, 4, 6])  # Y trajectory
 control_points = np.array([x, y, t]).T
 
+
 def plot_with_legend(plot: callable):
-  fig, ax = plt.subplots(1, 1)
-  fig.set_figheight(4, forward=True)
-  ax.scatter(x, y, c='k', label='Control points')
-  plot(ax)
-  ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
-  display(fig)
-  plt.close()
+    fig, ax = plt.subplots(1, 1)
+    fig.set_figheight(4, forward=True)
+    ax.scatter(x, y, c='k', label='Control points')
+    plot(ax)
+    ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+    display(fig)
+    plt.close()
+
 
 plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 3, derivatives=2))
 
@@ -687,21 +689,31 @@ plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 3, derivatives=2,
 
 plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 3, derivatives=2, bc_type='clamped'))
 
-plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.smoothing))
+plot_with_legend(
+    lambda ax: plot_spline(
+        ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.smoothing
+    )
+)
 
-plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.splrep))
+plot_with_legend(
+    lambda ax: plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.splrep)
+)
 
-plot_with_legend(lambda ax: (
-  plot_spline(ax, 0, control_points, 0.01, spline_type=SplineType.smoothing),
-  plot_spline(ax, 0, control_points, 0.5, spline_type=SplineType.splprep),
-  plot_spline(ax, 0, control_points, 1, spline_type=SplineType.splprep),
-))
+plot_with_legend(
+    lambda ax: (
+        plot_spline(ax, 0, control_points, 0.01, spline_type=SplineType.smoothing),
+        plot_spline(ax, 0, control_points, 0.5, spline_type=SplineType.splprep),
+        plot_spline(ax, 0, control_points, 1, spline_type=SplineType.splprep),
+    )
+)
 
-plot_with_legend(lambda ax: (
-  plot_spline(ax, 0, control_points, 1, mix=1),
-  plot_spline(ax, 0, control_points, 3, mix=0.5),
-  plot_spline(ax, 0, control_points, 3, mix=1),
-))
+plot_with_legend(
+    lambda ax: (
+        plot_spline(ax, 0, control_points, 1, mix=1),
+        plot_spline(ax, 0, control_points, 3, mix=0.5),
+        plot_spline(ax, 0, control_points, 3, mix=1),
+    )
+)
 ```
 
 ## An abandoned attempt to use smoothing splines for gait generation

--- a/docs/source/notebooks/3_1_appendix_smoothing_splines.md
+++ b/docs/source/notebooks/3_1_appendix_smoothing_splines.md
@@ -37,6 +37,7 @@ The first step is to enable live python modules reloading, so changes in the pyt
 The next step is configuring matplotlib backend. Widget backend allows to interact with the plots in the notebook and is supported in Google Colab and VSCode.
 
 ```{code-cell} ipython3
+%config InlineBackend.figure_formats = ['svg']
 %matplotlib widget
 
 from IPython.display import display

--- a/docs/source/notebooks/3_1_appendix_smoothing_splines.md
+++ b/docs/source/notebooks/3_1_appendix_smoothing_splines.md
@@ -73,6 +73,7 @@ plt.plot(x, y, 'o')
 plt.legend()
 
 display(fig)
+plt.close(fig)
 ```
 
 ## BSpline in application to gaits trajectory approximation
@@ -121,6 +122,7 @@ plt.xlabel('X')
 plt.ylabel('Y')
 plt.title('Spline Interpolation Curve')
 display(fig)
+plt.close(fig)
 ```
 
 ## Bezier curve using B-spline
@@ -163,6 +165,7 @@ plt.ylabel('Y')
 plt.title('Cubic Bézier Curve using B-Spline')
 plt.grid()
 display(fig)
+plt.close(fig)
 ```
 
 ```{code-cell} ipython3
@@ -239,6 +242,7 @@ for num_items in range(2, len(spline_x_all) + 1):
     ax.scatter(spline_x, spline_z, c='r', label='Trajectory points')
     ax.legend()
     display(fig)
+    plt.close(fig)
 ```
 
 ## Pure python implementation of Bézier curve
@@ -291,6 +295,7 @@ plt.xlabel('X')
 plt.ylabel('Y')
 plt.title('Bézier Curve')
 display(fig)
+plt.close(fig)
 ```
 
 ```{code-cell} ipython3
@@ -327,6 +332,7 @@ ax[1].set_title('Z offset')
 ax[1].plot(phase, [leg_control_point(p)[1] for p in phase])
 
 display(fig)
+plt.close(fig)
 ```
 
 ```{code-cell} ipython3
@@ -366,6 +372,7 @@ ax[1].plot(phase, [leg_gait_point(p)[1] for p in phase])
 ax[1].plot(phase, [leg_control_point(p)[1] for p in phase])
 
 display(fig)
+plt.close(fig)
 ```
 
 ```{code-cell} ipython3
@@ -406,6 +413,7 @@ ax[1].plot(phase[0:-1], bezier_control_pts_pairs[:, 1], label='Bezier (Control P
 ax[1].legend()
 
 display(fig)
+plt.close(fig)
 ```
 
 ```{code-cell} ipython3
@@ -476,6 +484,7 @@ ax[2].plot(
 ax[2].legend()
 
 display(fig)
+plt.close(fig)
 ```
 
 ```{code-cell} ipython3
@@ -516,6 +525,7 @@ ax.set_zlabel('Z')
 ax.legend()
 
 display(fig)
+plt.close(fig)
 ```
 
 ```{code-cell} ipython3
@@ -583,7 +593,7 @@ def update_spline(new_waypoint):
         ax.set_zlabel('Z')
         ax.legend()
         display(fig)
-        plt.close()
+        plt.close(fig)
 
 
 # Simulate incoming new waypoints dynamically
@@ -656,7 +666,7 @@ def update_spline(new_waypoint):
     ax.set_zlabel('Z')
     ax.legend()
     display(fig)
-    plt.close()
+    plt.close(fig)
 
 
 # Simulate incoming waypoints dynamically
@@ -680,7 +690,7 @@ def plot_with_legend(plot: callable):
     plot(ax)
     ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
     display(fig)
-    plt.close()
+    plt.close(fig)
 
 
 plot_with_legend(lambda ax: plot_spline(ax, 0, control_points, 3, derivatives=2))
@@ -790,6 +800,7 @@ ax.plot(phase_new, bspline_trajectory(phase_new))
 ax.scatter(spline_x, spline_z, c='r')
 
 display(fig)
+plt.close(fig)
 ```
 
 For the sake of completeness, this is how bezier curve will look like. As you can see, it doesn't follow control points, and thus is not the best choice for our use case.
@@ -807,6 +818,7 @@ ax.plot(phase, [bezier_curve(points, t)[1] for t in phase])
 ax.scatter(points[:, 0], points[:, 1], c='r')
 
 display(fig)
+plt.close(fig)
 ```
 
 ### Defining gaits as b-spline control points

--- a/docs/source/notebooks/3_1_appendix_smoothing_splines.md
+++ b/docs/source/notebooks/3_1_appendix_smoothing_splines.md
@@ -62,7 +62,8 @@ y = np.sin(x) + 0.4 * rng.standard_normal(size=len(x))
 
 xnew = np.arange(0, 9 / 4, 1 / 50) * np.pi
 
-fig = plt.figure(figsize=(8, 6))
+fig = plt.figure()
+fig.set_figheight(6)
 plt.plot(xnew, np.sin(xnew), '-.', label='sin(x)')
 plt.plot(xnew, make_splrep(x, y, s=0, k=4)(xnew), '-', label='s=0')
 plt.plot(xnew, make_splrep(x, y, s=len(x), k=3)(xnew), '-', label=f's={len(x)}, k=3')
@@ -110,7 +111,8 @@ t = np.linspace(0, 1, 100)
 curve_x = spline_x(t)
 curve_y = spline_y(t)
 
-fig = plt.figure(figsize=(8, 6))
+fig = plt.figure()
+fig.set_figheight(6)
 plt.plot(curve_x, curve_y, label='Spline Curve')
 plt.scatter(control_x, control_y, color='red', label='Control Points')
 plt.plot(control_x, control_y, 'r--', alpha=0.5)
@@ -151,7 +153,8 @@ curve_points_x = spl_x(t)
 curve_points_y = spl_y(t)
 
 # Plot the curve and control points
-fig = plt.figure(figsize=(8, 6))
+fig = plt.figure()
+fig.set_figheight(6)
 plt.plot(curve_points_x, curve_points_y, label='Bézier Curve')
 plt.plot(control_points[:, 0], control_points[:, 1], 'o--', label='Control Points')
 plt.legend()
@@ -278,7 +281,8 @@ points = [bezier_curve(control_pts, t) for t in t_values]
 curve_x, curve_y = zip(*points)
 control_x, control_y = zip(*control_pts)
 
-fig = plt.figure(figsize=(8, 6))
+fig = plt.figure()
+fig.set_figheight(6)
 plt.plot(curve_x, curve_y, label='Bézier Curve')
 plt.scatter(control_x, control_y, color='red', label='Control Points')
 plt.plot(control_x, control_y, 'r--', alpha=0.5)
@@ -499,7 +503,8 @@ y_smooth = spline_y(t_fine)
 z_smooth = spline_z(t_fine)
 
 # Plot the results
-fig = plt.figure(figsize=(8, 6))
+fig = plt.figure()
+fig.set_figheight(6)
 ax = fig.add_subplot(111, projection='3d')
 
 ax.plot(x, y, z, 'ro', label='Waypoints')  # Original points
@@ -567,7 +572,8 @@ def update_spline(new_waypoint):
 
         # Plot updated trajectory
         plt.clf()
-        fig = plt.figure(figsize=(8, 6))
+        fig = plt.figure()
+        fig.set_figheight(6)
         ax = fig.add_subplot(111, projection='3d')
         ax.plot(x, y, z, 'ro', label='Waypoints')
         ax.plot(x_smooth, y_smooth, z_smooth, 'b-', label='B-spline Trajectory')
@@ -639,7 +645,8 @@ def update_spline(new_waypoint):
 
     # Plot updated trajectory
     plt.clf()
-    fig = plt.figure(figsize=(8, 6))
+    fig = plt.figure()
+    fig.set_figheight(6)
     ax = fig.add_subplot(111, projection='3d')
     ax.plot(waypoints[:, 0], waypoints[:, 1], waypoints[:, 2], 'ro', label='Waypoints')
     ax.plot(x_smooth, y_smooth, z_smooth, 'b-', label='B-spline Trajectory')
@@ -663,60 +670,68 @@ from smoothing_splines import plot_spline, SplineType
 t = np.array([0, 1, 2.5, 4, 6])  # Time values (not uniformly spaced)
 x = np.array([0, 2, 3, 5, 8])  # X trajectory
 y = np.array([1, 3, 1, 4, 6])  # Y trajectory
-
 control_points = np.array([x, y, t]).T
 
-fig, axes = plt.subplots(7, 1, figsize=(12, 20))
-plot_i = 0
 
-ax = axes[plot_i]
-plot_i += 1
+fig, ax = plt.subplots(1, 1)
+fig.set_figheight(4, forward=True)
 ax.scatter(x, y, c='k', label='Control points')
 plot_spline(ax, 0, control_points, 3, derivatives=2)
-ax.legend()
+ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+display(fig)
+plt.close()
 
-ax = axes[plot_i]
-plot_i += 1
+fig, ax = plt.subplots(1, 1)
+fig.set_figheight(4, forward=True)
 ax.scatter(x, y, c='k', label='Control points')
 plot_spline(ax, 0, control_points, 3, derivatives=2, bc_type='natural')
-ax.legend()
+ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+display(fig)
+plt.close()
 
-ax = axes[plot_i]
-plot_i += 1
+fig, ax = plt.subplots(1, 1)
+fig.set_figheight(4, forward=True)
 ax.scatter(x, y, c='k', label='Control points')
 plot_spline(ax, 0, control_points, 3, derivatives=2, bc_type='clamped')
-ax.legend()
+ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+display(fig)
+plt.close()
 
-
-ax = axes[plot_i]
-plot_i += 1
+fig, ax = plt.subplots(1, 1)
+fig.set_figheight(4, forward=True)
 ax.scatter(x, y, c='k', label='Control points')
 plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.smoothing)
-ax.legend()
+ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+display(fig)
+plt.close()
 
-ax = axes[plot_i]
-plot_i += 1
+fig, ax = plt.subplots(1, 1)
+fig.set_figheight(4, forward=True)
 ax.scatter(x, y, c='k', label='Control points')
 plot_spline(ax, 0, control_points, 0.5, derivatives=2, spline_type=SplineType.splrep)
-ax.legend()
+ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+display(fig)
+plt.close()
 
-ax = axes[plot_i]
-plot_i += 1
+fig, ax = plt.subplots(1, 1)
+fig.set_figheight(4, forward=True)
 ax.scatter(x, y, c='k', label='Control points')
 plot_spline(ax, 0, control_points, 0.01, spline_type=SplineType.smoothing)
 plot_spline(ax, 0, control_points, 0.5, spline_type=SplineType.splprep)
 plot_spline(ax, 0, control_points, 1, spline_type=SplineType.splprep)
-ax.legend()
+ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+display(fig)
+plt.close()
 
-ax = axes[plot_i]
-plot_i += 1
+fig, ax = plt.subplots(1, 1)
+fig.set_figheight(4, forward=True)
 ax.scatter(x, y, c='k', label='Control points')
 plot_spline(ax, 0, control_points, 1, mix=1)
 plot_spline(ax, 0, control_points, 3, mix=0.5)
 plot_spline(ax, 0, control_points, 3, mix=1)
-ax.legend()
-
-fig
+ax.legend(bbox_to_anchor=(1.0, 0.97), loc='lower right')
+display(fig)
+plt.close()
 ```
 
 ## An abandoned attempt to use smoothing splines for gait generation

--- a/docs/source/notebooks/3_generating_gaits.md
+++ b/docs/source/notebooks/3_generating_gaits.md
@@ -1039,6 +1039,7 @@ ax[0].legend()
 ax[1].legend()
 
 display(fig)
+plt.close(fig)
 ```
 
 As you can see above, interpolating BSpline generates a smooth trajectory that follows the control points with smooth velocity changes, which will reduce strains on servos. However it comes at a cost of random overshooting that might be non desirable.

--- a/docs/source/notebooks/3_generating_gaits.md
+++ b/docs/source/notebooks/3_generating_gaits.md
@@ -460,7 +460,7 @@ directional_tripod_gen = DirectionalGaitGenerator(TripodGaitGenerator(step_lengt
 
 directional_tripod_gen.visualize_continuous_in_3d(direction=Point3D([1, 0, 0], 'Forward'))
 directional_tripod_gen.visualize_continuous_in_3d(direction=Point3D([0, 1, 0], 'Left'))
-directional_tripod_gen.visualize_continuous_in_3d(direction=Point3D([1, 1, 0], 'Forward-Left'))
+directional_tripod_gen.visualize_continuous_in_3d(direction=Point3D([1, -1, 0], 'Forward-right'))
 
 # stomp in place
 _ = directional_tripod_gen.visualize_continuous_in_3d(direction=Point3D([0, 0, 1], 'UP/Stomp'))

--- a/docs/source/notebooks/3_generating_gaits.md
+++ b/docs/source/notebooks/3_generating_gaits.md
@@ -1012,7 +1012,8 @@ trajectory_points = np.array(
         [3, 3, frames_between_points * 8],
     ]
 )
-fig, ax = plt.subplots(2, 1, figsize=(8, 10))
+fig, ax = plt.subplots(2, 1)
+fig.set_figheight(10)
 ax[0].scatter(trajectory_points[::, 0], trajectory_points[::, 1], c='k', label='Trajectory points')
 
 current_t = trajectory_points[3, 2] + 20
@@ -1049,7 +1050,8 @@ plt.rcParams['animation.embed_limit'] = 50
 
 
 plt.ioff()
-fig, ax = plt.subplots(1, 1, figsize=(10, 8))
+fig, ax = plt.subplots(1, 1)
+fig.set_figheight(8)
 
 num_items = 4
 max_points = 7

--- a/docs/source/notebooks/3_generating_gaits.md
+++ b/docs/source/notebooks/3_generating_gaits.md
@@ -45,6 +45,7 @@ The first step is to enable live python modules reloading, so changes in the pyt
 The next step is configuring matplotlib backend. Widget backend allows to interact with the plots in the notebook and is supported in Google Colab and VSCode.
 
 ```{code-cell} ipython3
+%config InlineBackend.figure_formats = ['svg']
 %matplotlib widget
 
 from IPython.display import display

--- a/docs/source/notebooks/gait_generators.py
+++ b/docs/source/notebooks/gait_generators.py
@@ -24,6 +24,7 @@ from models import HexapodLeg
 import numpy as np
 from point import Point3D
 from transforms import Transform
+from IPython.display import display
 
 
 class GaitGenerator:
@@ -188,7 +189,7 @@ class GaitGenerator:
         ax.legend()
 
         plt.tight_layout()
-        plt.show()
+        display(fig)
 
     def visualize_continuous_in_3d(
         self,
@@ -299,5 +300,5 @@ class GaitGenerator:
         if own_fig:
             ax.legend()
             plt.tight_layout()
-            plt.show()
+            display(fig)
         return ax, plot_lines

--- a/docs/source/notebooks/gait_generators.py
+++ b/docs/source/notebooks/gait_generators.py
@@ -82,7 +82,8 @@ class GaitGenerator:
                 z_values[leg].append(offset.z)
 
         # Plot the data
-        fig, axs = plt.subplots(4, 1, figsize=(10, 12))
+        fig, axs = plt.subplots(4, 1)
+        fig.set_figheight(12, forward=True)
         # Adjust spacing between subplots to avoid title overlapping with ticks
         plt.subplots_adjust(hspace=0.8)  # Increased from 0.5 to 0.8 for more space between subplots
 
@@ -248,7 +249,8 @@ class GaitGenerator:
 
         # Plot the data
         if ax is None:
-            fig = plt.figure(figsize=(12, 10))
+            fig = plt.figure()
+            fig.set_figheight(7, forward=True)
             ax = fig.add_subplot(111, projection='3d')
 
             # Adjust view angle for better visibility of all legs

--- a/docs/source/notebooks/gait_generators.py
+++ b/docs/source/notebooks/gait_generators.py
@@ -190,6 +190,7 @@ class GaitGenerator:
 
         plt.tight_layout()
         display(fig)
+        plt.close(fig)
 
     def visualize_continuous_in_3d(
         self,
@@ -301,4 +302,5 @@ class GaitGenerator:
             ax.legend()
             plt.tight_layout()
             display(fig)
+            plt.close(fig)
         return ax, plot_lines

--- a/docs/source/notebooks/gait_generators.py
+++ b/docs/source/notebooks/gait_generators.py
@@ -20,11 +20,11 @@
 
 from abc import abstractmethod
 
+from IPython.display import display
 from models import HexapodLeg
 import numpy as np
 from point import Point3D
 from transforms import Transform
-from IPython.display import display
 
 
 class GaitGenerator:

--- a/docs/source/notebooks/gait_generators.py
+++ b/docs/source/notebooks/gait_generators.py
@@ -207,8 +207,8 @@ class GaitGenerator:
         phases = np.linspace(phase_start, phase_end, _steps, endpoint=True)
 
         if leg_centers is None:
-            base_offset = step_length / 1.6
-            side_offset = base_offset * 1.5
+            base_offset = step_length * 1.3
+            side_offset = base_offset * 1.6
             leg_centers = {
                 HexapodLeg.left_middle: Point3D([0.0, side_offset, 0.0]),
                 HexapodLeg.left_front: Point3D([base_offset, base_offset, 0.0]),
@@ -274,6 +274,7 @@ class GaitGenerator:
             ax.set_xlim(min_x - padding, max_x + padding)
             ax.set_ylim(min_y - padding, max_y + padding)
             ax.set_zlim(min_z, max_z + padding)
+            ax.set_aspect('equal')
 
         # Plot x offsets
         for leg in self.all_legs:

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -625,7 +625,7 @@ def animate_plot(
 ):
     anim = None
 
-    plt.rcParams['animation.html'] = 'jshtml'
+    plt.rcParams['animation.html'] = 'html5'
 
     if _interactive and not is_sphinx_build():
         with plt.ion():

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -289,7 +289,7 @@ def plot_leg3d(
     # Doesn't really add anything to the plot
     # plot_cartesian_plane(ax, Point(-10, -10), Point(10, 10), no_ticks=True)
 
-    ax.set(aspect='equal')
+    ax.set_aspect('equal')
     # Hide grid lines
     ax.grid(False)
     # ax.grid(False, which='both', axis='z')

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -625,7 +625,7 @@ def animate_plot(
 ):
     if is_sphinx_build_no_videos():
         return
-
+    plt.close()  # Close all the previous figures to ensure best performance and least bugs
     anim = None
 
     plt.rcParams['animation.html'] = 'html5'

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -345,7 +345,7 @@ def plot_leg_links(
 
     # Add inline labels for leg links
     if link_labels == 'legend':
-        axes.legend()
+        axes.legend(bbox_to_anchor=(1.0, 0.97), loc='upper right')
     elif link_labels == 'inline':
         add_inline_labels(axes, with_overall_progress=False, fontsize='medium')
 

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -273,6 +273,7 @@ def plot_leg3d(
     subplot=111,
     fig=None,
     ax=None,
+    hide_grid=True,
 ):
     if fig is None:
         fig = plt.figure()
@@ -290,21 +291,21 @@ def plot_leg3d(
     # plot_cartesian_plane(ax, Point(-10, -10), Point(10, 10), no_ticks=True)
 
     ax.set_aspect('equal')
-    # Hide grid lines
-    ax.grid(False)
-    # ax.grid(False, which='both', axis='z')
-
-    # Hide axes ticks
-    ax.set_xticks([])
-    ax.set_yticks([])
-    ax.set_zticks([])
-
     ax.set_facecolor('white')
-    ax.xaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
-    ax.yaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
-    ax.zaxis.set_pane_color((0, 0.2, 0, 0.5))
-    # ax.zaxis.line.set_visible(False)  # OFF to bypass ValueError: 'bboxes' cannot be empty in inline figures
-    ax.zaxis.gridlines.set_visible(False)
+    if hide_grid:
+        ax.grid(False)
+
+        # Hide axes ticks
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_zticks([])
+
+        ax.xaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
+        ax.yaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
+        ax.zaxis.set_pane_color((0, 0.2, 0, 0.5))
+
+        # Hide grid lines
+        ax.zaxis.gridlines.set_visible(False)
 
     return fig, ax, plot_data
 

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -623,6 +623,9 @@ def animate_plot(
     _save_animation_name=None,
     **interact_kwargs,
 ):
+    if is_sphinx_build_no_videos():
+        return
+
     anim = None
 
     plt.rcParams['animation.html'] = 'html5'
@@ -645,3 +648,7 @@ def animate_plot(
 
 def is_sphinx_build():
     return os.getenv('SPHINX_BUILD') == '1'
+
+
+def is_sphinx_build_no_videos():
+    return os.getenv('SPHINX_BUILD_NO_VIDEOS') == '1'

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -638,6 +638,7 @@ def animate_plot(
         with plt.ioff():
             anim = FuncAnimation(_fig, _animate, frames=_frames, interval=_interval)
             display(anim)  # type: ignore # noqa: F821
+            plt.close()
 
             if _save_animation_name is not None:
                 animation_writer = FFMpegWriter(fps=24)

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -273,7 +273,7 @@ def plot_leg3d(
     subplot=111,
     fig=None,
     ax=None,
-    hide_grid=True,
+    hide_grid=False,
 ):
     if fig is None:
         fig = plt.figure()

--- a/docs/source/notebooks/plotting.py
+++ b/docs/source/notebooks/plotting.py
@@ -625,7 +625,7 @@ def animate_plot(
 ):
     if is_sphinx_build_no_videos():
         return
-    plt.close()  # Close all the previous figures to ensure best performance and least bugs
+
     anim = None
 
     plt.rcParams['animation.html'] = 'html5'
@@ -638,7 +638,7 @@ def animate_plot(
         with plt.ioff():
             anim = FuncAnimation(_fig, _animate, frames=_frames, interval=_interval)
             display(anim)  # type: ignore # noqa: F821
-            plt.close()
+            plt.close(_fig)
 
             if _save_animation_name is not None:
                 animation_writer = FFMpegWriter(fps=24)


### PR DESCRIPTION
# Fix Figure Sizes for Documentation

## Issue

Many notebooks had oversized plots that worked in standalone notebooks but were partially cut off in the documentation. This was particularly noticeable in pages like the gait generation documentation.

Closes #169

## Changes

Switched from setting figure width and height to setting only height and letting width being auto-assigned. 
Used CSS to set images and videos to full width of the page.
See below for more detailed breakdown:

### CSS Improvements
- Added responsive styling for notebook outputs to ensure figures are properly sized
- Made all notebook output images, videos, and canvas elements fluid with proper width constraints
- Ensured height is automatically adjusted to maintain aspect ratio

### Figure Display Improvements
- Switched from `plt.show()` to `display(fig)` to render diagrams as SVG images that can be viewed, saved, and scaled
- Set SVG as the default figure format for better scaling and quality
- Added proper figure closing after display to improve resource management
- Added `set_aspect('equal')` to ensure plots are not asymmetrical

### Animation Improvements
- Switched animations to HTML5 videos (MP4) for better compatibility and performance
- Added grid display in 3D animations to maintain better depth perspective
- Enhanced 3D foot display by adding depth to create proper perspective

### Code Refactoring
- Used template method pattern instead of copy-paste code for better maintainability
- Improved code hygiene by closing figures once they're no longer displayed
- Standardized figure height setting approach across notebooks

### Documentation Configuration
- Added lightbox2 extension for better image viewing experience
- Updated configuration to properly handle SVG images

## Testing
The changes have been tested by building the documentation locally and verifying that all figures display correctly with proper sizing and aspect ratios.