### PR TITLE
Remove duplicate workflow triggers

### DIFF
--- a/.github/workflows/act-docker-build-image.yml
+++ b/.github/workflows/act-docker-build-image.yml
@@ -2,7 +2,8 @@ name: Build act ubuntu docker images
 
 on:
   schedule:
-    - cron: 0 12 */7 * *
+    # Rerun workflow to pick up the latest base images
+    - cron: 0 12 */7 * * # “At 12:00 on every 7th day-of-month.” https://crontab.guru/#0_12_*/7_*_*
   push:
     paths:
       - .github/workflows/act-docker-build-image.yml

--- a/.github/workflows/act-docker-copy-full-image.yml
+++ b/.github/workflows/act-docker-copy-full-image.yml
@@ -3,7 +3,8 @@ name: Act Docker - Copy full images
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 12 */7 * *
+    # Rerun workflow to pick up the latest source images
+    - cron: 0 12 */7 * * # “At 12:00 on every 7th day-of-month.” https://crontab.guru/#0_12_*/7_*_*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - main
-      - v*
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI/CD
 
 on:
-  release:
-    types:
-      - published
   push:
     branches:
       - main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,9 @@ on:
     branches:
       - main
   schedule:
-    - cron: '32 17 * * 5'
+    # Schedule for codeql is needed in case new vulnerabilities are found in dependencies
+    # or new rules are added to CodeQL both of which happens outside of this repository.
+    - cron: '32 17 * * 5' # “At 17:32 on Friday.” https://crontab.guru/#32_17_*_*_5
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,6 @@ on:
   pull_request:
     branches:
       - main
-      - v*
   schedule:
     - cron: '32 17 * * 5'
   merge_group:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,5 @@
 name: Build docs
 on:
-  release:
-    types:
-      - published
   push:
     branches:
       - main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - main
-      - v*
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,8 +1,5 @@
 name: gitleaks
 on:
-  release:
-    types:
-      - published
   push:
     branches:
       - main

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - main
-      - v*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - main
-      - v*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,4 +1,5 @@
 name: reviewdog
+
 on:
   push:
     branches:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,8 +1,5 @@
 name: reviewdog
 on:
-  release:
-    types:
-      - published
   push:
     branches:
       - main

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - main
-      - v*
   merge_group:
     types:
       - checks_requested


### PR DESCRIPTION
Remove release published trigger for workflows as they already have tag triggers
Remove branch `v*` triggers as there are no branches like this, these are tags.
Document need for job schedules as well as human readable decoding of cron values