### PR TITLE
Unify reformat skip handling via reusable workflow output

### DIFF
--- a/.github/workflows/primary-checks.yml
+++ b/.github/workflows/primary-checks.yml
@@ -27,13 +27,6 @@ permissions: {}
 jobs:
   reformat:
     name: Reformat code
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft != true ||
-      !(contains(github.actor, 'copilot') ||
-        contains(github.actor, 'cursor') ||
-        contains(github.actor, 'codex') ||
-        contains(github.actor, 'claude'))
     permissions:
       issues: write
       pull-requests: write
@@ -53,8 +46,7 @@ jobs:
   ci:
     name: CI/CD
     needs: [reformat]
-    if: >-
-      (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    if: needs.reformat.outputs.run_downstream == 'true'
     permissions:
       packages: write
     uses: ./.github/workflows/ci.yml
@@ -69,8 +61,7 @@ jobs:
   docs:
     name: Build docs
     needs: [reformat]
-    if: >-
-      (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    if: needs.reformat.outputs.run_downstream == 'true'
     permissions: {}
     uses: ./.github/workflows/docs.yml
     with:
@@ -79,8 +70,7 @@ jobs:
   codeql:
     name: CodeQL Advanced
     needs: [reformat]
-    if: >-
-      (needs.reformat.result == 'skipped' || needs.reformat.outputs.changed != 'true')
+    if: needs.reformat.outputs.run_downstream == 'true'
     permissions:
       packages: read
       security-events: write

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -47,6 +47,12 @@ on:
       changed:
         description: Whether formatting produced file changes in the checked out tree.
         value: ${{ jobs.reformat.outputs.changed }}
+      reformat_result:
+        description: Result of the internal reformat job (success, failure, cancelled, skipped).
+        value: ${{ jobs.reformat.result }}
+      run_downstream:
+        description: Whether downstream workflows should run (reformat skipped or no changes produced).
+        value: ${{ jobs.reformat.result == 'skipped' || jobs.reformat.outputs.changed != 'true' }}
     secrets:
       REPO_PAT:
         required: false

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -46,13 +46,13 @@ on:
     outputs:
       changed:
         description: Whether formatting produced file changes in the checked out tree.
-        value: ${{ jobs.reformat.outputs.changed }}
+        value: ${{ jobs.gate.outputs.changed }}
       reformat_result:
         description: Result of the internal reformat job (success, failure, cancelled, skipped).
-        value: ${{ jobs.reformat.result }}
+        value: ${{ jobs.gate.outputs.reformat_result }}
       run_downstream:
         description: Whether downstream workflows should run (reformat skipped or no changes produced).
-        value: ${{ jobs.reformat.result == 'skipped' || jobs.reformat.outputs.changed != 'true' }}
+        value: ${{ jobs.gate.outputs.run_downstream }}
     secrets:
       REPO_PAT:
         required: false
@@ -254,3 +254,40 @@ jobs:
           VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: true
           VALIDATE_GITLEAKS: true
+
+  gate:
+    name: Reformat outputs gate
+    needs: [paths-filter, reformat]
+    if: always()
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    permissions: {}
+    outputs:
+      changed: ${{ steps.compute.outputs.changed }}
+      reformat_result: ${{ steps.compute.outputs.reformat_result }}
+      run_downstream: ${{ steps.compute.outputs.run_downstream }}
+    steps:
+      - name: Compute reusable outputs
+        id: compute
+        run: |
+          reformat_result="${NEEDS_REFORMAT_RESULT}"
+          changed="${NEEDS_REFORMAT_OUTPUT_CHANGED}"
+
+          if [[ -z "$reformat_result" ]]; then
+            reformat_result='skipped'
+          fi
+
+          if [[ "$changed" != 'true' ]]; then
+            changed='false'
+          fi
+
+          run_downstream='false'
+          if [[ "$reformat_result" == 'skipped' || "$changed" != 'true' ]]; then
+            run_downstream='true'
+          fi
+
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "reformat_result=$reformat_result" >> "$GITHUB_OUTPUT"
+          echo "run_downstream=$run_downstream" >> "$GITHUB_OUTPUT"
+        env:
+          NEEDS_REFORMAT_RESULT: ${{ needs.reformat.result }}
+          NEEDS_REFORMAT_OUTPUT_CHANGED: ${{ needs.reformat.outputs.changed }}

--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -285,9 +285,11 @@ jobs:
             run_downstream='true'
           fi
 
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
-          echo "reformat_result=$reformat_result" >> "$GITHUB_OUTPUT"
-          echo "run_downstream=$run_downstream" >> "$GITHUB_OUTPUT"
+          {
+            echo "changed=$changed"
+            echo "reformat_result=$reformat_result"
+            echo "run_downstream=$run_downstream"
+          } >> "$GITHUB_OUTPUT"
         env:
           NEEDS_REFORMAT_RESULT: ${{ needs.reformat.result }}
           NEEDS_REFORMAT_OUTPUT_CHANGED: ${{ needs.reformat.outputs.changed }}


### PR DESCRIPTION
# Summary
Refactors workflow gating so `primary-checks.yml` no longer duplicates reformat skip logic. The reusable `reformat.yml` workflow now publishes a single output used by downstream jobs to decide whether CI/docs/codeql should run.

## What Changed
- Removed caller-side draft/actor guard from the `reformat` job in `primary-checks.yml` so execution decisions remain inside the reusable workflow.
- Replaced repeated downstream conditions in `primary-checks.yml` with one expression: `needs.reformat.outputs.run_downstream == 'true'` for `ci`, `docs`, and `codeql`.
- Added reusable workflow outputs in `reformat.yml`:
  - `reformat_result`: exposes internal reformat job result.
  - `run_downstream`: canonical boolean expression for downstream execution.

## Why
Centralizing skip/run decisions in `reformat.yml` avoids duplicated conditions and keeps behavior consistent across all downstream jobs. This reduces maintenance risk when skip logic changes.

## How to Test
1. Trigger `primary-checks` for a PR where reformat is skipped and verify `ci`, `docs`, and `codeql` still run.
2. Trigger `primary-checks` for a PR where reformat changes files and verify downstream jobs are blocked on that run.
3. Confirm reusable output wiring resolves correctly by checking workflow expressions:
   - `reformat.yml` outputs `run_downstream`
   - `primary-checks.yml` jobs use `needs.reformat.outputs.run_downstream == 'true'`

## Breaking Changes
- None.

## Migration
- None.

## Related
- Design doc: None