### PR TITLE
Add serial port testing with pseudo terminals

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   "containerEnv": {},
   "mounts": [
   ],
-  "postCreateCommand": "sudo chown rosdev:rosdev /home/rosdev/ros2_ws/.ansible /home/rosdev/ros2_ws/.cache /home/rosdev/ros2_ws/build /home/rosdev/ros2_ws/install /home/rosdev/ros2_ws/lcov /home/rosdev/ros2_ws/log /home/rosdev/ros2_ws/docs/_build /home/rosdev/ros2_ws/.micromamba /home/rosdev/ros2_ws/.venv && python3 -m venv /home/rosdev/ros2_ws/.venv && /home/rosdev/ros2_ws/.venv/bin/python3 -m pip install -r /home/rosdev/ros2_ws/requirements.txt",
+  "postCreateCommand": "sudo chown rosdev:rosdev /home/rosdev/ros2_ws/.ansible /home/rosdev/ros2_ws/.vscode /home/rosdev/ros2_ws/.cache /home/rosdev/ros2_ws/build /home/rosdev/ros2_ws/install /home/rosdev/ros2_ws/lcov /home/rosdev/ros2_ws/log /home/rosdev/ros2_ws/docs/_build /home/rosdev/ros2_ws/.micromamba /home/rosdev/ros2_ws/.venv && python3 -m venv /home/rosdev/ros2_ws/.venv && /home/rosdev/ros2_ws/.venv/bin/python3 -m pip install -r /home/rosdev/ros2_ws/requirements.txt",
   "runArgs": [
     // Commented out to allow Codespaces use
     // "--network", "host",
@@ -23,6 +23,7 @@
     // "--device", "/dev/ttySC0"
 
     "--mount", "type=volume,source=drqp-ansible,target=/home/rosdev/ros2_ws/.ansible",
+    "--mount", "type=volume,source=drqp-vscode,target=/home/rosdev/ros2_ws/.vscode",
     "--mount", "type=volume,source=drqp-clangd-cache,target=/home/rosdev/ros2_ws/.cache",
     "--mount", "type=volume,source=drqp-colcon-build,target=/home/rosdev/ros2_ws/build",
     "--mount", "type=volume,source=drqp-colcon-install,target=/home/rosdev/ros2_ws/install",

--- a/docs/source/notebooks/gait_generators.py
+++ b/docs/source/notebooks/gait_generators.py
@@ -247,10 +247,9 @@ class GaitGenerator:
         else:
             subtitle = '\n' + ', '.join([f'{k}={v}' for k, v in gen_args.items()])
 
-        own_fig = ax is None
-
         # Plot the data
-        if own_fig:
+        fig = None
+        if ax is None:
             fig = plt.figure()
             fig.set_figheight(7, forward=True)
             ax = fig.add_subplot(111, projection='3d')
@@ -298,7 +297,7 @@ class GaitGenerator:
                     plot_lines = {}
                 plot_lines[leg] = lines[0]
 
-        if own_fig:
+        if fig is not None:
             ax.legend()
             plt.tight_layout()
             display(fig)

--- a/docs/source/notebooks/gait_generators.py
+++ b/docs/source/notebooks/gait_generators.py
@@ -250,7 +250,7 @@ class GaitGenerator:
         own_fig = ax is None
 
         # Plot the data
-        if ax is None:
+        if own_fig:
             fig = plt.figure()
             fig.set_figheight(7, forward=True)
             ax = fig.add_subplot(111, projection='3d')

--- a/packages/runtime/drqp_serial/include/drqp_serial/TcpSerial.h
+++ b/packages/runtime/drqp_serial/include/drqp_serial/TcpSerial.h
@@ -42,7 +42,11 @@ public:
   size_t writeBytes(const void* buffer, size_t size) override;
   size_t readBytes(void* buffer, size_t size) override;
 
+  void setTimeout(const std::chrono::milliseconds& timeout);
+  std::chrono::milliseconds getTimeout() const;
+
 private:
   boost::asio::io_service ioService_;
   tcp::socket socket_;
+  boost::posix_time::time_duration timeout_ = boost::posix_time::milliseconds{ 5000 };
 };

--- a/packages/runtime/drqp_serial/include/drqp_serial/TcpSerial.h
+++ b/packages/runtime/drqp_serial/include/drqp_serial/TcpSerial.h
@@ -48,5 +48,5 @@ public:
 private:
   boost::asio::io_service ioService_;
   tcp::socket socket_;
-  boost::posix_time::time_duration timeout_ = boost::posix_time::milliseconds{ 5000 };
+  boost::posix_time::time_duration timeout_ = boost::posix_time::milliseconds{5000};
 };

--- a/packages/runtime/drqp_serial/include/drqp_serial/UnixSerial.h
+++ b/packages/runtime/drqp_serial/include/drqp_serial/UnixSerial.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -39,6 +40,9 @@ public:
 
   size_t writeBytes(const void* buffer, size_t size) override;
   size_t readBytes(void* buffer, size_t size) override;
+
+  void setTimeout(const std::chrono::milliseconds& timeout);
+  std::chrono::milliseconds getTimeout() const;
 
 private:
   struct Impl;

--- a/packages/runtime/drqp_serial/src/AsioCommon.h
+++ b/packages/runtime/drqp_serial/src/AsioCommon.h
@@ -63,7 +63,7 @@ size_t doWithTimeout(
   timer.async_wait([&timerResult](const auto& ec) { timerResult = ec; });
 
   std::optional<boost::system::error_code> operationErrorCode;
-  std::optional<std::size_t> bytesTransferred;
+  std::size_t bytesTransferred = 0;
 
   AsyncOperation<operation>::perform(
     stream, buffers, [&operationErrorCode, &bytesTransferred](const auto& ec, std::size_t bt) {
@@ -81,8 +81,7 @@ size_t doWithTimeout(
 
   if (operationErrorCode && *operationErrorCode) {
     throw boost::system::system_error(*operationErrorCode);
-    return 0;
   }
 
-  return *bytesTransferred;
+  return bytesTransferred;
 }

--- a/packages/runtime/drqp_serial/src/AsioCommon.h
+++ b/packages/runtime/drqp_serial/src/AsioCommon.h
@@ -55,11 +55,11 @@ struct AsyncOperation<AsyncOp::Write>
 template <AsyncOp operation, typename MutableBufferSequence, typename Stream>
 size_t doWithTimeout(
   boost::asio::io_service& ioService, Stream& stream, const MutableBufferSequence& buffers,
-  uint64_t timeoutMs = 5000)
+  const boost::posix_time::time_duration& timeout)
 {
   std::optional<boost::system::error_code> timerResult;
   boost::asio::deadline_timer timer(ioService);
-  timer.expires_from_now(boost::posix_time::milliseconds(timeoutMs));
+  timer.expires_from_now(timeout);
   timer.async_wait([&timerResult](const auto& ec) { timerResult = ec; });
 
   std::optional<boost::system::error_code> operationErrorCode;

--- a/packages/runtime/drqp_serial/src/AsioCommon.h
+++ b/packages/runtime/drqp_serial/src/AsioCommon.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <utility>
 #include <optional>
 

--- a/packages/runtime/drqp_serial/src/TcpSerial.cpp
+++ b/packages/runtime/drqp_serial/src/TcpSerial.cpp
@@ -44,7 +44,8 @@ void TcpSerial::begin(const uint32_t baudRate, const uint8_t transferConfig) {}
 
 size_t TcpSerial::writeBytes(const void* buffer, size_t size)
 {
-  return doWithTimeout<AsyncOp::Write>(ioService_, socket_, boost::asio::buffer(buffer, size), timeout_);
+  return doWithTimeout<AsyncOp::Write>(
+    ioService_, socket_, boost::asio::buffer(buffer, size), timeout_);
 }
 
 void TcpSerial::flushRead()
@@ -71,7 +72,8 @@ bool TcpSerial::available()
 
 size_t TcpSerial::readBytes(void* buffer, size_t size)
 {
-  return doWithTimeout<AsyncOp::Read>(ioService_, socket_, boost::asio::buffer(buffer, size), timeout_);
+  return doWithTimeout<AsyncOp::Read>(
+    ioService_, socket_, boost::asio::buffer(buffer, size), timeout_);
 }
 
 void TcpSerial::setTimeout(const std::chrono::milliseconds& timeout)

--- a/packages/runtime/drqp_serial/src/TcpSerial.cpp
+++ b/packages/runtime/drqp_serial/src/TcpSerial.cpp
@@ -44,7 +44,7 @@ void TcpSerial::begin(const uint32_t baudRate, const uint8_t transferConfig) {}
 
 size_t TcpSerial::writeBytes(const void* buffer, size_t size)
 {
-  return doWithTimeout<AsyncOp::Write>(ioService_, socket_, boost::asio::buffer(buffer, size));
+  return doWithTimeout<AsyncOp::Write>(ioService_, socket_, boost::asio::buffer(buffer, size), timeout_);
 }
 
 void TcpSerial::flushRead()
@@ -71,5 +71,15 @@ bool TcpSerial::available()
 
 size_t TcpSerial::readBytes(void* buffer, size_t size)
 {
-  return doWithTimeout<AsyncOp::Read>(ioService_, socket_, boost::asio::buffer(buffer, size));
+  return doWithTimeout<AsyncOp::Read>(ioService_, socket_, boost::asio::buffer(buffer, size), timeout_);
+}
+
+void TcpSerial::setTimeout(const std::chrono::milliseconds& timeout)
+{
+  timeout_ = boost::posix_time::milliseconds(timeout.count());
+}
+
+std::chrono::milliseconds TcpSerial::getTimeout() const
+{
+  return std::chrono::milliseconds(timeout_.total_milliseconds());
 }

--- a/packages/runtime/drqp_serial/src/UnixSerial.cpp
+++ b/packages/runtime/drqp_serial/src/UnixSerial.cpp
@@ -30,7 +30,7 @@
 
 struct UnixSerial::Impl
 {
-  boost::posix_time::time_duration timeout_ = boost::posix_time::milliseconds{ 500 };
+  boost::posix_time::time_duration timeout_ = boost::posix_time::milliseconds{500};
   boost::asio::io_service ioService_;
   boost::asio::serial_port serial_;
 

--- a/packages/runtime/drqp_serial/src/UnixSerial.cpp
+++ b/packages/runtime/drqp_serial/src/UnixSerial.cpp
@@ -30,6 +30,7 @@
 
 struct UnixSerial::Impl
 {
+  boost::posix_time::time_duration timeout_ = boost::posix_time::milliseconds{ 500 };
   boost::asio::io_service ioService_;
   boost::asio::serial_port serial_;
 
@@ -95,7 +96,7 @@ void UnixSerial::begin(const uint32_t baudRate, const uint8_t transferConfig)
 size_t UnixSerial::writeBytes(const void* buffer, size_t size)
 {
   return doWithTimeout<AsyncOp::Write>(
-    impl_->ioService_, impl_->serial_, boost::asio::buffer(buffer, size));
+    impl_->ioService_, impl_->serial_, boost::asio::buffer(buffer, size), impl_->timeout_);
 }
 
 void UnixSerial::flushRead()
@@ -116,5 +117,15 @@ bool UnixSerial::available()
 size_t UnixSerial::readBytes(void* buffer, size_t size)
 {
   return doWithTimeout<AsyncOp::Read>(
-    impl_->ioService_, impl_->serial_, boost::asio::buffer(buffer, size));
+    impl_->ioService_, impl_->serial_, boost::asio::buffer(buffer, size), impl_->timeout_);
+}
+
+void UnixSerial::setTimeout(const std::chrono::milliseconds& timeout)
+{
+  impl_->timeout_ = boost::posix_time::milliseconds(timeout.count());
+}
+
+std::chrono::milliseconds UnixSerial::getTimeout() const
+{
+  return std::chrono::milliseconds(impl_->timeout_.total_milliseconds());
 }

--- a/packages/runtime/drqp_serial/test/CMakeLists.txt
+++ b/packages/runtime/drqp_serial/test/CMakeLists.txt
@@ -1,6 +1,11 @@
 
 find_package(catch_ros2 REQUIRED)
+
+add_executable(drqp_serial_port_test
+  TestSerialPort.cpp
+)
 add_executable(drqp_serial_tests
+  # TestSerialPort.cpp
   TestSerialRecordingProxy.cpp
 )
 drqp_test_enable_coverage(drqp_serial_tests)

--- a/packages/runtime/drqp_serial/test/CMakeLists.txt
+++ b/packages/runtime/drqp_serial/test/CMakeLists.txt
@@ -1,11 +1,8 @@
 
 find_package(catch_ros2 REQUIRED)
 
-add_executable(drqp_serial_port_test
-  TestSerialPort.cpp
-)
 add_executable(drqp_serial_tests
-  # TestSerialPort.cpp
+  TestSerialPort.cpp
   TestSerialRecordingProxy.cpp
 )
 drqp_test_enable_coverage(drqp_serial_tests)

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -21,6 +21,7 @@
 #include <pty.h>
 #include <unistd.h>
 
+#include <boost/asio.hpp>
 #include <catch_ros2/catch.hpp>
 
 #include "drqp_serial/UnixSerial.h"
@@ -70,6 +71,21 @@ SCENARIO("test unix serial with pseudo terminal")
         REQUIRE(bytes_read == data.length());
         buffer.resize(bytes_read);
         REQUIRE(buffer == data);
+      }
+    }
+
+    WHEN("no data is written to the master file descriptor")
+    {
+      THEN("serial.available() returns false")
+      {
+        REQUIRE(!serial.available());
+      }
+
+      THEN("serial.readBytes() throws an exception on timeout")
+      {
+        std::string buffer;
+        buffer.resize(10, '\0');
+        REQUIRE_THROWS_AS(serial.readBytes(buffer.data(), buffer.size()), boost::system::system_error);
       }
     }
   }

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -40,6 +40,7 @@ SCENARIO("test unix serial with pseudo terminal")
     INFO("Slave name: " << slave_name);
     UnixSerial serial(slave_name);
     serial.begin(115200);
+    serial.setTimeout(std::chrono::milliseconds{5});
 
     WHEN("data is written to the serial")
     {

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -9,15 +9,17 @@
 #include <string.h>
 
 int main() {
-    int master_fd, slave_fd;
-    char slave_name[256];
-    pid_t pid;
+    int master_fd = -1, slave_fd = -1;
+    char slave_name[256] = {};
+    pid_t pid = 0;
 
     // Open a pty
     if (openpty(&master_fd, &slave_fd, slave_name, nullptr, nullptr) == -1) {
         std::cerr << "Error opening pty: " << strerror(errno) << std::endl;
         return 1;
     }
+
+    std::cout << "Slave name: " << slave_name << std::endl;
 
     // Fork the process
     pid = fork();

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -45,11 +45,12 @@ SCENARIO("test unix serial with pseudo terminal")
 
       THEN("data is readable from the master file descriptor")
       {
-        char buffer[1024];
-        size_t bytes_read = read(master_fd, buffer, sizeof(buffer) - 1);
+        std::string buffer;
+        buffer.resize(data.length() + 1, '\0');
+        size_t bytes_read = read(master_fd, buffer.data(), buffer.size() - 1);
         REQUIRE(bytes_read == data.length());
-        buffer[bytes_read] = '\0';
-        REQUIRE(std::string(buffer) == data);
+        buffer.resize(bytes_read);
+        REQUIRE(buffer == data);
       }
     }
 
@@ -60,12 +61,13 @@ SCENARIO("test unix serial with pseudo terminal")
 
       THEN("data is readable from the serial")
       {
-        char buffer[1024];
+        std::string buffer;
+        buffer.resize(data.length() + 1, '\0');
         size_t bytes_read = 0;
-        REQUIRE_NOTHROW(bytes_read = serial.readBytes(buffer, data.length()));
+        REQUIRE_NOTHROW(bytes_read = serial.readBytes(buffer.data(), buffer.size() - 1));
         REQUIRE(bytes_read == data.length());
-        buffer[bytes_read] = '\0';
-        REQUIRE(std::string(buffer) == data);
+        buffer.resize(bytes_read);
+        REQUIRE(buffer == data);
       }
     }
 

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 #include <pty.h>
+#include <unistd.h>
 
 #include <catch_ros2/catch.hpp>
 
@@ -48,7 +49,7 @@ SCENARIO("test unix serial with pseudo terminal")
       {
         std::string buffer;
         buffer.resize(data.length() + 1, '\0');
-        size_t bytes_read = read(master_fd, buffer.data(), buffer.size() - 1);
+        size_t bytes_read = ::read(master_fd, buffer.data(), buffer.size() - 1);
         REQUIRE(bytes_read == data.length());
         buffer.resize(bytes_read);
         REQUIRE(buffer == data);
@@ -58,7 +59,7 @@ SCENARIO("test unix serial with pseudo terminal")
     WHEN("data is written to the master file descriptor")
     {
       std::string data = "Hello, World!";
-      write(master_fd, data.c_str(), data.length());
+      ::write(master_fd, data.c_str(), data.length());
 
       THEN("data is readable from the serial")
       {

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <string>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <pty.h>
+#include <errno.h>
+#include <string.h>
+
+int main() {
+    int master_fd, slave_fd;
+    char slave_name[256];
+    pid_t pid;
+
+    // Open a pty
+    if (openpty(&master_fd, &slave_fd, slave_name, nullptr, nullptr) == -1) {
+        std::cerr << "Error opening pty: " << strerror(errno) << std::endl;
+        return 1;
+    }
+
+    // Fork the process
+    pid = fork();
+    if (pid == -1) {
+        std::cerr << "Error forking process: " << strerror(errno) << std::endl;
+        return 1;
+    }
+
+    if (pid == 0) {
+        // Child process: execute a command in the pty
+        close(master_fd); // Close the master end in the child
+        setsid(); // Create a new session
+        dup2(slave_fd, STDIN_FILENO);  // Duplicate slave to stdin
+        dup2(slave_fd, STDOUT_FILENO); // Duplicate slave to stdout
+        dup2(slave_fd, STDERR_FILENO); // Duplicate slave to stderr
+        close(slave_fd); // Close the original slave fd
+
+        // Execute a command (e.g., bash)
+        execlp("bash", "bash", nullptr);
+        std::cerr << "Error executing command: " << strerror(errno) << std::endl;
+        return 1;
+    } else {
+        // Parent process: communicate with the child through the pty
+        close(slave_fd); // Close the slave end in the parent
+        std::string command;
+        char buffer[1024];
+        ssize_t bytes_read;
+
+        while (true) {
+            std::cout << "Enter command: ";
+            std::getline(std::cin, command);
+
+            // Send the command to the child process
+            write(master_fd, command.c_str(), command.length());
+            write(master_fd, "\n", 1); // Add newline character
+
+            // Read the output from the child process
+            while ((bytes_read = read(master_fd, buffer, sizeof(buffer) - 1)) > 0) {
+                buffer[bytes_read] = '\0';
+                std::cout << buffer;
+            }
+            if (bytes_read < 0) {
+              std::cerr << "Error reading from pty: " << strerror(errno) << std::endl;
+              break;
+            }
+            if (std::cin.eof()){
+                break;
+            }
+        }
+
+        // Wait for the child process to finish
+        wait(nullptr);
+        close(master_fd);
+    }
+
+    return 0;
+}

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -27,13 +27,14 @@
 SCENARIO("test unix serial with pseudo terminal")
 {
   int master_fd = -1, slave_fd = -1;
-  char slave_name[256] = {};
+  std::array<char, 256> slave_name_arr;
 
   // Open a pseudo terminal
-  REQUIRE(openpty(&master_fd, &slave_fd, slave_name, nullptr, nullptr) != -1);
+  REQUIRE(openpty(&master_fd, &slave_fd, slave_name_arr.data(), nullptr, nullptr) != -1);
 
   GIVEN("UnixSerial is created with slave name")
   {
+    std::string slave_name(slave_name_arr.data());
     INFO("Slave name: " << slave_name);
     UnixSerial serial(slave_name);
     serial.begin(115200);

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -72,7 +72,6 @@ SCENARIO("test unix serial with pseudo terminal")
         REQUIRE(buffer == data);
       }
     }
-
   }
   close(master_fd);
   close(slave_fd);

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -85,7 +85,8 @@ SCENARIO("test unix serial with pseudo terminal")
       {
         std::string buffer;
         buffer.resize(10, '\0');
-        REQUIRE_THROWS_AS(serial.readBytes(buffer.data(), buffer.size()), boost::system::system_error);
+        REQUIRE_THROWS_AS(
+          serial.readBytes(buffer.data(), buffer.size()), boost::system::system_error);
       }
     }
   }


### PR DESCRIPTION
This PR adds a test for the UnixSerial class using pseudo terminals (PTY) to simulate serial port communication. The test creates a master/slave PTY pair and verifies bidirectional communication between the UnixSerial instance and the master file descriptor.

## Changes
Add test that validates writing to the serial port and reading from the master FD
Add test that validates writing to the master FD and reading from the serial port
Add test that validates reads with no data available
Make timeouts configurable for UnixSerial and TcpSerial 
Use 5ms timeout for tests