### PR TITLE
fix(claude-review): scope concurrency group to issue number for comment events

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,7 @@ on:
       - reopened
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,7 @@ on:
       - reopened
 
 concurrency:
-  group: ${{ github.workflow }}-${{github.event_name}}-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.comment.id || github.event.review.id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,7 @@ on:
       - reopened
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.comment.id || github.event.review.id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,7 @@ on:
       - reopened
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.comment.id || github.event.review.id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,4 @@
-name: Claude PR Review
+name: Claude Responder
 
 on:
   issue_comment:
@@ -20,7 +20,7 @@ on:
       - reopened
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{github.event_name}}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 env:
@@ -34,7 +34,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
       (github.event_name == 'pull_request')
-    name: Claude Code Review
+    name: Claude Responder
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,11 +29,13 @@ env:
 jobs:
   review:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
-      (github.event_name == 'pull_request')
+      github.repository_owner == 'Dr-QP' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+        (github.event_name == 'pull_request')
+      )
     name: Claude Responder
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- `github.event.pull_request.number` is empty on `issue_comment`/`issues` events, so every comment-triggered run collapsed into the same concurrency group (`Claude PR Review-`) and canceled unrelated runs across different PRs/issues.
- Fall back to `github.event.issue.number`, which is always populated on `issue_comment`/`issues` events (PR conversations are issues under the hood).

## Why
Follow-up to #390 — observed in production: commenting `@claude` on a PR got canceled with "higher priority waiting request... exists" because the concurrency group key was empty for that event type.

## Testing
- Reviewed the workflow diff manually; will confirm behavior on the next `@claude` comment after merge.