### PR TITLE
[codex] Require observable AI PR review signal

### DIFF
--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -1,4 +1,4 @@
-name: Require Copilot Review
+name: Require AI Review
 
 on:
   pull_request:
@@ -23,17 +23,18 @@ permissions:
   pull-requests: read
 
 jobs:
-  copilot-review-present:
-    name: copilot-review-present
+  ai-review-present:
+    name: ai-review-present
     runs-on: ubuntu-latest
 
     steps:
-      - name: Verify Copilot reviewed PR
+      - name: Verify AI reviewed current PR head
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
+          github-token: ${{ github.token }}
           script: |
             if (context.eventName === 'merge_group') {
-              core.info('Merge group event, skipping Copilot review check');
+              core.info('Merge group event, skipping AI review check');
               return;
             }
 
@@ -52,6 +53,35 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pull_number = pr.number;
+            const currentHeadSha = pr.head.sha;
+            const acceptedReviewerLogins = new Set([
+              'copilot-pull-request-reviewer[bot]',
+              'codex',
+              'codex[bot]',
+            ]);
+            const acceptedReviewStates = new Set([
+              'approved',
+              'changes_requested',
+              'commented',
+            ]);
+
+            const isAcceptedCurrentHeadReview = (review) => {
+              const login = review?.user?.login;
+              const state = review?.state?.toLowerCase();
+              return (
+                acceptedReviewerLogins.has(login) &&
+                acceptedReviewStates.has(state) &&
+                review.commit_id === currentHeadSha
+              );
+            };
+
+            const eventReview = context.payload.review;
+            if (isAcceptedCurrentHeadReview(eventReview)) {
+              core.info(
+                `Found accepted current-head AI review by ${eventReview.user.login} from event payload for ${eventReview.commit_id} with state ${eventReview.state}.`
+              );
+              return;
+            }
 
             const reviews = await github.paginate(
               github.rest.pulls.listReviews,
@@ -63,27 +93,22 @@ jobs:
               }
             );
 
-            const copilotLogins = new Set([
-              'copilot-pull-request-reviewer[bot]',
-            ]);
+            const reviewSummary = reviews
+              .map((review) => `${review.user?.login ?? 'unknown'}:${review.state}:${review.commit_id}`)
+              .join(', ');
+            core.info(`Observed PR reviews: ${reviewSummary || 'none'}`);
 
-            // Require an active submitted Copilot review for any commit in the PR.
-            const matchingReview = reviews.find((review) => {
-              const login = review.user?.login;
-              const state = review.state;
-              return (
-                copilotLogins.has(login) &&
-                state &&
-                state !== 'PENDING' &&
-                state !== 'DISMISSED'
-              );
-            });
+            const matchingReview = [...reviews]
+              .reverse()
+              .find(isAcceptedCurrentHeadReview);
 
             if (!matchingReview) {
-              core.setFailed('Copilot has not submitted a review for this PR.');
+              core.setFailed(
+                `Neither Copilot nor Codex has submitted an accepted review for the current PR head (${currentHeadSha}).`
+              );
               return;
             }
 
             core.info(
-              `Found Copilot review by ${matchingReview.user.login} for ${matchingReview.commit_id} with state ${matchingReview.state}.`
+              `Found accepted current-head AI review by ${matchingReview.user.login} for ${matchingReview.commit_id} with state ${matchingReview.state}.`
             );

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -20,15 +20,17 @@ on:
 
 permissions:
   contents: read
+  issues: read
   pull-requests: read
 
 jobs:
   ai-review-present:
     name: ai-review-present
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - name: Verify AI reviewed current PR head
+      - name: Verify AI reviewed PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ github.token }}
@@ -54,10 +56,11 @@ jobs:
             const repo = context.repo.repo;
             const pull_number = pr.number;
             const currentHeadSha = pr.head.sha;
-            const acceptedReviewerLogins = new Set([
+            const copilotReviewerLogins = new Set([
               'copilot-pull-request-reviewer[bot]',
-              'codex',
-              'codex[bot]',
+            ]);
+            const codexReactionLogins = new Set([
+              'chatgpt-codex-connector[bot]',
             ]);
             const acceptedReviewStates = new Set([
               'approved',
@@ -65,50 +68,89 @@ jobs:
               'commented',
             ]);
 
-            const isAcceptedCurrentHeadReview = (review) => {
+            const isAcceptedCurrentHeadCopilotReview = (review) => {
               const login = review?.user?.login;
               const state = review?.state?.toLowerCase();
               return (
-                acceptedReviewerLogins.has(login) &&
+                copilotReviewerLogins.has(login) &&
                 acceptedReviewStates.has(state) &&
                 review.commit_id === currentHeadSha
               );
             };
 
+            const isAcceptedCodexReaction = (reaction) => {
+              return (
+                codexReactionLogins.has(reaction?.user?.login) &&
+                reaction?.content === '+1'
+              );
+            };
+
             const eventReview = context.payload.review;
-            if (isAcceptedCurrentHeadReview(eventReview)) {
+            if (isAcceptedCurrentHeadCopilotReview(eventReview)) {
               core.info(
-                `Found accepted current-head AI review by ${eventReview.user.login} from event payload for ${eventReview.commit_id} with state ${eventReview.state}.`
+                `Found accepted current-head Copilot review by ${eventReview.user.login} from event payload for ${eventReview.commit_id} with state ${eventReview.state}.`
               );
               return;
             }
 
-            const reviews = await github.paginate(
-              github.rest.pulls.listReviews,
-              {
-                owner,
-                repo,
-                pull_number,
-                per_page: 100,
+            const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+            const deadline = Date.now() + 8 * 60 * 1000;
+            let attempt = 1;
+
+            while (Date.now() < deadline) {
+              const reviews = await github.paginate(
+                github.rest.pulls.listReviews,
+                {
+                  owner,
+                  repo,
+                  pull_number,
+                  per_page: 100,
+                }
+              );
+
+              const reviewSummary = reviews
+                .map((review) => `${review.user?.login ?? 'unknown'}:${review.state}:${review.commit_id}`)
+                .join(', ');
+              core.info(`Attempt ${attempt}: observed PR reviews: ${reviewSummary || 'none'}`);
+
+              const matchingReview = [...reviews]
+                .reverse()
+                .find(isAcceptedCurrentHeadCopilotReview);
+
+              if (matchingReview) {
+                core.info(
+                  `Found accepted current-head Copilot review by ${matchingReview.user.login} for ${matchingReview.commit_id} with state ${matchingReview.state}.`
+                );
+                return;
               }
-            );
 
-            const reviewSummary = reviews
-              .map((review) => `${review.user?.login ?? 'unknown'}:${review.state}:${review.commit_id}`)
-              .join(', ');
-            core.info(`Observed PR reviews: ${reviewSummary || 'none'}`);
-
-            const matchingReview = [...reviews]
-              .reverse()
-              .find(isAcceptedCurrentHeadReview);
-
-            if (!matchingReview) {
-              core.setFailed(
-                `Neither Copilot nor Codex has submitted an accepted review for the current PR head (${currentHeadSha}).`
+              const reactions = await github.paginate(
+                github.rest.reactions.listForIssue,
+                {
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  per_page: 100,
+                }
               );
-              return;
+
+              const reactionSummary = reactions
+                .map((reaction) => `${reaction.user?.login ?? 'unknown'}:${reaction.content}:${reaction.created_at}`)
+                .join(', ');
+              core.info(`Attempt ${attempt}: observed PR reactions: ${reactionSummary || 'none'}`);
+
+              const matchingReaction = reactions.find(isAcceptedCodexReaction);
+              if (matchingReaction) {
+                core.info(
+                  `Found accepted Codex review marker by ${matchingReaction.user.login}: ${matchingReaction.content} reaction created at ${matchingReaction.created_at}.`
+                );
+                return;
+              }
+
+              attempt += 1;
+              await sleep(30 * 1000);
             }
 
-            core.info(
-              `Found accepted current-head AI review by ${matchingReview.user.login} for ${matchingReview.commit_id} with state ${matchingReview.state}.`
+            core.setFailed(
+              `Neither Copilot nor Codex has marked this PR as AI-reviewed. Expected either a current-head Copilot review for ${currentHeadSha} or a +1 reaction from chatgpt-codex-connector[bot].`
             );


### PR DESCRIPTION
## Summary

Update the PR review gate so it verifies an observable AI-review signal from either Copilot or Codex.

## What Changed

- Rename the workflow and check from Copilot-specific wording to AI-review wording.
- Keep strict current-head validation for Copilot by requiring a submitted Copilot review on `pr.head.sha`.
- Accept Codex's actual GitHub signal: a `+1` reaction from `chatgpt-codex-connector[bot]` on the PR.
- Poll for up to 8 minutes so the check can pass when Codex adds its reaction shortly after the workflow starts.
- Log observed PR review authors/states/commit IDs and PR reactions for troubleshooting.
- Add `issues: read` because PR reactions are exposed through GitHub's issue reactions API.

## Why

Codex does not currently submit a standard pull request review or participate in GitHub's requested-reviewer flow like Copilot. The observable Codex marker is the connector bot's PR reaction, so the workflow needs to validate that marker instead of looking for a Codex review record.

## Important Limitation

The Codex reaction is PR-level, not commit-scoped. This workflow can prove that Codex marked the PR, but it cannot prove Codex reviewed the current head commit the way Copilot's submitted review record can.

## Validation

- Fetched the committed workflow from the remote branch and inspected the resulting script content locally.
- Confirmed the branch diff is limited to `.github/workflows/require-copilot-review.yml`.
- Could not run local Git validation because this Codex worktree has a broken `.git` pointer.
- Could not run a full YAML parser locally because Ruby was killed in the sandbox and PyYAML is not installed.