### PR TITLE
221 implement finalization sequence

### DIFF
--- a/packages/runtime/drqp_brain/drqp_brain/brain_node.py
+++ b/packages/runtime/drqp_brain/drqp_brain/brain_node.py
@@ -140,6 +140,7 @@ class HexapodBrain(rclpy.node.Node):
             JoystickButton(ButtonIndex.DpadRight, lambda b, e: self.next_gait()),
             JoystickButton(ButtonIndex.PS, lambda b, e: self.process_kill_switch()),
             JoystickButton(ButtonIndex.Start, lambda b, e: self.reboot_servos()),
+            JoystickButton(ButtonIndex.Select, lambda b, e: self.finalize()),
         ]
         self.joystick_sub = self.create_subscription(
             sensor_msgs.msg.Joy, '/joy', self.process_inputs, qos_profile=10
@@ -245,11 +246,12 @@ class HexapodBrain(rclpy.node.Node):
         self.publish_servo_goals()
 
     def initialization_sequence(self):
-        self.sequence_queue.add(0.6, self.initialization_sequence_step1)
+        self.sequence_queue.clear()
+        self.sequence_queue.add(1.0, self.initialization_sequence_step1)
         self.sequence_queue.add(0.6, self.initialization_sequence_step2)
         self.sequence_queue.add(0.6, self.initialization_sequence_step3)
         self.sequence_queue.add(0.6, self.initialization_sequence_step4)
-        self.sequence_queue.add(0.6, self.initialization_sequence_step5)
+        self.sequence_queue.add(0.5, self.initialization_sequence_step5)
         self.sequence_queue.add(0.0, self.initialization_sequence_done)
 
     # - Turn torque on for femur
@@ -287,6 +289,25 @@ class HexapodBrain(rclpy.node.Node):
 
     def initialization_sequence_done(self):
         self.robot_event_pub.publish(std_msgs.msg.String(data='initializing_done'))
+
+    def finalization_sequence(self):
+        self.sequence_queue.clear()
+        self.sequence_queue.add(1.1, self.finalization_sequence_step1)
+        self.sequence_queue.add(0.6, self.finalization_sequence_step2)
+        self.sequence_queue.add(0.0, self.finalization_sequence_done)
+
+    def finalization_sequence_step1(self):
+        self.get_logger().info('Finalization sequence started')
+
+        self.hexapod.forward_kinematics(0, -105, 0)
+        self.publish_servo_goals(playtime_ms=1000)
+
+    def finalization_sequence_step2(self):
+        self.hexapod.forward_kinematics(0, -105, -60)
+        self.publish_servo_goals(playtime_ms=500)
+
+    def finalization_sequence_done(self):
+        self.robot_event_pub.publish(std_msgs.msg.String(data='finalizing_done'))
 
     def turn_torque_on(self, joints):
         msg = drqp_interfaces.msg.TorqueOn()
@@ -327,17 +348,29 @@ class HexapodBrain(rclpy.node.Node):
 
         if self.robot_state == 'torque_off':
             self.get_logger().info('Torque is off, stopping')
-            self.loop_timer.cancel()
-            self.sequence_queue.clear()
-            torque_on_msg = drqp_interfaces.msg.TorqueOn()
-            torque_on_msg.torque_on.append(False)
-            self.servo_torque_on_pub.publish(torque_on_msg)
+            self.stop_walk_controller()
+            self.publish_torque_off()
         elif self.robot_state == 'initializing':
-            self.get_logger().info('Initializing')
             self.initialization_sequence()
         elif self.robot_state == 'torque_on':
             self.get_logger().info('Torque is on, starting')
             self.loop_timer.reset()
+        elif self.robot_state == 'finalizing':
+            self.stop_walk_controller()
+            self.finalization_sequence()
+        elif self.robot_state == 'finalized':
+            self.get_logger().info('Finalized')
+            self.publish_torque_off()
+
+    def stop_walk_controller(self):
+        self.get_logger().info('Stopping')
+        self.loop_timer.cancel()
+        self.sequence_queue.clear()
+
+    def publish_torque_off(self):
+        torque_on_msg = drqp_interfaces.msg.TorqueOn()
+        torque_on_msg.torque_on.append(False)
+        self.servo_torque_on_pub.publish(torque_on_msg)
 
     def process_kill_switch(self):
         self.get_logger().info('Kill switch pressed')
@@ -346,6 +379,9 @@ class HexapodBrain(rclpy.node.Node):
             self.robot_event_pub.publish(std_msgs.msg.String(data='kill_switch_off'))
         else:
             self.robot_event_pub.publish(std_msgs.msg.String(data='kill_switch_on'))
+
+    def finalize(self):
+        self.robot_event_pub.publish(std_msgs.msg.String(data='finalize'))
 
     def reboot_servos(self):
         self.get_logger().info('Rebooting servos')

--- a/packages/runtime/drqp_brain/drqp_brain/brain_node.py
+++ b/packages/runtime/drqp_brain/drqp_brain/brain_node.py
@@ -373,12 +373,7 @@ class HexapodBrain(rclpy.node.Node):
         self.servo_torque_on_pub.publish(torque_on_msg)
 
     def process_kill_switch(self):
-        self.get_logger().info('Kill switch pressed')
-
-        if self.robot_state == 'torque_off':
-            self.robot_event_pub.publish(std_msgs.msg.String(data='kill_switch_off'))
-        else:
-            self.robot_event_pub.publish(std_msgs.msg.String(data='kill_switch_on'))
+        self.robot_event_pub.publish(std_msgs.msg.String(data='kill_switch_pressed'))
 
     def finalize(self):
         self.robot_event_pub.publish(std_msgs.msg.String(data='finalize'))

--- a/packages/runtime/drqp_brain/drqp_brain/robot_state/robot_state_machine.py
+++ b/packages/runtime/drqp_brain/drqp_brain/robot_state/robot_state_machine.py
@@ -44,5 +44,4 @@ class RobotStateMachine(StateMachine):
     finalize = torque_on.to(finalizing)
     finalizing_done = finalizing.to(finalized)
 
-    kill_switch_on = turn_off
-    kill_switch_off = initialize
+    kill_switch_pressed = turn_off | initialize

--- a/packages/runtime/drqp_brain/drqp_brain/robot_state/robot_state_machine.py
+++ b/packages/runtime/drqp_brain/drqp_brain/robot_state/robot_state_machine.py
@@ -34,7 +34,7 @@ class RobotStateMachine(StateMachine):
 
     # Transitions/Events
     initialize = torque_off.to(initializing) | finalized.to(initializing)
-    turn_on = initializing.to(torque_on)
+    initializing_done = initializing.to(torque_on)
     turn_off = (
         torque_on.to(torque_off)
         | initializing.to(torque_off)
@@ -42,9 +42,7 @@ class RobotStateMachine(StateMachine):
         | finalized.to(torque_off)
     )
     finalize = torque_on.to(finalizing)
-    done = finalizing.to(finalized)
+    finalizing_done = finalizing.to(finalized)
 
     kill_switch_on = turn_off
     kill_switch_off = initialize
-    initializing_done = turn_on
-    finalizing_done = done

--- a/packages/runtime/drqp_brain/test/test_robot_state_machine.py
+++ b/packages/runtime/drqp_brain/test/test_robot_state_machine.py
@@ -34,16 +34,16 @@ class TestRobotStateMachine:
         # img_path = './robot_state_machine.png'
         # state_machine._graph().write_png(img_path)
 
-    def test_should_turn_on_from_initialization(self, state_machine):
+    def test_should_initializing_done_from_initialization(self, state_machine):
         state_machine.send('initialize')
         assert state_machine.current_state == state_machine.initializing
 
-        state_machine.send('turn_on', state_machine)
+        state_machine.send('initializing_done', state_machine)
         assert state_machine.current_state == state_machine.torque_on
 
     def test_should_finalize_from_turned_on(self, state_machine):
         state_machine.send('initialize')
-        state_machine.send('turn_on')
+        state_machine.send('initializing_done')
         assert state_machine.current_state == state_machine.torque_on
 
         state_machine.send('finalize')
@@ -51,11 +51,11 @@ class TestRobotStateMachine:
 
     def test_should_done_from_finalizing(self, state_machine):
         state_machine.send('initialize')
-        state_machine.send('turn_on')
+        state_machine.send('initializing_done')
         state_machine.send('finalize')
         assert state_machine.current_state == state_machine.finalizing
 
-        state_machine.send('done')
+        state_machine.send('finalizing_done')
         assert state_machine.current_state == state_machine.finalized
 
     def test_should_turn_off_from_initialization(self, state_machine):
@@ -67,7 +67,7 @@ class TestRobotStateMachine:
 
     def test_should_turn_off_from_turned_on(self, state_machine):
         state_machine.send('initialize')
-        state_machine.send('turn_on')
+        state_machine.send('initializing_done')
         assert state_machine.current_state == state_machine.torque_on
 
         state_machine.send('turn_off')
@@ -75,7 +75,7 @@ class TestRobotStateMachine:
 
     def test_should_turn_off_from_finalizing(self, state_machine):
         state_machine.send('initialize')
-        state_machine.send('turn_on')
+        state_machine.send('initializing_done')
         state_machine.send('finalize')
         assert state_machine.current_state == state_machine.finalizing
 
@@ -84,9 +84,9 @@ class TestRobotStateMachine:
 
     def test_should_turn_off_from_finalized(self, state_machine):
         state_machine.send('initialize')
-        state_machine.send('turn_on')
+        state_machine.send('initializing_done')
         state_machine.send('finalize')
-        state_machine.send('done')
+        state_machine.send('finalizing_done')
         assert state_machine.current_state == state_machine.finalized
 
         state_machine.send('turn_off')


### PR DESCRIPTION
Implement finalization sequence to fold robot
Merge kill switch related events into a single one to fix handling of finalized->kill_switch sequence
Normalize event names a little:
 - Rename `turn_on` to `initializing_done`
 - `done` to `finalizing_done`