### PR TITLE
Stabilize serial ports tests on GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,14 @@ jobs:
       options: --user rosdev # Mandatory! Sets user:group matching the one of the runner, allowing access to mounted paths
     steps:
       - uses: actions/checkout@v4
+
+      - name: Build and test ROS workspace
+        shell: bash
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          colcon build --mixin coverage-pytest ninja --event-handlers=console_cohesion+ --cmake-args -D DRQP_ENABLE_COVERAGE=ON
+          colcon test --mixin coverage-pytest --event-handlers=console_cohesion+
+
       - uses: ros-tooling/action-ros-ci@v0.4
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,11 @@ jobs:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           no-symlink-install: true
           extra-cmake-args: ' -D DRQP_ENABLE_COVERAGE=ON'
-          # pin the repository in the workflow to a specific commit to avoid
-          # changes in colcon-mixin-repository from breaking your tests.
-          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/b8436aa16c0bdbc01081b12caa253cbf16e0fb82/index.yaml
+          # devcontianer includes the default mixins already, so we don't need to add them here
+          # moreover, the recent change to rate limit on GitHub unauthenticated access is causing
+          # the build to fail frequently with 429 errors
+          # https://github.com/orgs/community/discussions/157887#discussioncomment-13193098
+          colcon-mixin-repository: ""
           colcon-defaults: |
             {
               "build": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,20 +132,29 @@ jobs:
       - name: copy .colcon $HOME
         shell: bash
         run: |
+          set -x
+          set +e
+
+          echo PWD="$PWD"
           env | sort
+
+          colcon mixin list
+          colcon mixin show
+          colcon mixin update default || true
+
+          ls -al /home/rosdev/.colcon $HOME
           cp -r /home/rosdev/.colcon $HOME
+          ls -al $HOME/.colcon
+
+          colcon mixin list
+          colcon mixin show
+          colcon mixin update default
 
       - uses: actions/checkout@v4
 
       - name: Build and test ROS workspace
         shell: bash
         run: |
-          env | sort
-          echo PWD="$PWD"
-          colcon mixin list
-          colcon mixin show
-          colcon mixin update default
-          ls -al
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           colcon build --mixin coverage-pytest ninja --event-handlers=console_cohesion+ --cmake-args -D DRQP_ENABLE_COVERAGE=ON
           colcon test --mixin coverage-pytest --event-handlers=console_cohesion+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,14 @@ jobs:
               }
             }
 
+      - name: Build and test ROS workspace again
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          colcon build --mixin coverage-pytest ninja --event-handlers=console_cohesion+ --cmake-args -D DRQP_ENABLE_COVERAGE=ON
+          colcon test --mixin coverage-pytest --event-handlers=console_cohesion+
+
       - name: Process llvm coverage
         shell: bash
         run: ./packages/cmake/llvm-cov-export-all.py ./ros_ws/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,33 +155,19 @@ jobs:
       - name: Build and test ROS workspace
         shell: bash
         run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          colcon build --mixin coverage-pytest ninja --event-handlers=console_cohesion+ --cmake-args -D DRQP_ENABLE_COVERAGE=ON
-          colcon test --mixin coverage-pytest --event-handlers=console_cohesion+
+          set -x
+          set -e
 
-      - uses: ros-tooling/action-ros-ci@v0.4
-        with:
-          target-ros2-distro: ${{ env.ROS_DISTRO }}
-          no-symlink-install: true
-          extra-cmake-args: ' -D DRQP_ENABLE_COVERAGE=ON'
-          # devcontianer includes the default mixins already, so we don't need to add them here
-          # moreover, the recent change to rate limit on GitHub unauthenticated access is causing
-          # the build to fail frequently with 429 errors
-          # https://github.com/orgs/community/discussions/157887#discussioncomment-13193098
-          colcon-mixin-repository: ""
-          colcon-defaults: |
-            {
-              "build": {
-                "mixin": ["coverage-pytest", "ninja"]
-              },
-              "test": {
-                "mixin": ["coverage-pytest"]
-              }
-            }
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          time sudo apt update
+          time rosdep update
+          time ./scripts/ros-dep.sh
+          time colcon build --mixin coverage-pytest ninja rel-with-deb-info --event-handlers=console_cohesion+ --cmake-args -D DRQP_ENABLE_COVERAGE=ON
+          time colcon test --mixin coverage-pytest --event-handlers=console_cohesion+
 
       - name: Process llvm coverage
         shell: bash
-        run: ./packages/cmake/llvm-cov-export-all.py ./ros_ws/build
+        run: ./packages/cmake/llvm-cov-export-all.py ./build
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
@@ -190,19 +176,19 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests-${{ matrix.arch }}
           name: codecov-umbrella
-          directory: ros_ws/build/
+          directory: build/
 
       - name: Test Summary
         uses: test-summary/action@v2
         if: ${{ env.ACT == '' && !cancelled() }}
         with:
-          paths: "ros_ws/build/*/test_results/*/*.xunit.xml"
+          paths: "build/*/test_results/*/*.xunit.xml"
 
       - name: Discover test reports
         if: ${{ !cancelled() }}
         run: |
           set -x
-          test_reports=$(find ros_ws/build -name "*.xunit.xml" | tr '\n' ',')
+          test_reports=$(find build -name "*.xunit.xml" | tr '\n' ',')
           test_reports=${test_reports%,}  # Remove trailing comma
 
           echo "result=$test_reports" >> "$GITHUB_OUTPUT"
@@ -222,22 +208,8 @@ jobs:
         if: always()
         with:
           name: colcon-logs-${{ matrix.arch }}
-          path: ros_ws/log
+          path: log
           retention-days: 90
-
-      - name: Troubleshoot
-        if: failure()
-        shell: bash
-        run: |
-          set -x
-          set +e
-          ls -al ${{ github.workspace }}
-          ls -al .
-          ls -al ros_ws
-          cd ros_ws
-          find src/ -print0 | xargs -0 ls -al
-          cat package.repo
-          vcs import --force --recursive src/ < package.repo
 
   dev-container-ci:
       name: Devcontainer image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,23 @@ jobs:
       - name: copy .colcon $HOME
         shell: bash
         run: |
+          env | sort
           cp -r /home/rosdev/.colcon $HOME
 
       - uses: actions/checkout@v4
+
+      - name: Build and test ROS workspace
+        shell: bash
+        run: |
+          env | sort
+          echo PWD="$PWD"
+          colcon mixin list
+          colcon mixin show
+          colcon mixin update default
+          ls -al
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          colcon build --mixin coverage-pytest ninja --event-handlers=console_cohesion+ --cmake-args -D DRQP_ENABLE_COVERAGE=ON
+          colcon test --mixin coverage-pytest --event-handlers=console_cohesion+
 
       - uses: ros-tooling/action-ros-ci@v0.4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,13 +136,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Build and test ROS workspace
-        shell: bash
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          colcon build --mixin coverage-pytest ninja --event-handlers=console_cohesion+ --cmake-args -D DRQP_ENABLE_COVERAGE=ON
-          colcon test --mixin coverage-pytest --event-handlers=console_cohesion+
-
       - uses: ros-tooling/action-ros-ci@v0.4
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
@@ -162,14 +155,6 @@ jobs:
                 "mixin": ["coverage-pytest"]
               }
             }
-
-      - name: Build and test ROS workspace again
-        if: ${{ always() }}
-        shell: bash
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          colcon build --mixin coverage-pytest ninja --event-handlers=console_cohesion+ --cmake-args -D DRQP_ENABLE_COVERAGE=ON
-          colcon test --mixin coverage-pytest --event-handlers=console_cohesion+
 
       - name: Process llvm coverage
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,11 @@ jobs:
       image: ${{ needs.merge-dev-image.outputs.image }}
       options: --user rosdev # Mandatory! Sets user:group matching the one of the runner, allowing access to mounted paths
     steps:
+      - name: copy .colcon $HOME
+        shell: bash
+        run: |
+          cp -r /home/rosdev/.colcon $HOME
+
       - uses: actions/checkout@v4
 
       - name: Build and test ROS workspace

--- a/docs/source/Howto/issue-using-act-and-devcontainers-ci.md
+++ b/docs/source/Howto/issue-using-act-and-devcontainers-ci.md
@@ -4,9 +4,9 @@ The problem is that the **mounted workspace** in the
 `devcontainers/ci` docker container is **from the host file system**.
 
 `act` is creating its own docker container with the workspace copied
-into its container’s file system. `devcontainers/ci` docker ntainer is
+into its container’s file system. `devcontainers/ci` docker container is
 not created inside `act`’s container (no docker-in-docker), but
-besides it. Therefore `devcontainers/ci`’s workspace mount is t
+besides it. Therefore `devcontainers/ci`’s workspace mount is not
 pointing to `act`’s workspace copy, but to the original workspace on
 the host file system.
 
@@ -14,7 +14,7 @@ This is why the devcontainer cannot start. Path
 `/var/run/act/workflow/` exists in `act`’s container but not on
 your host system:
 
-```
+```shell
 | [2023-11-17T09:14:55.111Z] Start: Run: docker run
 ...
 --mount type=bind,src=/var/run/act/workflow/outputcmd.txt,dst=/mnt/github/output

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -49,7 +49,8 @@ SCENARIO("test unix serial with pseudo terminal")
     {
       std::string data = "Hello, World 1!";
       REQUIRE_NOTHROW(serial.writeBytes(data.c_str(), data.length()));
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      // std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      ::fsync(slave_fd);
 
       THEN("data is readable from the master file descriptor")
       {
@@ -66,7 +67,8 @@ SCENARIO("test unix serial with pseudo terminal")
     {
       std::string data = "Hello, World 2!";
       ::write(master_fd, data.c_str(), data.length());
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      // std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      ::fsync(master_fd);
 
       THEN("data is readable from the serial")
       {
@@ -84,7 +86,8 @@ SCENARIO("test unix serial with pseudo terminal")
     {
       std::string data = "Hello, World 3!";
       ::write(master_fd, data.c_str(), data.length());
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      // std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      ::fsync(master_fd);
 
       serial.flushRead();
 

--- a/packages/runtime/drqp_serial/test/TestSerialPort.cpp
+++ b/packages/runtime/drqp_serial/test/TestSerialPort.cpp
@@ -49,8 +49,7 @@ SCENARIO("test unix serial with pseudo terminal")
     {
       std::string data = "Hello, World 1!";
       REQUIRE_NOTHROW(serial.writeBytes(data.c_str(), data.length()));
-      // std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      ::fsync(slave_fd);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
       THEN("data is readable from the master file descriptor")
       {
@@ -67,8 +66,7 @@ SCENARIO("test unix serial with pseudo terminal")
     {
       std::string data = "Hello, World 2!";
       ::write(master_fd, data.c_str(), data.length());
-      // std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      ::fsync(master_fd);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
       THEN("data is readable from the serial")
       {
@@ -86,8 +84,7 @@ SCENARIO("test unix serial with pseudo terminal")
     {
       std::string data = "Hello, World 3!";
       ::write(master_fd, data.c_str(), data.length());
-      // std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      ::fsync(master_fd);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
       serial.flushRead();
 


### PR DESCRIPTION
Serial port tests have been failing intermittently on GHA for what looked like a delay in write operations. According to spec data should be available right away, but for some reason it is not.

Update test to do more checks and reporting. This allowed to reproduce issue locally in devcontainer 
Add 100ms sleep between write and read operations, this seems to resolve the issue for now both locally and GHA