### PR TITLE
Actions workflow orchestrator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,31 @@ env:
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
 
 jobs:
+  paths-filter:
+    name: Need to run?
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    permissions: {}
+    timeout-minutes: 10
+    outputs:
+      pass: ${{ steps.filter.outputs.pass }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Filters
+        uses: ./.github/actions/paths-filter
+        id: filter
+        with:
+          extra-filter: |
+            - .github/workflows/ci.yml
+
   build-dev-image:
     name: Development image
     timeout-minutes: 35
+    needs: paths-filter
+    if: needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch'
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,23 @@ name: CI/CD
 on:
   workflow_call:
     inputs:
+      caller_event_name:
+        description: Event name from the calling workflow.
+        required: false
+        default: ''
+        type: string
+      caller_pr_head_sha:
+        description: Pull request head SHA from the calling workflow.
+        required: false
+        default: ''
+        type: string
       clean_build:
         description: Build images from scratch instead of reusing the edge image.
+        required: false
+        default: false
+        type: boolean
+      force_run:
+        description: Run CI even when the path filter does not match.
         required: false
         default: false
         type: boolean
@@ -46,7 +61,7 @@ jobs:
     name: Development image
     timeout-minutes: 35
     needs: paths-filter
-    if: needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.paths-filter.outputs.pass == 'true' || inputs.force_run
     permissions:
       packages: write
     strategy:
@@ -63,7 +78,7 @@ jobs:
 
       - name: Check commit message for clean-build
         id: clean_build_msg
-        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        if: inputs.caller_event_name == 'push' || inputs.caller_event_name == 'pull_request'
         continue-on-error: true
         uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2
         with:
@@ -74,7 +89,7 @@ jobs:
         env:
           CLEAN_BUILD_DISPATCH: ${{ inputs.clean_build }}
           CLEAN_BUILD_COMMIT: ${{ steps.clean_build_msg.outcome == 'success' }}
-          CLEAN_BUILD_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
+          CLEAN_BUILD_MERGE_GROUP: ${{ inputs.caller_event_name == 'merge_group' }}
           IS_MAIN: ${{ github.ref == 'refs/heads/main' || contains(github.ref, 'tags/v') }}
         run: |
           echo "ansible_base=ubuntu:24.04" >> "$GITHUB_OUTPUT"
@@ -354,7 +369,7 @@ jobs:
           registry-token: ${{ secrets.GITHUB_TOKEN }}
           build-args: |
             ROS_DISTRO=${{ env.ROS_DISTRO }}
-            GIT_SHA=${{ github.event.pull_request && github.event.pull_request.head.sha || github.sha }}
+            GIT_SHA=${{ inputs.caller_pr_head_sha || github.sha }}
             BUILD_IMAGE=${{ needs.merge-dev-image.outputs.image }}
 
   merge-deploy-image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,16 @@
 name: CI/CD
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
-  pull_request:
-  merge_group:
-    types:
-      - checks_requested
-  workflow_dispatch:
+  workflow_call:
     inputs:
       clean_build:
-        description: 'Build images from scratch (no base from main)'
+        description: Build images from scratch instead of reusing the edge image.
         required: false
         default: false
         type: boolean
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 defaults:
   run:
@@ -32,31 +22,9 @@ env:
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
 
 jobs:
-  paths-filter:
-    name: Need to run?
-    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-    permissions: {}
-    timeout-minutes: 10
-    outputs:
-      pass: ${{ steps.filter.outputs.pass }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
-
-      - name: Filters
-        uses: ./.github/actions/paths-filter
-        id: filter
-        with:
-          extra-filter: |
-            - .github/workflows/ci.yml
-
   build-dev-image:
     name: Development image
     timeout-minutes: 35
-    needs: paths-filter
-    if: needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch'
     permissions:
       packages: write
     strategy:
@@ -82,7 +50,7 @@ jobs:
       - name: Set base image refs
         id: base_refs
         env:
-          CLEAN_BUILD_DISPATCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.clean_build }}
+          CLEAN_BUILD_DISPATCH: ${{ inputs.clean_build }}
           CLEAN_BUILD_COMMIT: ${{ steps.clean_build_msg.outcome == 'success' }}
           CLEAN_BUILD_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
           IS_MAIN: ${{ github.ref == 'refs/heads/main' || contains(github.ref, 'tags/v') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         continue-on-error: true
         uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2
         with:
+          error: 'Commit message does not request a clean build.'
           pattern: '\[ci:clean_build\]'
 
       - name: Set base image refs

--- a/.github/workflows/codeql-scheduled.yml
+++ b/.github/workflows/codeql-scheduled.yml
@@ -1,0 +1,17 @@
+name: CodeQL scheduled
+
+on:
+  schedule:
+    # Schedule for codeql is needed in case new vulnerabilities are found in dependencies
+    # or new rules are added to CodeQL both of which happens outside of this repository.
+    - cron: '32 17 * * 5' # “At 17:32 on Friday.” https://crontab.guru/#32_17_*_*_5
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  codeql:
+    name: CodeQL Advanced
+    uses: ./.github/workflows/codeql.yml
+    secrets: inherit

--- a/.github/workflows/codeql-scheduled.yml
+++ b/.github/workflows/codeql-scheduled.yml
@@ -14,4 +14,6 @@ jobs:
   codeql:
     name: CodeQL Advanced
     uses: ./.github/workflows/codeql.yml
+    with:
+      force_run: true
     secrets: inherit

--- a/.github/workflows/codeql-scheduled.yml
+++ b/.github/workflows/codeql-scheduled.yml
@@ -10,10 +10,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   codeql:
     name: CodeQL Advanced
+    permissions:
+      packages: read
+      security-events: write
     uses: ./.github/workflows/codeql.yml
     with:
       force_run: true
-    secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       pass: ${{ steps.filter.outputs.pass }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -77,7 +77,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -89,7 +89,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -121,7 +121,7 @@ jobs:
           colcon build --cmake-args -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{matrix.language}}'
           output: sarif-results
@@ -134,14 +134,14 @@ jobs:
           echo "file=$PWD/$file" >> "$GITHUB_OUTPUT"
 
       - name: Upload loc as a Build Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.language}}-raw.sarif
           path: ${{ steps.sarif.outputs.file }}
           retention-days: 7
 
       - name: filter-sarif
-        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1
+        uses: advanced-security/filter-sarif@v1
         with:
           input: ${{ steps.sarif.outputs.file }}
           output: ${{ steps.sarif.outputs.file }}
@@ -155,7 +155,7 @@ jobs:
             -**/packages/vendor/**
 
       - name: Upload SARIF
-        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@v4
         id: upload-sarif
         with:
           sarif_file: ${{ steps.sarif.outputs.file }}
@@ -165,7 +165,7 @@ jobs:
       - name: Dismiss alerts that were suppressed with inline comments
         # run auto dismissal only on main branch, aka reviewed code only, since dismissals are global
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: advanced-security/dismiss-alerts@efd44793f4ee18db9e6201c219fb96de57b11ed1 # v1
+        uses: advanced-security/dismiss-alerts@v1
         with:
           sarif-id: ${{ steps.upload-sarif.outputs.sarif-id }}
           sarif-file: ${{ steps.sarif.outputs.file }}
@@ -173,7 +173,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload loc as a Build Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.language}}-filtered.sarif
           path: ${{ steps.sarif.outputs.file }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,12 @@ name: "CodeQL Advanced"
 
 on:
   workflow_call:
+    inputs:
+      force_run:
+        description: Run CodeQL even when the path filter does not match.
+        required: false
+        default: false
+        type: boolean
 
 env:
   ROS_DISTRO: jazzy # duplicated in job.container.image
@@ -30,7 +36,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     needs: paths-filter
-    if: needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.paths-filter.outputs.pass == 'true' || inputs.force_run
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,28 @@ env:
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
 
 jobs:
+  paths-filter:
+    name: Need to run?
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    permissions: {}
+    timeout-minutes: 10
+    outputs:
+      pass: ${{ steps.filter.outputs.pass }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Filters
+        uses: ./.github/actions/paths-filter
+        id: filter
+        with:
+          extra-filter: |
+            - .github/workflows/codeql.yml
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: paths-filter
+    if: needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch'
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,7 +89,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -121,7 +121,7 @@ jobs:
           colcon build --cmake-args -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: '/language:${{matrix.language}}'
           output: sarif-results
@@ -155,7 +155,7 @@ jobs:
             -**/packages/vendor/**
 
       - name: Upload SARIF
-        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         id: upload-sarif
         with:
           sarif_file: ${{ steps.sarif.outputs.file }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,24 +1,7 @@
 name: "CodeQL Advanced"
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
-  pull_request:
-  schedule:
-    # Schedule for codeql is needed in case new vulnerabilities are found in dependencies
-    # or new rules are added to CodeQL both of which happens outside of this repository.
-    - cron: '32 17 * * 5' # “At 17:32 on Friday.” https://crontab.guru/#32_17_*_*_5
-  merge_group:
-    types:
-      - checks_requested
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  workflow_call:
 
 env:
   ROS_DISTRO: jazzy # duplicated in job.container.image
@@ -26,28 +9,8 @@ env:
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
 
 jobs:
-  paths-filter:
-    name: Need to run?
-    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-    permissions: {}
-    timeout-minutes: 10
-    outputs:
-      pass: ${{ steps.filter.outputs.pass }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Filters
-        uses: ./.github/actions/paths-filter
-        id: filter
-        with:
-          extra-filter: |
-            - .github/workflows/codeql.yml
-
   analyze:
     name: Analyze (${{ matrix.language }})
-    needs: paths-filter
-    if: needs.paths-filter.outputs.pass == 'true'
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: "CodeQL Advanced"
+name: 'CodeQL Advanced'
 
 on:
   workflow_call:
@@ -11,7 +11,7 @@ on:
 
 env:
   ROS_DISTRO: jazzy # duplicated in job.container.image
-  CMAKE_EXPORT_COMPILE_COMMANDS: "1"
+  CMAKE_EXPORT_COMPILE_COMMANDS: '1'
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
 
 jobs:
@@ -24,7 +24,9 @@ jobs:
       pass: ${{ steps.filter.outputs.pass }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Filters
         uses: ./.github/actions/paths-filter
@@ -56,15 +58,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: c-cpp
-          build-mode: manual
-        - language: python
-          build-mode: none
-        - language: actions
-          build-mode: none
-          supports-dismissal: false
-        - language: javascript-typescript
-          build-mode: none
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+            supports-dismissal: false
+          - language: javascript-typescript
+            build-mode: none
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -74,106 +76,108 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-        config-file: ./.github/codeql/codeql-config.yml
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Build C++ code
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        set -x
-        set -e
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Build C++ code
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          set -x
+          set -e
 
-        source "/opt/ros/${{ env.ROS_DISTRO }}/setup.bash"
-        sudo apt-get update
-        rosdep update
-        ./scripts/ros-dep.sh
-        colcon build --cmake-args -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          source "/opt/ros/${{ env.ROS_DISTRO }}/setup.bash"
+          sudo apt-get update
+          rosdep update
+          ./scripts/ros-dep.sh
+          colcon build --cmake-args -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
-        output: sarif-results
-        upload: failure-only
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          category: '/language:${{matrix.language}}'
+          output: sarif-results
+          upload: failure-only
 
-    - name: Find sarif file
-      id: sarif
-      run: |
-        file=$(find sarif-results -name "*.sarif")
-        echo "file=$PWD/$file" >> "$GITHUB_OUTPUT"
+      - name: Find sarif file
+        id: sarif
+        run: |
+          file=$(find sarif-results -name "*.sarif")
+          echo "file=$PWD/$file" >> "$GITHUB_OUTPUT"
 
-    - name: Upload loc as a Build Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{matrix.language}}-raw.sarif
-        path: ${{ steps.sarif.outputs.file }}
-        retention-days: 7
+      - name: Upload loc as a Build Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{matrix.language}}-raw.sarif
+          path: ${{ steps.sarif.outputs.file }}
+          retention-days: 7
 
-    - name: filter-sarif
-      uses: advanced-security/filter-sarif@v1
-      with:
-        input: ${{ steps.sarif.outputs.file }}
-        output: ${{ steps.sarif.outputs.file }}
-        patterns: |
-          -**/build/**
-          -**/install/**
-          -**/logs/**
-          -**/examples/**
-          -**/test/**
-          -**/node_modules/**
-          -**/packages/vendor/**
+      - name: filter-sarif
+        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1
+        with:
+          input: ${{ steps.sarif.outputs.file }}
+          output: ${{ steps.sarif.outputs.file }}
+          patterns: |
+            -**/build/**
+            -**/install/**
+            -**/logs/**
+            -**/examples/**
+            -**/test/**
+            -**/node_modules/**
+            -**/packages/vendor/**
 
-    - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v4
-      id: upload-sarif
-      with:
-        sarif_file: ${{ steps.sarif.outputs.file }}
+      - name: Upload SARIF
+        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        id: upload-sarif
+        with:
+          sarif_file: ${{ steps.sarif.outputs.file }}
 
-      # Unlock inline mechanism to suppress CodeQL warnings.
-      # https://github.com/github/codeql/issues/11427#issuecomment-1721059096
-    - name: Dismiss alerts that were suppressed with inline comments
-      # run auto dismissal only on main branch, aka reviewed code only, since dismissals are global
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: advanced-security/dismiss-alerts@v1
-      with:
-        sarif-id: ${{ steps.upload-sarif.outputs.sarif-id }}
-        sarif-file: ${{ steps.sarif.outputs.file }}
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        # Unlock inline mechanism to suppress CodeQL warnings.
+        # https://github.com/github/codeql/issues/11427#issuecomment-1721059096
+      - name: Dismiss alerts that were suppressed with inline comments
+        # run auto dismissal only on main branch, aka reviewed code only, since dismissals are global
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: advanced-security/dismiss-alerts@efd44793f4ee18db9e6201c219fb96de57b11ed1 # v1
+        with:
+          sarif-id: ${{ steps.upload-sarif.outputs.sarif-id }}
+          sarif-file: ${{ steps.sarif.outputs.file }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
-    - name: Upload loc as a Build Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{matrix.language}}-filtered.sarif
-        path: ${{ steps.sarif.outputs.file }}
-        retention-days: 7
+      - name: Upload loc as a Build Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{matrix.language}}-filtered.sarif
+          path: ${{ steps.sarif.outputs.file }}
+          retention-days: 7
 
   merge-all:
     name: Code Analysis finished

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       pass: ${{ steps.filter.outputs.pass }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -77,7 +77,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -89,7 +89,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -121,7 +121,7 @@ jobs:
           colcon build --cmake-args -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: '/language:${{matrix.language}}'
           output: sarif-results
@@ -134,14 +134,14 @@ jobs:
           echo "file=$PWD/$file" >> "$GITHUB_OUTPUT"
 
       - name: Upload loc as a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{matrix.language}}-raw.sarif
           path: ${{ steps.sarif.outputs.file }}
           retention-days: 7
 
       - name: filter-sarif
-        uses: advanced-security/filter-sarif@v1
+        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1
         with:
           input: ${{ steps.sarif.outputs.file }}
           output: ${{ steps.sarif.outputs.file }}
@@ -155,7 +155,7 @@ jobs:
             -**/packages/vendor/**
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         id: upload-sarif
         with:
           sarif_file: ${{ steps.sarif.outputs.file }}
@@ -165,7 +165,7 @@ jobs:
       - name: Dismiss alerts that were suppressed with inline comments
         # run auto dismissal only on main branch, aka reviewed code only, since dismissals are global
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: advanced-security/dismiss-alerts@v1
+        uses: advanced-security/dismiss-alerts@efd44793f4ee18db9e6201c219fb96de57b11ed1 # v1
         with:
           sarif-id: ${{ steps.upload-sarif.outputs.sarif-id }}
           sarif-file: ${{ steps.sarif.outputs.file }}
@@ -173,7 +173,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload loc as a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{matrix.language}}-filtered.sarif
           path: ${{ steps.sarif.outputs.file }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: Build docs
 on:
   workflow_call:
+    inputs:
+      force_run:
+        description: Run docs even when the path filter does not match.
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   paths-filter:
@@ -27,7 +33,7 @@ jobs:
   docs:
     name: docs
     needs: [paths-filter]
-    if: needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.paths-filter.outputs.pass == 'true' || inputs.force_run
     timeout-minutes: 10
     permissions: {}
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,31 @@ on:
   workflow_call:
 
 jobs:
+  paths-filter:
+    name: Need to run?
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    permissions: {}
+    timeout-minutes: 10
+    outputs:
+      pass: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # all history for all branches and tags.
+
+      - name: Filter
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            docs:
+              - docs/**
+              - .github/workflows/docs.yml
+
   docs:
     name: docs
+    needs: [paths-filter]
+    if: needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 10
     permissions: {}
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,9 +17,10 @@ jobs:
     outputs:
       pass: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # all history for all branches and tags.
+          persist-credentials: false
 
       - name: Filter
         id: filter
@@ -38,9 +39,10 @@ jobs:
     permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # all history for all branches and tags.
+          persist-credentials: false
 
       - name: Install ffmpeg
         run: |
@@ -63,7 +65,7 @@ jobs:
 
       - name: Upload docs build error logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-build-logs
           path: docs/_build/html/reports/notebooks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,6 @@
 name: Build docs
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
-  pull_request:
-  merge_group:
-    types:
-      - checks_requested
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   docs:
@@ -30,28 +18,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ffmpeg --no-install-recommends
 
-      - name: Filter
-        id: filter
-        uses: dorny/paths-filter@v3.0.2
-        with:
-          filters: |
-            docs:
-              - docs/**
-              - .github/workflows/docs.yml
-
       - name: Setup Python venv
-        if: ${{ steps.filter.outputs.docs == 'true' }}
         uses: ./.github/actions/setup-python-venv
 
         # Multiple builds are not supported, so run them one after another. See https://github.com/sphinx-doc/sphinx/issues/10096
       - name: sphinx - check redirects diff
-        if: ${{ steps.filter.outputs.docs == 'true' }}
         shell: bash
         run: |
           .venv/bin/sphinx-build -nW --keep-going -b rediraffecheckdiff docs/source/ docs/_build/html
 
       - name: sphinx - build html
-        if: ${{ steps.filter.outputs.docs == 'true' }}
         shell: bash
         run: |
           .venv/bin/sphinx-build -nW --keep-going -b html docs/source/ docs/_build/html

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -77,6 +77,8 @@ jobs:
     needs: [reformat]
     if: >-
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    permissions:
+      security-events: write
     uses: ./.github/workflows/codeql.yml
     with:
       force_run: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -34,6 +34,12 @@ jobs:
         contains(github.actor, 'claude'))
     uses: ./.github/workflows/reformat.yml
     with:
+      caller_event_name: ${{ github.event_name }}
+      caller_pr_head_ref: ${{ github.event.pull_request.head.ref || '' }}
+      caller_pr_head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name || '' }}
+      caller_pr_head_sha: ${{ github.event.pull_request.head.sha || '' }}
+      caller_pr_is_draft: ${{ github.event.pull_request.draft || false }}
+      force_run: ${{ github.event_name == 'workflow_dispatch' }}
       validate_all_codebase: ${{ github.event_name == 'workflow_dispatch' }}
     secrets: inherit
 
@@ -44,7 +50,10 @@ jobs:
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
     uses: ./.github/workflows/ci.yml
     with:
+      caller_event_name: ${{ github.event_name }}
+      caller_pr_head_sha: ${{ github.event.pull_request.head.sha || '' }}
       clean_build: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_build || false }}
+      force_run: ${{ github.event_name == 'workflow_dispatch' }}
     secrets: inherit
 
   docs:
@@ -53,6 +62,8 @@ jobs:
     if: >-
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
     uses: ./.github/workflows/docs.yml
+    with:
+      force_run: ${{ github.event_name == 'workflow_dispatch' }}
     secrets: inherit
 
   codeql:
@@ -61,4 +72,6 @@ jobs:
     if: >-
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
     uses: ./.github/workflows/codeql.yml
+    with:
+      force_run: ${{ github.event_name == 'workflow_dispatch' }}
     secrets: inherit

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -23,91 +23,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  paths-filter:
-    name: Need to run?
-    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-    permissions: {}
-    timeout-minutes: 10
-    outputs:
-      reformat: ${{ steps.override.outputs.reformat }}
-      ci: ${{ steps.filter.outputs.ci }}
-      docs: ${{ steps.filter.outputs.docs }}
-      codeql: ${{ steps.filter.outputs.codeql }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
-
-      - name: Filter workflow scopes
-        id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          filters: |
-            reformat:
-              - .github/workflows/**
-              - docs/source/notebooks/**
-              - ansible/**
-              - packages/**/*.cpp
-              - packages/**/*.h
-              - packages/**/*.py
-              - py_packages/**/*.py
-              - scripts/cpp-reformat.sh
-              - scripts/python-reformat.sh
-              - .clang-format
-              - '**/*.md'
-              - '**/*.markdown'
-              - '**/*.yml'
-              - '**/*.yaml'
-              - '**/*.json'
-              - '**/*.sh'
-              - '**/*.bash'
-              - '**/*.zsh'
-              - '**/Dockerfile'
-              - '**/Dockerfile.*'
-            ci:
-              - .clang-format
-              - .devcontainer/**
-              - .github/actions/**
-              - .github/workflows/**
-              - codecov.yml
-              - docker/**
-              - packages/**
-              - scripts/**
-            docs:
-              - docs/**
-              - .github/workflows/**
-            codeql:
-              - .clang-format
-              - .devcontainer/**
-              - .github/actions/**
-              - .github/codeql/**
-              - .github/workflows/**
-              - codecov.yml
-              - docker/**
-              - packages/**
-              - scripts/**
-
-      - name: Override reformat for draft AI PRs
-        id: override
-        run: |
-          reformat="${STEPS_FILTER_OUTPUTS_REFORMAT}"
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.draft }}" == "true" ]]; then
-            case "${GITHUB_ACTOR}" in
-              *copilot*|*cursor*|*codex*|*claude*)
-                reformat='false'
-                ;;
-            esac
-          fi
-
-          echo "reformat=$reformat" >> "$GITHUB_OUTPUT"
-        env:
-          STEPS_FILTER_OUTPUTS_REFORMAT: ${{ steps.filter.outputs.reformat }}
-
   reformat:
     name: Reformat code
-    needs: paths-filter
-    if: ${{ needs.paths-filter.outputs.reformat == 'true' || github.event_name == 'workflow_dispatch' }}
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft != true ||
+      !(contains(github.actor, 'copilot') ||
+        contains(github.actor, 'cursor') ||
+        contains(github.actor, 'codex') ||
+        contains(github.actor, 'claude'))
     uses: ./.github/workflows/reformat.yml
     with:
       validate_all_codebase: ${{ github.event_name == 'workflow_dispatch' }}
@@ -115,9 +39,8 @@ jobs:
 
   ci:
     name: CI/CD
-    needs: [paths-filter, reformat]
+    needs: [reformat]
     if: >-
-      (needs.paths-filter.outputs.ci == 'true' || github.event_name == 'workflow_dispatch') &&
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
     uses: ./.github/workflows/ci.yml
     with:
@@ -126,18 +49,16 @@ jobs:
 
   docs:
     name: Build docs
-    needs: [paths-filter, reformat]
+    needs: [reformat]
     if: >-
-      (needs.paths-filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch') &&
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
     uses: ./.github/workflows/docs.yml
     secrets: inherit
 
   codeql:
     name: CodeQL Advanced
-    needs: [paths-filter, reformat]
+    needs: [reformat]
     if: >-
-      (needs.paths-filter.outputs.codeql == 'true' || github.event_name == 'workflow_dispatch') &&
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
     uses: ./.github/workflows/codeql.yml
     secrets: inherit

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -78,6 +78,7 @@ jobs:
     if: >-
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
     permissions:
+      packages: read
       security-events: write
     uses: ./.github/workflows/codeql.yml
     with:

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -32,6 +32,10 @@ jobs:
         contains(github.actor, 'cursor') ||
         contains(github.actor, 'codex') ||
         contains(github.actor, 'claude'))
+    permissions:
+      issues: write
+      pull-requests: write
+      statuses: write
     uses: ./.github/workflows/reformat.yml
     with:
       caller_event_name: ${{ github.event_name }}

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -52,6 +52,8 @@ jobs:
     needs: [reformat]
     if: >-
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    permissions:
+      packages: write
     uses: ./.github/workflows/ci.yml
     with:
       caller_event_name: ${{ github.event_name }}

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,0 +1,143 @@
+name: Workflow orchestration
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+  merge_group:
+    types:
+      - checks_requested
+  workflow_dispatch:
+    inputs:
+      clean_build:
+        description: 'Build images from scratch (no base from main)'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  paths-filter:
+    name: Need to run?
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    permissions: {}
+    timeout-minutes: 10
+    outputs:
+      reformat: ${{ steps.override.outputs.reformat }}
+      ci: ${{ steps.filter.outputs.ci }}
+      docs: ${{ steps.filter.outputs.docs }}
+      codeql: ${{ steps.filter.outputs.codeql }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Filter workflow scopes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            reformat:
+              - .github/workflows/**
+              - docs/source/notebooks/**
+              - ansible/**
+              - packages/**/*.cpp
+              - packages/**/*.h
+              - packages/**/*.py
+              - py_packages/**/*.py
+              - scripts/cpp-reformat.sh
+              - scripts/python-reformat.sh
+              - .clang-format
+              - '**/*.md'
+              - '**/*.markdown'
+              - '**/*.yml'
+              - '**/*.yaml'
+              - '**/*.json'
+              - '**/*.sh'
+              - '**/*.bash'
+              - '**/*.zsh'
+              - '**/Dockerfile'
+              - '**/Dockerfile.*'
+            ci:
+              - .clang-format
+              - .devcontainer/**
+              - .github/actions/**
+              - .github/workflows/**
+              - codecov.yml
+              - docker/**
+              - packages/**
+              - scripts/**
+            docs:
+              - docs/**
+              - .github/workflows/**
+            codeql:
+              - .clang-format
+              - .devcontainer/**
+              - .github/actions/**
+              - .github/codeql/**
+              - .github/workflows/**
+              - codecov.yml
+              - docker/**
+              - packages/**
+              - scripts/**
+
+      - name: Override reformat for draft AI PRs
+        id: override
+        run: |
+          reformat="${STEPS_FILTER_OUTPUTS_REFORMAT}"
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            case "${GITHUB_ACTOR}" in
+              *copilot*|*cursor*|*codex*|*claude*)
+                reformat='false'
+                ;;
+            esac
+          fi
+
+          echo "reformat=$reformat" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_FILTER_OUTPUTS_REFORMAT: ${{ steps.filter.outputs.reformat }}
+
+  reformat:
+    name: Reformat code
+    needs: paths-filter
+    if: ${{ needs.paths-filter.outputs.reformat == 'true' || github.event_name == 'workflow_dispatch' }}
+    uses: ./.github/workflows/reformat.yml
+    with:
+      validate_all_codebase: ${{ github.event_name == 'workflow_dispatch' }}
+    secrets: inherit
+
+  ci:
+    name: CI/CD
+    needs: [paths-filter, reformat]
+    if: >-
+      (needs.paths-filter.outputs.ci == 'true' || github.event_name == 'workflow_dispatch') &&
+      (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    uses: ./.github/workflows/ci.yml
+    with:
+      clean_build: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_build || false }}
+    secrets: inherit
+
+  docs:
+    name: Build docs
+    needs: [paths-filter, reformat]
+    if: >-
+      (needs.paths-filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch') &&
+      (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    uses: ./.github/workflows/docs.yml
+    secrets: inherit
+
+  codeql:
+    name: CodeQL Advanced
+    needs: [paths-filter, reformat]
+    if: >-
+      (needs.paths-filter.outputs.codeql == 'true' || github.event_name == 'workflow_dispatch') &&
+      (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    uses: ./.github/workflows/codeql.yml
+    secrets: inherit

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -22,6 +22,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   reformat:
     name: Reformat code
@@ -45,7 +47,8 @@ jobs:
       caller_pr_is_draft: ${{ github.event.pull_request.draft || false }}
       force_run: ${{ github.event_name == 'workflow_dispatch' }}
       validate_all_codebase: ${{ github.event_name == 'workflow_dispatch' }}
-    secrets: inherit
+    secrets:
+      REPO_PAT: ${{ secrets.REPO_PAT }}
 
   ci:
     name: CI/CD
@@ -60,17 +63,18 @@ jobs:
       caller_pr_head_sha: ${{ github.event.pull_request.head.sha || '' }}
       clean_build: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_build || false }}
       force_run: ${{ github.event_name == 'workflow_dispatch' }}
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   docs:
     name: Build docs
     needs: [reformat]
     if: >-
       (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    permissions: {}
     uses: ./.github/workflows/docs.yml
     with:
       force_run: ${{ github.event_name == 'workflow_dispatch' }}
-    secrets: inherit
 
   codeql:
     name: CodeQL Advanced
@@ -83,4 +87,3 @@ jobs:
     uses: ./.github/workflows/codeql.yml
     with:
       force_run: ${{ github.event_name == 'workflow_dispatch' }}
-    secrets: inherit

--- a/.github/workflows/primary-checks.yml
+++ b/.github/workflows/primary-checks.yml
@@ -1,4 +1,4 @@
-name: Workflow orchestration
+name: Primary checks
 
 on:
   push:

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -26,9 +26,65 @@ defaults:
     shell: bash -xeuo pipefail {0}
 
 jobs:
+  paths-filter:
+    name: Need to run?
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    permissions: {}
+    timeout-minutes: 10
+    outputs:
+      pass: ${{ steps.override.outputs.pass }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Filters
+        uses: ./.github/actions/paths-filter
+        id: filter
+        with:
+          extra-filter: |
+            - .github/workflows/reformat.yml
+            - docs/source/notebooks/**
+            - ansible/**
+            - packages/**/*.cpp
+            - packages/**/*.h
+            - packages/**/*.py
+            - py_packages/**/*.py
+            - scripts/cpp-reformat.sh
+            - scripts/python-reformat.sh
+            - .clang-format
+            - '**/*.md'
+            - '**/*.markdown'
+            - '**/*.yml'
+            - '**/*.yaml'
+            - '**/*.json'
+            - '**/*.sh'
+            - '**/*.bash'
+            - '**/*.zsh'
+            - '**/Dockerfile'
+            - '**/Dockerfile.*'
+
+      - name: Override pass for draft AI PRs
+        id: override
+        run: |
+          pass="${STEPS_FILTER_OUTPUTS_PASS}"
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            case "${GITHUB_ACTOR}" in
+              *copilot*|*cursor*|*codex*|*claude*)
+                pass='false'
+                ;;
+            esac
+          fi
+
+          echo "pass=$pass" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_FILTER_OUTPUTS_PASS: ${{ steps.filter.outputs.pass }}
+
   reformat:
     name: Reformat
-    if: inputs.should_run
+    needs: paths-filter
+    if: inputs.should_run && (needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: 'ubuntu-24.04' # superlinter only supports x86_64 for now
     container:
       image: ghcr.io/dr-qp/jazzy-ros-desktop:edge

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -3,6 +3,36 @@ name: Reformat code
 on:
   workflow_call:
     inputs:
+      caller_event_name:
+        description: Event name from the calling workflow.
+        required: false
+        default: ''
+        type: string
+      caller_pr_head_ref:
+        description: Pull request head ref from the calling workflow.
+        required: false
+        default: ''
+        type: string
+      caller_pr_head_repo_full_name:
+        description: Pull request head repository full name from the calling workflow.
+        required: false
+        default: ''
+        type: string
+      caller_pr_head_sha:
+        description: Pull request head SHA from the calling workflow.
+        required: false
+        default: ''
+        type: string
+      caller_pr_is_draft:
+        description: Whether the calling pull request is a draft.
+        required: false
+        default: false
+        type: boolean
+      force_run:
+        description: Run reformat even when the path filter does not match.
+        required: false
+        default: false
+        type: boolean
       should_run:
         description: Whether the formatter should execute for this invocation.
         required: false
@@ -17,6 +47,9 @@ on:
       changed:
         description: Whether formatting produced file changes in the checked out tree.
         value: ${{ jobs.reformat.outputs.changed }}
+    secrets:
+      REPO_PAT:
+        required: false
 
 env:
   COMMIT_MESSAGE: Apply linter fixes and reformatting
@@ -69,7 +102,7 @@ jobs:
         id: override
         run: |
           pass="${STEPS_FILTER_OUTPUTS_PASS}"
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.draft }}" == "true" ]]; then
+          if [[ "${{ inputs.caller_event_name }}" == "pull_request" && "${{ inputs.caller_pr_is_draft }}" == "true" ]]; then
             case "${GITHUB_ACTOR}" in
               *copilot*|*cursor*|*codex*|*claude*)
                 pass='false'
@@ -84,7 +117,7 @@ jobs:
   reformat:
     name: Reformat
     needs: paths-filter
-    if: inputs.should_run && (needs.paths-filter.outputs.pass == 'true' || github.event_name == 'workflow_dispatch')
+    if: inputs.should_run && (needs.paths-filter.outputs.pass == 'true' || inputs.force_run)
     runs-on: 'ubuntu-24.04' # superlinter only supports x86_64 for now
     container:
       image: ghcr.io/dr-qp/jazzy-ros-desktop:edge
@@ -167,7 +200,7 @@ jobs:
         id: verify
         run: |
           skip_commit=false
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "${{ inputs.caller_event_name }}" != "pull_request" ]]; then
             echo "Not a pull request. Skipping commit."
             skip_commit=true
           elif [[ "${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME}" != "${{ github.repository }}" ]]; then
@@ -180,8 +213,8 @@ jobs:
 
           echo "skip_commit=$skip_commit" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ inputs.caller_pr_head_repo_full_name }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ inputs.caller_pr_head_sha }}
 
       - name: Commit all changed files back to the repository
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
@@ -190,7 +223,7 @@ jobs:
         with:
           # Specify the branch to commit to instead of checkout, otherwise super-linter's GITHUB_SHA validation fails to find the commit.
           # For pull requests, this will be the source branch; for pushes, this will be the current branch.
-          branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
+          branch: ${{ inputs.caller_pr_head_ref || github.head_ref || github.ref }}
           commit_message: ${{ env.COMMIT_MESSAGE }}
 
       - name: Verify changes were committed if any

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -226,6 +226,7 @@ jobs:
           git diff --exit-code --cached
 
       - name: Run Super-Linter checks
+        if: steps.commit.outcome != 'success'
         uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -1,17 +1,22 @@
 name: Reformat code
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
-  pull_request:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      should_run:
+        description: Whether the formatter should execute for this invocation.
+        required: false
+        default: true
+        type: boolean
+      validate_all_codebase:
+        description: Whether super-linter should validate the full repository.
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      changed:
+        description: Whether formatting produced file changes in the checked out tree.
+        value: ${{ jobs.reformat.outputs.changed }}
 
 env:
   COMMIT_MESSAGE: Apply linter fixes and reformatting
@@ -21,68 +26,14 @@ defaults:
     shell: bash -xeuo pipefail {0}
 
 jobs:
-  paths-filter:
-    name: Need to run?
-    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-    permissions: {}
-    timeout-minutes: 10
-    outputs:
-      pass: ${{ steps.override.outputs.pass }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
-
-      - name: Filters
-        uses: ./.github/actions/paths-filter
-        id: filter
-        with:
-          extra-filter: |
-            - .github/workflows/reformat.yml
-            - docs/source/notebooks/**
-            - ansible/**
-            - packages/**/*.cpp
-            - packages/**/*.h
-            - packages/**/*.py
-            - py_packages/**/*.py
-            - scripts/cpp-reformat.sh
-            - scripts/python-reformat.sh
-            - .clang-format
-            - '**/*.md'
-            - '**/*.markdown'
-            - '**/*.yml'
-            - '**/*.yaml'
-            - '**/*.json'
-            - '**/*.sh'
-            - '**/*.bash'
-            - '**/*.zsh'
-            - '**/Dockerfile'
-            - '**/Dockerfile.*'
-
-      - name: Override pass for draft AI PRs
-        id: override
-        run: |
-          pass="${STEPS_FILTER_OUTPUTS_PASS}"
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.draft }}" == "true" ]]; then
-            case "${GITHUB_ACTOR}" in
-              *copilot*|*cursor*|*codex*|*claude*)
-                pass='false'
-                ;;
-            esac
-          fi
-
-          echo "pass=$pass" >> "$GITHUB_OUTPUT"
-        env:
-          STEPS_FILTER_OUTPUTS_PASS: ${{ steps.filter.outputs.pass }}
-
   reformat:
     name: Reformat
-    needs: paths-filter
-    if: needs.paths-filter.outputs.pass == 'true'
+    if: inputs.should_run
     runs-on: 'ubuntu-24.04' # superlinter only supports x86_64 for now
     container:
       image: ghcr.io/dr-qp/jazzy-ros-desktop:edge
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
     permissions:
       statuses: write # To update PR status
       issues: write # To post pull request summary comments
@@ -117,7 +68,7 @@ jobs:
         uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'workflow_dispatch' }}
+          VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase }}
           FILTER_REGEX_EXCLUDE: '(^|/)(build|install|log|\.venv|packages/vendor|\.git)/'
 
           # Comment on the workflow only summary instead of the pull request conversation to avoid spamming notifications for every push to a PR.
@@ -146,8 +97,17 @@ jobs:
           FIX_JSONC_PRETTIER: true
           FIX_GITHUB_ACTIONS_ZIZMOR: true
 
+      - name: Detect formatter changes
+        id: diff
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Verify if not recursive commit
-        if: always()
+        if: always() && steps.diff.outputs.changed == 'true'
         id: verify
         run: |
           skip_commit=false
@@ -169,7 +129,7 @@ jobs:
 
       - name: Commit all changed files back to the repository
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
-        if: always() && steps.verify.outputs.skip_commit != 'true'
+        if: always() && steps.diff.outputs.changed == 'true' && steps.verify.outputs.skip_commit != 'true'
         id: commit
         with:
           # Specify the branch to commit to instead of checkout, otherwise super-linter's GITHUB_SHA validation fails to find the commit.
@@ -178,7 +138,7 @@ jobs:
           commit_message: ${{ env.COMMIT_MESSAGE }}
 
       - name: Verify changes were committed if any
-        if: always()
+        if: always() && steps.diff.outputs.changed == 'true'
         run: |
           git diff --exit-code
           git diff --exit-code --cached

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -153,7 +153,8 @@ jobs:
           source scripts/setup.bash
           ./scripts/python-reformat.sh
 
-      - name: Run Super-Linter
+      - name: Run Super-Linter autofixes
+        continue-on-error: true
         uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -165,22 +166,14 @@ jobs:
           ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
           ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
 
-          # Markdown: lint via Prettier only
+          # Run only fix-capable linters before the commit step.
           VALIDATE_MARKDOWN_PRETTIER: true
-          FIX_MARKDOWN_PRETTIER: true
-
-          # Additional file types not currently covered by existing CI linters
-          # Note: Ansible YAML under docker/ros/ansible/** is excluded via .prettierignore
-          # so ansible-lint --fix remains the single formatter for those files.
           VALIDATE_YAML_PRETTIER: true
           VALIDATE_JSON_PRETTIER: true
           VALIDATE_JSONC_PRETTIER: true
-          VALIDATE_BASH: true
-          VALIDATE_DOCKERFILE_HADOLINT: true
-          VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: true
-          VALIDATE_GITLEAKS: true
 
+          FIX_MARKDOWN_PRETTIER: true
           FIX_YAML_PRETTIER: true
           FIX_JSON_PRETTIER: true
           FIX_JSONC_PRETTIER: true
@@ -231,3 +224,24 @@ jobs:
         run: |
           git diff --exit-code
           git diff --exit-code --cached
+
+      - name: Run Super-Linter checks
+        uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase }}
+          FILTER_REGEX_EXCLUDE: '(^|/)(build|install|log|\.venv|packages/vendor|\.git)/'
+
+          SAVE_SUPER_LINTER_SUMMARY: true
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
+          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
+
+          VALIDATE_MARKDOWN_PRETTIER: true
+          VALIDATE_YAML_PRETTIER: true
+          VALIDATE_JSON_PRETTIER: true
+          VALIDATE_JSONC_PRETTIER: true
+          VALIDATE_BASH: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: true
+          VALIDATE_GITLEAKS: true

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -102,7 +102,7 @@ jobs:
         id: override
         run: |
           pass="${STEPS_FILTER_OUTPUTS_PASS}"
-          if [[ "${{ inputs.caller_event_name }}" == "pull_request" && "${{ inputs.caller_pr_is_draft }}" == "true" ]]; then
+          if [[ "${INPUTS_CALLER_EVENT_NAME}" == "pull_request" && "${{ inputs.caller_pr_is_draft }}" == "true" ]]; then
             case "${GITHUB_ACTOR}" in
               *copilot*|*cursor*|*codex*|*claude*)
                 pass='false'
@@ -113,6 +113,7 @@ jobs:
           echo "pass=$pass" >> "$GITHUB_OUTPUT"
         env:
           STEPS_FILTER_OUTPUTS_PASS: ${{ steps.filter.outputs.pass }}
+          INPUTS_CALLER_EVENT_NAME: ${{ inputs.caller_event_name }}
 
   reformat:
     name: Reformat
@@ -155,7 +156,7 @@ jobs:
 
       - name: Run Super-Linter autofixes
         continue-on-error: true
-        uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8
+        uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase }}
@@ -193,7 +194,7 @@ jobs:
         id: verify
         run: |
           skip_commit=false
-          if [[ "${{ inputs.caller_event_name }}" != "pull_request" ]]; then
+          if [[ "${INPUTS_CALLER_EVENT_NAME}" != "pull_request" ]]; then
             echo "Not a pull request. Skipping commit."
             skip_commit=true
           elif [[ "${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME}" != "${{ github.repository }}" ]]; then
@@ -208,6 +209,7 @@ jobs:
         env:
           GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ inputs.caller_pr_head_repo_full_name }}
           GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ inputs.caller_pr_head_sha }}
+          INPUTS_CALLER_EVENT_NAME: ${{ inputs.caller_event_name }}
 
       - name: Commit all changed files back to the repository
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
@@ -226,7 +228,7 @@ jobs:
           git diff --exit-code --cached
 
       - name: Run Super-Linter checks
-        uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8
+        uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase }}

--- a/uv.lock
+++ b/uv.lock
@@ -899,7 +899,6 @@ version = "0.1.0"
 source = { editable = "packages/runtime/drqp_brain" }
 dependencies = [
     { name = "adafruit-circuitpython-bno055" },
-    { name = "drqp-kinematics" },
     { name = "lgpio" },
     { name = "numpy" },
     { name = "python-statemachine" },
@@ -910,7 +909,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "adafruit-circuitpython-bno055" },
-    { name = "drqp-kinematics" },
     { name = "lgpio" },
     { name = "numpy" },
     { name = "python-statemachine", specifier = ">=2.5.0" },


### PR DESCRIPTION
# Summary

Convert the CI, docs, CodeQL, and reformat workflows into reusable `workflow_call` entrypoints and route repository events through a new top-level orchestrator workflow. The orchestrator is responsible only for sequencing runs and short-circuiting downstream jobs when reformatting produces changes.

## What Changed

- Added a new top-level workflow orchestrator that keeps the repository triggers (`push`, `pull_request`, `merge_group`, and `workflow_dispatch`), preserves the existing draft-AI PR skip logic for reformatting, and gates CI, docs, and CodeQL on the reformat workflow's `changed` output.
- Converted `ci.yml`, `docs.yml`, `codeql.yml`, and `reformat.yml` to reusable workflows invoked via `workflow_call` instead of owning repository triggers directly.
- Extended the reusable workflow contracts where needed: CI now accepts `clean_build` and an optional `CODECOV_TOKEN` secret, and reformat now exposes a `changed` output after detecting whether formatting modified the checkout.
- Added `codeql-scheduled.yml` as a dedicated scheduled wrapper so the weekly CodeQL run remains repository-triggered even though `codeql.yml` is now reusable.

## How to Test

1. Run `.github/skills/open-pr/scripts/review-git-changes.sh --base-ref origin/main` to review the full branch diff against `origin/main`.
2. Run `git diff --check origin/main..HEAD -- .github/workflows/orchestrator.yml .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/codeql.yml .github/workflows/codeql-scheduled.yml .github/workflows/reformat.yml`.
3. Inspect the workflow files to confirm the reusable workflow contracts, restored per-workflow path filters, reformat `changed` output, and scheduled CodeQL wrapper align with the orchestration flow.

## Breaking Changes

- None.

## Migration

- None.

## Related

- None.
