### PR TITLE
Follow robot in sim camera

### DIFF
--- a/packages/simulation/drqp_gazebo/launch/sim.launch.py
+++ b/packages/simulation/drqp_gazebo/launch/sim.launch.py
@@ -22,12 +22,18 @@ from drqp_brain.instance_guard import make_launch_instance_guard
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    ExecuteProcess,
     GroupAction,
     IncludeLaunchDescription,
+    RegisterEventHandler,
     SetEnvironmentVariable,
+    TimerAction,
 )
+from launch.conditions import IfCondition
+from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import (
+    AllSubstitution,
     EnvironmentVariable,
     IfElseSubstitution,
     LaunchConfiguration,
@@ -72,6 +78,28 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
+            'world',
+            default_value='empty.sdf',
+            description='Gazebo world file or resource to load.',
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'follow_camera',
+            default_value='true',
+            choices=['true', 'false'],
+            description='Ask Gazebo GUI to follow the spawned drqp model.',
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            'follow_camera_delay',
+            default_value='5.0',
+            description='Seconds to wait after robot spawn before sending the Gazebo GUI follow command.',
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
             'gz_partition',
             default_value=[
                 EnvironmentVariable('HOSTNAME', default_value='unknown-host'),
@@ -90,9 +118,12 @@ def generate_launch_description():
     # Initialize Arguments
     sim_gui = LaunchConfiguration('sim_gui')
     load_moveit = LaunchConfiguration('load_moveit')
+    world = LaunchConfiguration('world')
+    follow_camera = LaunchConfiguration('follow_camera')
+    follow_camera_delay = LaunchConfiguration('follow_camera_delay')
     gz_partition = LaunchConfiguration('gz_partition')
     container_name = 'drqp_gazebo_container'
-    gz_args = '-r -v 3 empty.sdf'
+    gz_args = ['-r -v 3 ', world]
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
@@ -107,7 +138,7 @@ def generate_launch_description():
             'gz_args': IfElseSubstitution(
                 sim_gui,
                 gz_args,
-                gz_args + ' --headless-rendering -s',
+                [*gz_args, ' --headless-rendering -s'],
             ),
             'on_exit_shutdown': 'true',
         }.items(),
@@ -140,6 +171,37 @@ def generate_launch_description():
         ],
     )
 
+    follow_camera_command = RegisterEventHandler(
+        OnProcessExit(
+            target_action=gz_spawn_entity,
+            on_exit=[
+                TimerAction(
+                    period=follow_camera_delay,
+                    actions=[
+                        ExecuteProcess(
+                            cmd=[
+                                'gz',
+                                'service',
+                                '-s',
+                                '/gui/follow',
+                                '--reqtype',
+                                'gz.msgs.StringMsg',
+                                '--reptype',
+                                'gz.msgs.Boolean',
+                                '--timeout',
+                                '5000',
+                                '--req',
+                                'data: "drqp"',
+                            ],
+                            output='screen',
+                        ),
+                    ],
+                    condition=IfCondition(AllSubstitution(sim_gui, follow_camera)),
+                ),
+            ],
+        )
+    )
+
     drqp_system = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
@@ -168,6 +230,7 @@ def generate_launch_description():
                     gazebo,
                     gazebo_bridge,
                     gz_spawn_entity,
+                    follow_camera_command,
                 ]
             ),
         ]


### PR DESCRIPTION
## Summary

Adds runtime Gazebo GUI camera following for the spawned Dr.QP model while keeping the simulation world configurable. The launch file now sends a one-shot `/gui/follow` request after the robot spawn process exits instead of baking camera behavior into a custom world.

## What Changed

- Added a `world` launch argument so callers can choose any Gazebo world resource while preserving `empty.sdf` as the default.
- Added `follow_camera` and `follow_camera_delay` launch arguments to control the post-spawn camera follow command.
- Registered an `OnProcessExit` handler for the `ros_gz_sim create` process that calls `gz service -s /gui/follow` for the `drqp` model when GUI mode is enabled.

## Why

The previous world-file approach constrained world customization. Sending the GUI follow command after the regular simulation starts keeps the launch flexible and still gives the expected follow-camera behavior.

## How to Test

- Confirmed the launch file parses and instantiates with `ROS_LOG_DIR=./.tmp`.
- Ran `ros2 launch drqp_gazebo sim.launch.py --show-args` and verified the new `world`, `follow_camera`, and `follow_camera_delay` arguments.
- Ran `colcon build --symlink-install --event-handlers console_cohesion+ --packages-select drqp_gazebo`.
- Manually confirmed the approach works in simulation.