### PR TITLE
Extract pr-review skill and gate Claude review prompt on pull_request event

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: pr-review
+description: 'Perform a thorough automated code review of a GitHub pull request in this ROS 2 robotics workspace, posting top-level and inline comments via gh and the GitHub inline-comment MCP tool. Use when asked to review a pull request, or when a PR is opened/reopened and an automated review is required. Keywords: PR review, code review, pull request review, automated review.'
+---
+
+# PR Review
+
+Use this skill to review a pull request's diff and publish feedback as GitHub comments.
+
+## When to Use This Skill
+
+- A pull request was just opened or reopened and needs an automated review
+- Someone explicitly asks for a review of a pull request (e.g. "@claude review this PR")
+
+## Prerequisites
+
+- `gh` must be installed and authenticated
+- The `mcp__github_inline_comment__create_inline_comment` tool must be available for inline comments
+- REPO (`owner/name`) and PR NUMBER must be known — read them from the workflow context or ask the user if not provided
+
+## Review Focus
+
+Analyze the full diff and provide a thorough code review focused on:
+
+- Code quality, correctness, and best practices
+- Potential bugs or edge cases
+- Security implications
+- Performance considerations
+- ROS 2 conventions (node lifecycle, topic/service naming, parameter handling)
+- C++/Python style and idioms
+- Test coverage and quality
+
+## Steps
+
+1. Fetch the diff: `gh pr diff <PR_NUMBER>`
+2. Fetch the PR description for context: `gh pr view <PR_NUMBER>`
+3. Analyze the changes against the review focus areas above.
+4. Post overall, top-level feedback with `gh pr comment <PR_NUMBER> --body "..."`.
+5. Post line-specific feedback with `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`).
+
+## Constraints
+
+- Only post GitHub comments — do not submit review text as plain chat/assistant messages.
+- Keep feedback specific and actionable; cite file paths and line numbers.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,7 +51,9 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      # Automated review when a PR is opened/reopened: always run the pr-review skill.
       - name: Claude PR Review
+        if: ${{ github.event_name == 'pull_request' }}
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -61,25 +63,22 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            You are reviewing a pull request in a ROS 2 robotics workspace. Analyze the diff and provide a thorough code review focused on:
-            - Code quality, correctness, and best practices
-            - Potential bugs or edge cases
-            - Security implications
-            - Performance considerations
-            - ROS 2 conventions (node lifecycle, topic/service naming, parameter handling)
-            - C++/Python style and idioms
-            - Test coverage and quality
-
-            Use `gh pr diff ${{ github.event.pull_request.number }}` to see the full diff.
-            Use `gh pr view ${{ github.event.pull_request.number }}` to see the PR description.
-
-            Use `gh pr comment ${{ github.event.pull_request.number }} --body "..."` for overall top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to add inline comments on specific lines.
-
-            Only post GitHub comments — do not submit review text as messages.
+            Use the pr-review skill to review this pull request.
           claude_args: >-
             --allowedTools
-            "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            "Skill,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # Comment/mention-driven requests (issue_comment, pull_request_review_comment,
+      # pull_request_review, issues): no fixed prompt, so Claude responds to whatever
+      # was actually asked in the comment. It can invoke the pr-review skill itself
+      # if the request is a review.
+      - name: Claude Code Respond
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Trigger when specific user is assigned to an issue
+          assignee_trigger: 'claude-bot'
 
       - name: Log debug stats
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- Move the hardcoded PR-review prompt out of `claude-review.yml` into a reusable `.github/skills/pr-review/SKILL.md` skill (also auto-mirrored to `.claude/skills/`).
- Split the single review step into two `if`-gated steps: `Claude PR Review` (runs only on `pull_request`, invokes the `pr-review` skill) and `Claude Code Respond` (runs for comment/mention-driven events with no fixed prompt, so it can respond to whatever was actually asked).

## Why
The fixed review prompt was being applied on every trigger, including ad-hoc `@claude` comments — so Claude always tried to do a full PR review instead of answering the actual request in the comment.

## Testing
- Reviewed the workflow diff manually; no automated tests for GitHub Actions YAML in this repo.
- Not run live against GitHub Actions (requires a real PR/comment event).