### PR TITLE
203 implement kill switch

### DIFF
--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -156,9 +156,10 @@
   "tasks": {
     "version": "2.0.0",
     "tasks": [
+
       {
         "label": "Dr.QP colcon build",
-        "type": "RDE",
+        "type": "ROS2",
         "command": "colcon",
         "args": [
           "build",
@@ -198,7 +199,7 @@
       },
       {
         "label": "Dr.QP colcon test",
-        "type": "RDE",
+        "type": "ROS2",
         "command": "colcon",
         "args": [
           "test",
@@ -266,7 +267,7 @@
       },
       {
         "label": "Dr.QP rosdep",
-        "type": "RDE",
+        "type": "ROS2",
         "command": "./scripts/ros-dep.sh",
         "problemMatcher": []
       },
@@ -367,13 +368,12 @@
     "cmake.generator": "Ninja",
     "cmake.exportCompileCommandsFile": true,
 
-    "RDE.distro": "jazzy",
+    "ROS2.distro": "jazzy",
     "ament-task-provider.envSetup": "source /opt/ros/jazzy/setup.bash",
 
     // Draft for .micromamba ros-jazzy, but still doesn't work
-    // "ros2.rosRootDir": ".micromamba/envs/ros-jazzy/",
-    // "ros.rosSetupScript": ".micromamba/envs/ros-jazzy/setup.bash",
-    // "RDE.rosSetupScript": ".micromamba/envs/ros-jazzy/setup.bash",
+    // "ROS2.rosRootDir": ".micromamba/envs/ros-jazzy/",
+    // "ROS2.rosSetupScript": ".micromamba/envs/ros-jazzy/setup.bash",
     // "ament-task-provider.envSetup": "source .micromamba/envs/ros-jazzy/setup.bash",
     "python.autoComplete.extraPaths": [
       "/opt/ros/jazzy/lib/python3.12/site-packages",

--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -159,7 +159,7 @@
 
       {
         "label": "Dr.QP colcon build",
-        "type": "RDE",
+        "type": "ROS2",
         "command": "colcon",
         "args": [
           "build",
@@ -199,7 +199,7 @@
       },
       {
         "label": "Dr.QP colcon test",
-        "type": "RDE",
+        "type": "ROS2",
         "command": "colcon",
         "args": [
           "test",
@@ -267,7 +267,7 @@
       },
       {
         "label": "Dr.QP rosdep",
-        "type": "RDE",
+        "type": "ROS2",
         "command": "./scripts/ros-dep.sh",
         "problemMatcher": []
       },

--- a/Dr.QP.code-workspace
+++ b/Dr.QP.code-workspace
@@ -159,7 +159,7 @@
 
       {
         "label": "Dr.QP colcon build",
-        "type": "ROS2",
+        "type": "RDE",
         "command": "colcon",
         "args": [
           "build",
@@ -199,7 +199,7 @@
       },
       {
         "label": "Dr.QP colcon test",
-        "type": "ROS2",
+        "type": "RDE",
         "command": "colcon",
         "args": [
           "test",
@@ -267,7 +267,7 @@
       },
       {
         "label": "Dr.QP rosdep",
-        "type": "ROS2",
+        "type": "RDE",
         "command": "./scripts/ros-dep.sh",
         "problemMatcher": []
       },

--- a/docker/ros/ansible/playbooks/200_pair_controller.yml
+++ b/docker/ros/ansible/playbooks/200_pair_controller.yml
@@ -20,8 +20,26 @@
         state: present
         update_cache: true
 
+    - name: Create temporary directory
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: bt_pair_
+      register: temp_dir
+
+    - name: Copy bt_pair.expect script to remote host
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../../../../scripts/bt_pair.expect"
+        dest: "{{ temp_dir.path }}/bt_pair.expect"
+        mode: "0755"
+
     - name: Pair controller by MAC or name
       register: pairing_result
       changed_when: "'already paired' not in pairing_result.stdout and 'Paired successfully' in pairing_result.stdout"
-      ansible.builtin.script:
-        cmd: '{{ playbook_dir }}/../../scripts/bt_pair.expect --mac "{{ controller_mac }}" --name "{{ controller_name }}"'
+      ansible.builtin.command:
+        cmd: '{{ temp_dir.path }}/bt_pair.expect --mac "{{ controller_mac }}" --name "{{ controller_name }}"'
+
+    - name: Clean up temporary directory
+      ansible.builtin.file:
+        path: "{{ temp_dir.path }}"
+        state: absent
+      when: temp_dir.path is defined

--- a/docs/source/GettingStarted/ansible.md
+++ b/docs/source/GettingStarted/ansible.md
@@ -276,6 +276,16 @@ or
 ansible-playbook -i inventories/real-robots.yml playbooks/200_pair_controller.yml -e "controller_mac=XX:XX:XX:XX:XX:XX"
 ```
 
+#### Putting a PS5 Dualsense Controller into Pairing Mode
+
+To put a PS5 Dualsense controller into pairing mode, press and hold the PS button and the Create (or Share) button simultaneously until the light bar starts flashing. This indicates that the controller is discoverable for pairing with other devices, such as a PC or a smartphone.
+
+Here's a more detailed breakdown:
+
+1. Ensure the controller is off: If the controller is already on, hold the PS button until it turns off.
+2. Initiate pairing mode: Press and hold both the PS button and the Create (or Share) button at the same time.
+3. Observe the light bar: The light bar on the controller will start flashing, indicating that it's in pairing mode.
+
 ## Migration from Shell Scripts
 
 The Ansible playbooks replaced the following shell scripts:

--- a/packages/runtime/drqp_a1_16_driver/src/PoseSetter.cpp
+++ b/packages/runtime/drqp_a1_16_driver/src/PoseSetter.cpp
@@ -83,9 +83,11 @@ public:
             killModeActive_ = true;
             XYZrobotServo servo(*servoSerial_, XYZrobotServo::kBroadcastId);
             servo.torqueOff();
+            RCLCPP_INFO(get_logger(), "Kill mode activated");
           } else {
             killModeActive_ = false;
             unkillTimestamp = msg.header.stamp;
+            RCLCPP_INFO(get_logger(), "Kill mode deactivated");
           }
         } catch (std::exception& e) {
           RCLCPP_ERROR(get_logger(), "Exception occurred in kill_switch handler %s", e.what());

--- a/packages/runtime/drqp_a1_16_driver/src/PoseSetter.cpp
+++ b/packages/runtime/drqp_a1_16_driver/src/PoseSetter.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 
+#include <rclcpp/logging.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <drqp_interfaces/msg/multi_servo_position_goal.hpp>
@@ -56,7 +57,7 @@ public:
         "/servo_goals", 10, [this](const drqp_interfaces::msg::MultiServoPositionGoal& msg) {
           try {
             if (killModeActive_) {
-              RCLCPP_INFO(get_logger(), "Kill switch is on, not setting pose");
+              RCLCPP_DEBUG(get_logger(), "Kill switch is on, not setting pose");
               return;
             }
 

--- a/packages/runtime/drqp_brain/drqp_brain/run_hexapod_ros.py
+++ b/packages/runtime/drqp_brain/drqp_brain/run_hexapod_ros.py
@@ -62,7 +62,7 @@ class ButtonIndex(Enum):
     DpadDown = 12
     DpadLeft = 13
     DpadRight = 14
-    TouchpadButton = 15
+    # TouchpadButton = 20 # DOES NOT WORK WITH DEFAULT ROS joy node https://github.com/Dr-QP/Dr.QP/issues/207
 
 
 class ButtonAxis(Enum):
@@ -134,7 +134,7 @@ class HexapodController(rclpy.node.Node):
         self.joystick_buttons = [
             JoystickButton(ButtonIndex.DpadLeft, lambda b, e: self.prev_gait()),
             JoystickButton(ButtonIndex.DpadRight, lambda b, e: self.next_gait()),
-            JoystickButton(ButtonIndex.TouchpadButton, lambda b, e: self.kill_switch()),
+            JoystickButton(ButtonIndex.PS, lambda b, e: self.kill_switch()),
         ]
 
         self.joint_state_pub = self.create_publisher(
@@ -198,6 +198,7 @@ class HexapodController(rclpy.node.Node):
         self.walk_speed = abs(left_x) + abs(left_y) + abs(left_trigger)
         self.rotation_speed = right_x
 
+        self.get_logger().info(f'Buttons: {joy.buttons}')
         for button in self.joystick_buttons:
             button.update(joy.buttons)
 

--- a/packages/runtime/drqp_brain/drqp_brain/run_hexapod_ros.py
+++ b/packages/runtime/drqp_brain/drqp_brain/run_hexapod_ros.py
@@ -23,6 +23,7 @@
 import argparse
 from enum import auto, Enum
 
+import drqp_interfaces.msg
 from drqp_brain.geometry import Point3D
 from drqp_brain.models import HexapodModel
 from drqp_brain.walk_controller import GaitType, WalkController
@@ -133,10 +134,14 @@ class HexapodController(rclpy.node.Node):
         self.joystick_buttons = [
             JoystickButton(ButtonIndex.DpadLeft, lambda b, e: self.prev_gait()),
             JoystickButton(ButtonIndex.DpadRight, lambda b, e: self.next_gait()),
+            JoystickButton(ButtonIndex.TouchpadButton, lambda b, e: self.kill_switch()),
         ]
 
         self.joint_state_pub = self.create_publisher(
             sensor_msgs.msg.JointState, '/joint_states', qos_profile=50
+        )
+        self.kill_switch_pub = self.create_publisher(
+            drqp_interfaces.msg.KillSwitch, '/kill_switch', qos_profile=1
         )
         self.setup_hexapod()
 
@@ -228,6 +233,12 @@ class HexapodController(rclpy.node.Node):
                 msg.position.append(np.radians(angle))
 
         self.joint_state_pub.publish(msg)
+
+    def kill_switch(self):
+        self.get_logger().info('Kill switch pressed')
+        msg = drqp_interfaces.msg.KillSwitch()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        self.kill_switch_pub.publish(msg)
 
 
 def main():

--- a/packages/runtime/drqp_brain/drqp_brain/run_hexapod_ros.py
+++ b/packages/runtime/drqp_brain/drqp_brain/run_hexapod_ros.py
@@ -198,7 +198,6 @@ class HexapodController(rclpy.node.Node):
         self.walk_speed = abs(left_x) + abs(left_y) + abs(left_trigger)
         self.rotation_speed = right_x
 
-        self.get_logger().info(f'Buttons: {joy.buttons}')
         for button in self.joystick_buttons:
             button.update(joy.buttons)
 

--- a/packages/runtime/drqp_brain/launch/bringup.launch.py
+++ b/packages/runtime/drqp_brain/launch/bringup.launch.py
@@ -30,6 +30,7 @@ from launch_ros.actions import Node
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
     load_drivers = LaunchConfiguration('load_drivers')
+    servo_device = LaunchConfiguration('servo_device')
     load_joystick = LaunchConfiguration('load_joystick')
     show_rviz = LaunchConfiguration('show_rviz')
 
@@ -58,11 +59,21 @@ def generate_launch_description():
                 choices=['true', 'false'],
                 description='Load drqp_a1_16_driver pose_setter',
             ),
+            DeclareLaunchArgument(
+                name='servo_device',
+                default_value='/dev/ttySC0',
+                description='Serial device for servos',
+            ),
             Node(
                 package='drqp_a1_16_driver',
                 executable='pose_setter',
                 output='screen',
-                parameters=[{'use_sim_time': use_sim_time}],
+                parameters=[
+                    {
+                        'use_sim_time': use_sim_time,
+                        'device_address': servo_device,
+                    }
+                ],
                 condition=IfCondition(load_drivers),
             ),
             DeclareLaunchArgument(

--- a/packages/runtime/drqp_interfaces/CMakeLists.txt
+++ b/packages/runtime/drqp_interfaces/CMakeLists.txt
@@ -22,6 +22,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/ServoState.msg
   msg/MultiServoState.msg
 
+  msg/KillSwitch.msg
+
   DEPENDENCIES std_msgs
 )
 

--- a/packages/runtime/drqp_interfaces/msg/KillSwitch.msg
+++ b/packages/runtime/drqp_interfaces/msg/KillSwitch.msg
@@ -1,0 +1,1 @@
+std_msgs/Header header

--- a/scripts/bt_pair.expect
+++ b/scripts/bt_pair.expect
@@ -50,8 +50,10 @@ expect {
         if {($mac ne "" && $found_mac eq $mac) || ($name ne "" && [string match "*$name*" $found_name])} {
             set device_mac $found_mac
             set full_device_name $found_name
-            puts "✅ Device '$full_device_name' ($device_mac) already paired!"
-            exit 0
+            puts "✅ Device '$full_device_name' ($device_mac) already paired. Removing pairing..."
+            send "remove $device_mac\r"
+            expect "#"
+            puts "✅ Removed pairing."
         }
         exp_continue
     }


### PR DESCRIPTION
Implement kill switch using PS button, as touchpad button doesn't work with default ros joy node
Add KillSwitch message that is sent on kill button press and works as toggle in the driver turning off torque and blocking commands until flipped back

Other changes:
Migrate tasks type to the new ROS2 extension
Fix controller pairing ansible playbook
Add servo_device option to bringup launch file