### PR TITLE
Enable kill switch on TouchButton

### DIFF
--- a/packages/runtime/drqp_brain/drqp_brain/brain_node.py
+++ b/packages/runtime/drqp_brain/drqp_brain/brain_node.py
@@ -62,6 +62,7 @@ class HexapodBrain(rclpy.node.Node):
                 ButtonIndex.DpadLeft: lambda b, e: self.prev_gait(),
                 ButtonIndex.DpadRight: lambda b, e: self.next_gait(),
                 ButtonIndex.PS: lambda b, e: self.process_kill_switch(),
+                ButtonIndex.TouchpadButton: lambda b, e: self.process_kill_switch(),
                 ButtonIndex.Start: lambda b, e: self.reboot_servos(),
                 ButtonIndex.Select: lambda b, e: self.finalize(),
             }

--- a/packages/runtime/drqp_brain/drqp_brain/brain_node.py
+++ b/packages/runtime/drqp_brain/drqp_brain/brain_node.py
@@ -62,8 +62,7 @@ class HexapodBrain(rclpy.node.Node):
                 ButtonIndex.DpadLeft: lambda b, e: self.prev_gait(),
                 ButtonIndex.DpadRight: lambda b, e: self.next_gait(),
                 ButtonIndex.PS: lambda b, e: self.process_kill_switch(),
-                ButtonIndex.TouchpadButton: lambda b, e: self.process_kill_switch(),
-                ButtonIndex.Start: lambda b, e: self.reboot_servos(),
+                ButtonIndex.TouchpadButton: lambda b, e: self.reboot_servos(),
                 ButtonIndex.Select: lambda b, e: self.finalize(),
             }
         )

--- a/packages/runtime/drqp_brain/drqp_brain/brain_node.py
+++ b/packages/runtime/drqp_brain/drqp_brain/brain_node.py
@@ -62,7 +62,8 @@ class HexapodBrain(rclpy.node.Node):
                 ButtonIndex.DpadLeft: lambda b, e: self.prev_gait(),
                 ButtonIndex.DpadRight: lambda b, e: self.next_gait(),
                 ButtonIndex.PS: lambda b, e: self.process_kill_switch(),
-                ButtonIndex.TouchpadButton: lambda b, e: self.reboot_servos(),
+                ButtonIndex.TouchpadButton: lambda b, e: self.process_kill_switch(),
+                ButtonIndex.Start: lambda b, e: self.reboot_servos(),
                 ButtonIndex.Select: lambda b, e: self.finalize(),
             }
         )

--- a/packages/runtime/drqp_brain/drqp_brain/joystick_button.py
+++ b/packages/runtime/drqp_brain/drqp_brain/joystick_button.py
@@ -48,8 +48,7 @@ class ButtonIndex(Enum):
     DpadDown = 12
     DpadLeft = 13
     DpadRight = 14
-    # DOES NOT WORK WITH DEFAULT ROS joy node https://github.com/Dr-QP/Dr.QP/issues/207
-    # TouchpadButton = 20
+    TouchpadButton = 20
 
 
 class ButtonAxis(Enum):

--- a/scripts/bt_pair.expect
+++ b/scripts/bt_pair.expect
@@ -68,6 +68,12 @@ expect {
 
 send "scan on\r"
 
+puts "Scanning for device..."
+puts "=================================================================================================="
+puts "||  To enter DualSense pair mode simultaneously press and hold the PS button (center)"
+puts "||  and the Create button (top left) for a few seconds until the light bar starts to strobe blue"
+puts "=================================================================================================="
+
 # Wait until the device appears in scan output
 expect {
     -re {.*NEW.*Device ([0-9A-Fa-f:]+) (.*)} {


### PR DESCRIPTION
TouchButton is handled just right by SDL and ros/joy, at least when running nodes directly on raspi or laptop.
Re-Enable kill switch on TouchButton

Add instructions on how to enable dualsense BT pairing