### PR TITLE
docs: TODO remediation specs with agent-turn effort estimates

### DIFF
--- a/.github/specs/todo-remediation/README.md
+++ b/.github/specs/todo-remediation/README.md
@@ -1,0 +1,31 @@
+# TODO Remediation Specs
+
+Audit date: 2026-06-17. 38 raw TODO/FIXME/XXX annotations found across the codebase.
+
+## Disposition summary
+
+| Tier | Count | Action |
+|------|-------|--------|
+| Drop — vendored/meta | 29 | No action; owned by upstream |
+| T1 — address soon | 2 | High impact, address next sprint |
+| T2 — address when ready | 3 | Medium impact, schedule within quarter |
+| T3 — housekeeping | 4 | Low effort, opportunistic |
+
+## Effort unit
+
+Estimates use **agent turns** — one agent turn is one focused agent session (research → implement → verify) operating without human intervention. A simple file edit is 1 turn; a full TDD Red/Green/Refactor cycle across multiple files is ~5–8 turns.
+
+## Specs
+
+| ID | File | Agent turns | Spec |
+|----|------|-------------|------|
+| [T1-A](./t1-a-fix-rotation-test.md) | `drqp_brain/test/test_walk_controller.py` | 3 | Fix commented-out rotation assertion |
+| [T1-B](./t1-b-gmock-hardware-interface-tests.md) | `drqp_control/CMakeLists.txt` | 10 | Add gmock unit tests for hardware interface |
+| [T2-A](./t2-a-unix-serial-options-parsing.md) | `drqp_serial/src/UnixSerial.cpp` | 4 | Parse `transferConfig` instead of hardcoding 8N1 |
+| [T2-B](./t2-b-dynamic-joint-state-test.md) | `drqp_control/test/test_a1_16_hardware_interface.py` | 3 | Assert position via `dynamic_joint_states` topic |
+| [T2-C](./t2-c-rotation-viz-decoupling.md) | `docs/source/notebooks/plotting/gaits.py` | 5 | Remove rotation-gait branch from plotter |
+| [T3-A](./t3-a-package-description.md) | `drqp_control/package.xml` | 1 | Fill in placeholder description |
+| [T3-B](./t3-b-serial-player-optimization.md) | `drqp_serial/src/SerialPlayer.cpp` | 2 | Position-index vs erase-from-front |
+| [T3-C](./t3-c-test-cli-options.md) | `drqp_a1_16_driver/test/TestXYZrobotServo.cpp` | 3 | Add CLI argument parsing to hardware test |
+| [T3-D](./t3-d-ik-notebook-diagram.md) | `docs/source/notebooks/…` | 2 | Update IK diagram to match current leg geometry |
+| [DROP](./drop-vendored-meta.md) | various | 0 | Vendored and meta TODOs — no action |

--- a/.github/specs/todo-remediation/README.md
+++ b/.github/specs/todo-remediation/README.md
@@ -4,12 +4,12 @@ Audit date: 2026-06-17. 38 raw TODO/FIXME/XXX annotations found across the codeb
 
 ## Disposition summary
 
-| Tier | Count | Action |
-|------|-------|--------|
-| Drop — vendored/meta | 29 | No action; owned by upstream |
-| T1 — address soon | 2 | High impact, address next sprint |
-| T2 — address when ready | 3 | Medium impact, schedule within quarter |
-| T3 — housekeeping | 4 | Low effort, opportunistic |
+| Tier                    | Count | Action                                 |
+| ----------------------- | ----- | -------------------------------------- |
+| Drop — vendored/meta    | 29    | No action; owned by upstream           |
+| T1 — address soon       | 2     | High impact, address next sprint       |
+| T2 — address when ready | 3     | Medium impact, schedule within quarter |
+| T3 — housekeeping       | 4     | Low effort, opportunistic              |
 
 ## Effort unit
 
@@ -17,15 +17,15 @@ Estimates use **agent turns** — one agent turn is one focused agent session (r
 
 ## Specs
 
-| ID | File | Agent turns | Spec |
-|----|------|-------------|------|
-| [T1-A](./t1-a-fix-rotation-test.md) | `drqp_brain/test/test_walk_controller.py` | 3 | Fix commented-out rotation assertion |
-| [T1-B](./t1-b-gmock-hardware-interface-tests.md) | `drqp_control/CMakeLists.txt` | 10 | Add gmock unit tests for hardware interface |
-| [T2-A](./t2-a-unix-serial-options-parsing.md) | `drqp_serial/src/UnixSerial.cpp` | 4 | Parse `transferConfig` instead of hardcoding 8N1 |
-| [T2-B](./t2-b-dynamic-joint-state-test.md) | `drqp_control/test/test_a1_16_hardware_interface.py` | 3 | Assert position via `dynamic_joint_states` topic |
-| [T2-C](./t2-c-rotation-viz-decoupling.md) | `docs/source/notebooks/plotting/gaits.py` | 5 | Remove rotation-gait branch from plotter |
-| [T3-A](./t3-a-package-description.md) | `drqp_control/package.xml` | 1 | Fill in placeholder description |
-| [T3-B](./t3-b-serial-player-optimization.md) | `drqp_serial/src/SerialPlayer.cpp` | 2 | Position-index vs erase-from-front |
-| [T3-C](./t3-c-test-cli-options.md) | `drqp_a1_16_driver/test/TestXYZrobotServo.cpp` | 3 | Add CLI argument parsing to hardware test |
-| [T3-D](./t3-d-ik-notebook-diagram.md) | `docs/source/notebooks/…` | 2 | Update IK diagram to match current leg geometry |
-| [DROP](./drop-vendored-meta.md) | various | 0 | Vendored and meta TODOs — no action |
+| ID                                               | File                                                 | Agent turns | Spec                                             |
+| ------------------------------------------------ | ---------------------------------------------------- | ----------- | ------------------------------------------------ |
+| [T1-A](./t1-a-fix-rotation-test.md)              | `drqp_brain/test/test_walk_controller.py`            | 3           | Fix commented-out rotation assertion             |
+| [T1-B](./t1-b-gmock-hardware-interface-tests.md) | `drqp_control/CMakeLists.txt`                        | 10          | Add gmock unit tests for hardware interface      |
+| [T2-A](./t2-a-unix-serial-options-parsing.md)    | `drqp_serial/src/UnixSerial.cpp`                     | 4           | Parse `transferConfig` instead of hardcoding 8N1 |
+| [T2-B](./t2-b-dynamic-joint-state-test.md)       | `drqp_control/test/test_a1_16_hardware_interface.py` | 3           | Assert position via `dynamic_joint_states` topic |
+| [T2-C](./t2-c-rotation-viz-decoupling.md)        | `docs/source/notebooks/plotting/gaits.py`            | 5           | Remove rotation-gait branch from plotter         |
+| [T3-A](./t3-a-package-description.md)            | `drqp_control/package.xml`                           | 1           | Fill in placeholder description                  |
+| [T3-B](./t3-b-serial-player-optimization.md)     | `drqp_serial/src/SerialPlayer.cpp`                   | 2           | Position-index vs erase-from-front               |
+| [T3-C](./t3-c-test-cli-options.md)               | `drqp_a1_16_driver/test/TestXYZrobotServo.cpp`       | 3           | Add CLI argument parsing to hardware test        |
+| [T3-D](./t3-d-ik-notebook-diagram.md)            | `docs/source/notebooks/…`                            | 2           | Update IK diagram to match current leg geometry  |
+| [DROP](./drop-vendored-meta.md)                  | various                                              | 0           | Vendored and meta TODOs — no action              |

--- a/.github/specs/todo-remediation/drop-vendored-meta.md
+++ b/.github/specs/todo-remediation/drop-vendored-meta.md
@@ -10,39 +10,39 @@ They are documented here so they can be excluded from future audits.
 All annotated by upstream contributors (wjwwood, ivanpauno, hidmic, dhood, jacobperron,
 jacobperron). These are tracked in the upstream `ros2/launch` repository.
 
-| File | Line | Author | Note |
-|------|------|--------|------|
-| `substitutions/python_expression.py` | 120 | — | Backward compat note |
-| `launch_service.py` | 216 | wjwwood | SIGQUIT subprocess cleanup |
-| `logging/handlers.py` | 53 | hidmic | Module `__getattr__` migration |
-| `logging/__init__.py` | 83 | hidmic | TOCTTOU race in log dir creation |
-| `event_handlers/on_shutdown.py` | 54 | wjwwood | Callable signature validation |
-| `event_handlers/on_shutdown.py` | 69 | dhood | Known-actions description |
-| `event_handlers/on_process_io.py` | 33 | wjwwood | `__init__` flexibility |
-| `event_handlers/on_action_event_base.py` | 89 | wjwwood | Callable signature validation |
-| `event_handlers/on_action_event_base.py` | 127 | jacobperron | Entity description |
-| `frontend/expose.py` | 71 | ivanpauno | Signature check |
-| `frontend/expose.py` | 72 | ivanpauno | Annotation inference |
-| `actions/execute_local.py` | 343 | wjwwood | Windows SIGINT workaround |
-| `actions/execute_local.py` | 752 | — | `OnProcessExit` None callable |
-| `actions/log_info.py` | 21 | — | Remove after L-turtle release |
-| `actions/log.py` | 62 | — | Remove after Python 3.11 min |
-| `actions/log.py` | 95 | — | Remove after L-turtle release |
-| `launch_introspector.py` | 51 | wjwwood | Text formatting edge case |
-| `launch_introspector.py` | 80 | wjwwood | Complex branching description |
-| `substitutions/python_expression.py` | 84 | — | XXX type annotation confusion |
+| File                                     | Line | Author      | Note                             |
+| ---------------------------------------- | ---- | ----------- | -------------------------------- |
+| `substitutions/python_expression.py`     | 120  | —           | Backward compat note             |
+| `launch_service.py`                      | 216  | wjwwood     | SIGQUIT subprocess cleanup       |
+| `logging/handlers.py`                    | 53   | hidmic      | Module `__getattr__` migration   |
+| `logging/__init__.py`                    | 83   | hidmic      | TOCTTOU race in log dir creation |
+| `event_handlers/on_shutdown.py`          | 54   | wjwwood     | Callable signature validation    |
+| `event_handlers/on_shutdown.py`          | 69   | dhood       | Known-actions description        |
+| `event_handlers/on_process_io.py`        | 33   | wjwwood     | `__init__` flexibility           |
+| `event_handlers/on_action_event_base.py` | 89   | wjwwood     | Callable signature validation    |
+| `event_handlers/on_action_event_base.py` | 127  | jacobperron | Entity description               |
+| `frontend/expose.py`                     | 71   | ivanpauno   | Signature check                  |
+| `frontend/expose.py`                     | 72   | ivanpauno   | Annotation inference             |
+| `actions/execute_local.py`               | 343  | wjwwood     | Windows SIGINT workaround        |
+| `actions/execute_local.py`               | 752  | —           | `OnProcessExit` None callable    |
+| `actions/log_info.py`                    | 21   | —           | Remove after L-turtle release    |
+| `actions/log.py`                         | 62   | —           | Remove after Python 3.11 min     |
+| `actions/log.py`                         | 95   | —           | Remove after L-turtle release    |
+| `launch_introspector.py`                 | 51   | wjwwood     | Text formatting edge case        |
+| `launch_introspector.py`                 | 80   | wjwwood     | Complex branching description    |
+| `substitutions/python_expression.py`     | 84   | —           | XXX type annotation confusion    |
 
 ## Vendored rapidjson library (5 items)
 
 **Path prefix:** `packages/runtime/drqp_rapidjson/include/drqp_rapidjson/`
 
-| File | Line | Note |
-|------|------|------|
-| `schema.h` | 2204 | Return type question |
-| `schema.h` | 2278 | Cache pointer↔id mapping |
+| File       | Line | Note                                 |
+| ---------- | ---- | ------------------------------------ |
+| `schema.h` | 2204 | Return type question                 |
+| `schema.h` | 2278 | Cache pointer↔id mapping             |
 | `schema.h` | 2300 | Cache pointer↔id mapping (duplicate) |
-| `schema.h` | 2323 | Cache pointer↔id mapping (FindId) |
-| `reader.h` | 1722 | StrtodX overflow reporting |
+| `schema.h` | 2323 | Cache pointer↔id mapping (FindId)    |
+| `reader.h` | 1722 | StrtodX overflow reporting           |
 
 ## Ansible configuration template (3 items)
 

--- a/.github/specs/todo-remediation/drop-vendored-meta.md
+++ b/.github/specs/todo-remediation/drop-vendored-meta.md
@@ -1,0 +1,77 @@
+# DROP · Vendored and meta TODO annotations — no action required
+
+These 29 items appear in code or files that the project does not own and should not modify.
+They are documented here so they can be excluded from future audits.
+
+## Vendored ROS 2 launch library (11 items)
+
+**Path prefix:** `packages/vendor/launch/launch/launch/`
+
+All annotated by upstream contributors (wjwwood, ivanpauno, hidmic, dhood, jacobperron,
+jacobperron). These are tracked in the upstream `ros2/launch` repository.
+
+| File | Line | Author | Note |
+|------|------|--------|------|
+| `substitutions/python_expression.py` | 120 | — | Backward compat note |
+| `launch_service.py` | 216 | wjwwood | SIGQUIT subprocess cleanup |
+| `logging/handlers.py` | 53 | hidmic | Module `__getattr__` migration |
+| `logging/__init__.py` | 83 | hidmic | TOCTTOU race in log dir creation |
+| `event_handlers/on_shutdown.py` | 54 | wjwwood | Callable signature validation |
+| `event_handlers/on_shutdown.py` | 69 | dhood | Known-actions description |
+| `event_handlers/on_process_io.py` | 33 | wjwwood | `__init__` flexibility |
+| `event_handlers/on_action_event_base.py` | 89 | wjwwood | Callable signature validation |
+| `event_handlers/on_action_event_base.py` | 127 | jacobperron | Entity description |
+| `frontend/expose.py` | 71 | ivanpauno | Signature check |
+| `frontend/expose.py` | 72 | ivanpauno | Annotation inference |
+| `actions/execute_local.py` | 343 | wjwwood | Windows SIGINT workaround |
+| `actions/execute_local.py` | 752 | — | `OnProcessExit` None callable |
+| `actions/log_info.py` | 21 | — | Remove after L-turtle release |
+| `actions/log.py` | 62 | — | Remove after Python 3.11 min |
+| `actions/log.py` | 95 | — | Remove after L-turtle release |
+| `launch_introspector.py` | 51 | wjwwood | Text formatting edge case |
+| `launch_introspector.py` | 80 | wjwwood | Complex branching description |
+| `substitutions/python_expression.py` | 84 | — | XXX type annotation confusion |
+
+## Vendored rapidjson library (5 items)
+
+**Path prefix:** `packages/runtime/drqp_rapidjson/include/drqp_rapidjson/`
+
+| File | Line | Note |
+|------|------|------|
+| `schema.h` | 2204 | Return type question |
+| `schema.h` | 2278 | Cache pointer↔id mapping |
+| `schema.h` | 2300 | Cache pointer↔id mapping (duplicate) |
+| `schema.h` | 2323 | Cache pointer↔id mapping (FindId) |
+| `reader.h` | 1722 | StrtodX overflow reporting |
+
+## Ansible configuration template (3 items)
+
+**File:** `docker/ros/ansible/ansible.cfg`
+
+Lines 343, 693, 696 carry `# TODO: write it` placeholders that are part of the Ansible
+upstream template. The project does not maintain this file's content beyond configuration
+values it actively sets.
+
+## Documentation examples (2 items)
+
+**File:** `.github/instructions/agent-skills.instructions.md` lines 300 and 303
+
+The word "TODO" appears inside a Markdown code block used as an example of how to structure
+agent workflow checklists. It is not a project annotation.
+
+**File:** `.github/skills/implement-publisher-subscriber/SKILL.md` line 46
+
+"Include copyright, TODO for message population." is instruction text telling a code
+generator to emit a TODO comment in generated code. Not a project annotation.
+
+## Recommended suppression
+
+Add the following paths to any lint/grep-based TODO scanner to prevent these from resurfacing:
+
+```
+packages/vendor/
+packages/runtime/drqp_rapidjson/
+docker/ros/ansible/ansible.cfg
+.github/instructions/
+.github/skills/
+```

--- a/.github/specs/todo-remediation/drop-vendored-meta.md
+++ b/.github/specs/todo-remediation/drop-vendored-meta.md
@@ -3,7 +3,7 @@
 These 29 items appear in code or files that the project does not own and should not modify.
 They are documented here so they can be excluded from future audits.
 
-## Vendored ROS 2 launch library (11 items)
+## Vendored ROS 2 launch library (19 items)
 
 **Path prefix:** `packages/vendor/launch/launch/launch/`
 

--- a/.github/specs/todo-remediation/t1-a-fix-rotation-test.md
+++ b/.github/specs/todo-remediation/t1-a-fix-rotation-test.md
@@ -45,24 +45,28 @@ difference into `(-π, π]` before converting to degrees.
 ## Implementation approach
 
 ### Turn 1 — Diagnose
+
 Run the test with the assertion un-commented and capture the failure message. Compare
 `angular_distance` to `walker.rotation_speed_degrees / 4` to understand the discrepancy.
 Check whether phase `0.5` is the right sample point (foot should be mid-swing, not mid-stance).
 
 ### Turn 2 — Fix
+
 Apply the minimal correction. Likely candidates:
+
 - Wrap normalisation: `(a - b + np.pi) % (2 * np.pi) - np.pi` before `np.rad2deg`.
 - Phase choice: verify that at `phase_override=0.5` the leg is actually in the swing phase.
   If not, adjust to a phase that is clearly in swing for the rotation gait.
 
 ### Turn 3 — Verify
+
 Run the full test module. Confirm the previously-commented assertion now passes and no other
 test regresses.
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
+| File                                                       | Change                                  |
+| ---------------------------------------------------------- | --------------------------------------- |
 | `packages/runtime/drqp_brain/test/test_walk_controller.py` | Uncomment and fix the angular assertion |
 
 ## Dependencies

--- a/.github/specs/todo-remediation/t1-a-fix-rotation-test.md
+++ b/.github/specs/todo-remediation/t1-a-fix-rotation-test.md
@@ -1,0 +1,70 @@
+# T1-A · Fix commented-out rotation assertion in walk controller test
+
+**Severity:** High
+**Agent turns:** 3
+**File:** `packages/runtime/drqp_brain/test/test_walk_controller.py:340`
+
+## Background
+
+`TestRotation.test_rotation` verifies that a rotation gait moves leg tips. The test checks that
+feet displace in X and Y but the assertion that feet actually rotate angularly around the body
+centre is commented out with `# TODO fix this test`:
+
+```python
+# TODO fix this test
+# angular_distance = np.rad2deg(
+#     np.arctan2(after_step.y, after_step.x) - np.arctan2(at_rest.y, at_rest.x)
+# )
+# assert abs(angular_distance) == pytest.approx(
+#     walker.rotation_speed_degrees / 4, abs=1e-2
+# )
+```
+
+The omitted assertion is the _only_ thing that distinguishes a passing rotation gait from an
+arbitrary lateral displacement. Without it the test provides false assurance.
+
+## Goal
+
+Restore a working angular-displacement assertion so that a broken rotation gait causes a test
+failure.
+
+## Root-cause hypothesis
+
+`np.arctan2` returns values in `(-π, π]`. When a foot crosses the ±π boundary the naive
+difference wraps and produces an incorrect angular distance. The fix is to normalise the
+difference into `(-π, π]` before converting to degrees.
+
+## Acceptance criteria
+
+- [ ] The commented block is uncommented (or replaced with an equivalent).
+- [ ] The assertion passes with the current walk controller implementation.
+- [ ] If the computation required a fix, there is a brief comment explaining the wrap-around
+      normalisation.
+- [ ] No other tests in `test_walk_controller.py` regress.
+
+## Implementation approach
+
+### Turn 1 — Diagnose
+Run the test with the assertion un-commented and capture the failure message. Compare
+`angular_distance` to `walker.rotation_speed_degrees / 4` to understand the discrepancy.
+Check whether phase `0.5` is the right sample point (foot should be mid-swing, not mid-stance).
+
+### Turn 2 — Fix
+Apply the minimal correction. Likely candidates:
+- Wrap normalisation: `(a - b + np.pi) % (2 * np.pi) - np.pi` before `np.rad2deg`.
+- Phase choice: verify that at `phase_override=0.5` the leg is actually in the swing phase.
+  If not, adjust to a phase that is clearly in swing for the rotation gait.
+
+### Turn 3 — Verify
+Run the full test module. Confirm the previously-commented assertion now passes and no other
+test regresses.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `packages/runtime/drqp_brain/test/test_walk_controller.py` | Uncomment and fix the angular assertion |
+
+## Dependencies
+
+None.

--- a/.github/specs/todo-remediation/t1-b-gmock-hardware-interface-tests.md
+++ b/.github/specs/todo-remediation/t1-b-gmock-hardware-interface-tests.md
@@ -1,0 +1,88 @@
+# T1-B · Add gmock unit tests for the A1-16 hardware interface
+
+**Severity:** High
+**Agent turns:** 10
+**File:** `packages/runtime/drqp_control/CMakeLists.txt:95`
+
+## Background
+
+`drqp_control` implements a `ros2_control` hardware interface plugin. The package already
+declares `ament_cmake_gmock` as a test dependency (`package.xml:36`) but the CMakeLists has
+only a placeholder:
+
+```cmake
+#TODO: Add gmock tests for hardware interface from
+# https://github.com/ros-controls/ros2_control/blob/jazzy/hardware_interface/CMakeLists.txt
+```
+
+The existing test (`test_a1_16_hardware_interface.py`) is a full-stack integration test that
+requires a running ROS 2 system, a URDF, and the controller manager. It catches system-level
+bugs but cannot isolate hardware-interface logic from ROS infrastructure, and it cannot run in
+a plain unit-test environment (e.g. in CI without a launched system).
+
+## Goal
+
+Add a gmock-based C++ unit-test suite that exercises the hardware interface class in isolation,
+with the serial driver replaced by a mock.
+
+## Acceptance criteria
+
+- [ ] At least the following test cases exist and pass:
+  - Hardware interface initialises successfully when given a valid URDF/config.
+  - `on_init` returns `CallbackReturn::ERROR` when mandatory YAML parameters are missing.
+  - `on_activate` transitions state to `ACTIVE`.
+  - `on_deactivate` transitions state to `INACTIVE`.
+  - `write()` with a valid command produces the expected byte sequence on the mock serial port.
+  - `read()` with a valid response correctly populates joint state interfaces.
+- [ ] Tests compile with `colcon build --packages-select drqp_control --cmake-args -DBUILD_TESTING=ON`.
+- [ ] Tests pass with `colcon test --packages-select drqp_control`.
+- [ ] No new warnings at `-Wall -Wextra`.
+
+## Implementation approach
+
+### Turn 1 — Study upstream reference
+Read `ros2_control/hardware_interface/test/` (referenced in the TODO comment) to understand
+the test fixture pattern: `MockHardwareInterface`, `HardwareInterfaceTestSuite`, how lifecycle
+transitions are driven without a full ROS 2 stack.
+
+### Turn 2 — Identify seams in the hardware interface
+Read the current implementation headers and sources in `drqp_control/`. Identify:
+- Where the serial driver is injected (constructor? `on_init`?).
+- What types are used (`ISerial`, `XYZrobotServo`, etc.).
+- Whether a mock-friendly interface already exists in `drqp_serial` or `drqp_a1_16_driver`.
+
+### Turn 3 — Create or extend a mock serial interface
+If no mock/fake `ISerial` exists, create one in `drqp_serial` or as a test-only header in
+`drqp_control/test/`. The mock should capture written bytes and allow injecting read bytes.
+Use gmock `MOCK_METHOD` macros.
+
+### Turns 4–7 — Write test cases (TDD Red/Green cycle)
+Implement one test class per concern:
+- `HardwareInterfaceInitTest` — init/config parsing.
+- `HardwareInterfaceLifecycleTest` — activate/deactivate state transitions.
+- `HardwareInterfaceReadWriteTest` — command/state round-trips.
+
+### Turn 8 — Wire CMakeLists
+Add `ament_add_gmock(test_a1_16_hardware_interface_unit …)` with correct link libraries.
+Mirror the structure from the upstream reference.
+
+### Turn 9 — CI check
+Run `colcon build` and `colcon test` locally; confirm all tests pass and no unrelated tests
+regress.
+
+### Turn 10 — Refactor / cleanup
+Remove any dead code introduced during exploration. Ensure test helpers are in a reusable
+location if they could be shared with future hardware interface tests.
+
+## Files to modify / create
+
+| File | Change |
+|------|--------|
+| `packages/runtime/drqp_control/CMakeLists.txt` | Add `ament_add_gmock` target; remove placeholder TODO |
+| `packages/runtime/drqp_control/test/test_a1_16_hardware_interface_unit.cpp` | New file — gmock test suite |
+| `packages/runtime/drqp_serial/include/…/MockSerial.h` (if needed) | New file — gmock mock for `ISerial` |
+
+## Dependencies
+
+- T2-B (optional): the integration test improvement can be done independently but is related.
+- Requires understanding of the A1-16 hardware interface implementation details before starting.

--- a/.github/specs/todo-remediation/t1-b-gmock-hardware-interface-tests.md
+++ b/.github/specs/todo-remediation/t1-b-gmock-hardware-interface-tests.md
@@ -41,46 +41,55 @@ with the serial driver replaced by a mock.
 ## Implementation approach
 
 ### Turn 1 — Study upstream reference
+
 Read `ros2_control/hardware_interface/test/` (referenced in the TODO comment) to understand
 the test fixture pattern: `MockHardwareInterface`, `HardwareInterfaceTestSuite`, how lifecycle
 transitions are driven without a full ROS 2 stack.
 
 ### Turn 2 — Identify seams in the hardware interface
+
 Read the current implementation headers and sources in `drqp_control/`. Identify:
+
 - Where the serial driver is injected (constructor? `on_init`?).
 - What types are used (`ISerial`, `XYZrobotServo`, etc.).
 - Whether a mock-friendly interface already exists in `drqp_serial` or `drqp_a1_16_driver`.
 
 ### Turn 3 — Create or extend a mock serial interface
+
 If no mock/fake `ISerial` exists, create one in `drqp_serial` or as a test-only header in
 `drqp_control/test/`. The mock should capture written bytes and allow injecting read bytes.
 Use gmock `MOCK_METHOD` macros.
 
 ### Turns 4–7 — Write test cases (TDD Red/Green cycle)
+
 Implement one test class per concern:
+
 - `HardwareInterfaceInitTest` — init/config parsing.
 - `HardwareInterfaceLifecycleTest` — activate/deactivate state transitions.
 - `HardwareInterfaceReadWriteTest` — command/state round-trips.
 
 ### Turn 8 — Wire CMakeLists
+
 Add `ament_add_gmock(test_a1_16_hardware_interface_unit …)` with correct link libraries.
 Mirror the structure from the upstream reference.
 
 ### Turn 9 — CI check
+
 Run `colcon build` and `colcon test` locally; confirm all tests pass and no unrelated tests
 regress.
 
 ### Turn 10 — Refactor / cleanup
+
 Remove any dead code introduced during exploration. Ensure test helpers are in a reusable
 location if they could be shared with future hardware interface tests.
 
 ## Files to modify / create
 
-| File | Change |
-|------|--------|
-| `packages/runtime/drqp_control/CMakeLists.txt` | Add `ament_add_gmock` target; remove placeholder TODO |
-| `packages/runtime/drqp_control/test/test_a1_16_hardware_interface_unit.cpp` | New file — gmock test suite |
-| `packages/runtime/drqp_serial/include/…/MockSerial.h` (if needed) | New file — gmock mock for `ISerial` |
+| File                                                                        | Change                                                |
+| --------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `packages/runtime/drqp_control/CMakeLists.txt`                              | Add `ament_add_gmock` target; remove placeholder TODO |
+| `packages/runtime/drqp_control/test/test_a1_16_hardware_interface_unit.cpp` | New file — gmock test suite                           |
+| `packages/runtime/drqp_serial/include/…/MockSerial.h` (if needed)           | New file — gmock mock for `ISerial`                   |
 
 ## Dependencies
 

--- a/.github/specs/todo-remediation/t2-a-unix-serial-options-parsing.md
+++ b/.github/specs/todo-remediation/t2-a-unix-serial-options-parsing.md
@@ -1,0 +1,90 @@
+# T2-A · Parse `transferConfig` in `UnixSerial::begin()` instead of hardcoding 8N1
+
+**Severity:** Medium
+**Agent turns:** 4
+**File:** `packages/runtime/drqp_serial/src/UnixSerial.cpp:89`
+
+## Background
+
+`UnixSerial::begin(uint32_t baudRate, uint8_t transferConfig)` accepts a `transferConfig`
+byte but ignores it, hardcoding 8N1:
+
+```cpp
+// TODO(anton-matosov): Implement parsing of the options or migrate to explicit options from ext
+// SERIAL_8N1
+impl_->serial_.set_option(serial_port_base::character_size(8));
+impl_->serial_.set_option(serial_port_base::parity(serial_port_base::parity::none));
+impl_->serial_.set_option(serial_port_base::stop_bits(serial_port_base::stop_bits::one));
+```
+
+The silent drop of `transferConfig` creates a hidden contract: every caller must use SERIAL_8N1
+or observe the wrong serial framing with no diagnostic. The A1-16 servo does use 8N1, so the
+project currently works, but the contract is invisible.
+
+`transferConfig` follows the Arduino `HardwareSerial` bitmask convention:
+
+| Bits | Meaning |
+|------|---------|
+| 5–4 | Parity: 00=none, 10=even, 11=odd |
+| 3 | Stop bits: 0=one, 1=two |
+| 2–1 | Data bits offset: 00=5, 01=6, 10=7, 11=8 |
+
+Common values: `SERIAL_8N1 = 0x06`, `SERIAL_8E1 = 0x26`, `SERIAL_8O1 = 0x36`.
+
+## Goal
+
+Either decode the bitmask and apply the correct `boost::asio` options, **or** replace the
+`uint8_t transferConfig` API with an explicit options struct and update all call sites. Choose
+the approach that fits the rest of the codebase style.
+
+## Acceptance criteria
+
+- [ ] Passing an arbitrary `transferConfig` value produces the corresponding serial options on
+      the Boost ASIO port — or the parameter is replaced by an explicit struct and all callers
+      updated.
+- [ ] 8N1 behaviour is preserved (no regression for existing callers).
+- [ ] The TODO comment is removed.
+- [ ] A unit test (or an update to an existing test) verifies the mapping for at least 8N1,
+      8E1, and 8O1 (can use `SerialPlayer` mock or a gmock on the Boost ASIO option setters).
+
+## Implementation approach
+
+### Turn 1 — Audit call sites and the `ISerial` interface
+Find every call to `begin()` across the codebase. Determine whether the interface is defined
+in a header shared with `SerialPlayer` and other implementations. Decide: bitmask decode vs.
+struct refactor.
+
+### Turn 2 — Implement the chosen approach
+**Option A (bitmask decode):**
+```cpp
+uint8_t dataBits = 5 + ((transferConfig >> 1) & 0x03);
+bool twoStopBits = (transferConfig >> 3) & 0x01;
+uint8_t parityBits = (transferConfig >> 4) & 0x03;
+// map to boost::asio options …
+```
+**Option B (explicit struct):**
+```cpp
+struct SerialConfig { uint8_t dataBits = 8; Parity parity = Parity::none; StopBits stopBits = StopBits::one; };
+```
+Update `ISerial::begin`, `UnixSerial`, `SerialPlayer`, and all call sites.
+
+### Turn 3 — Add/update tests
+Write or extend a unit test that exercises at least three `transferConfig` values and asserts
+the correct Boost ASIO options are set.
+
+### Turn 4 — Verify build and tests
+Build `drqp_serial` and `drqp_a1_16_driver`. Run all serial-related tests.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `packages/runtime/drqp_serial/src/UnixSerial.cpp` | Implement decoding / remove TODO |
+| `packages/runtime/drqp_serial/include/…/ISerial.h` | Update signature (Option B only) |
+| `packages/runtime/drqp_serial/src/SerialPlayer.cpp` | Update signature (Option B only) |
+| Call sites in `drqp_a1_16_driver` | Update (Option B only) |
+| Relevant test file | Add coverage for non-8N1 configs |
+
+## Dependencies
+
+None. Can be done independently.

--- a/.github/specs/todo-remediation/t2-a-unix-serial-options-parsing.md
+++ b/.github/specs/todo-remediation/t2-a-unix-serial-options-parsing.md
@@ -23,11 +23,11 @@ project currently works, but the contract is invisible.
 
 `transferConfig` follows the Arduino `HardwareSerial` bitmask convention:
 
-| Bits | Meaning |
-|------|---------|
-| 5–4 | Parity: 00=none, 10=even, 11=odd |
-| 3 | Stop bits: 0=one, 1=two |
-| 2–1 | Data bits offset: 00=5, 01=6, 10=7, 11=8 |
+| Bits | Meaning                                  |
+| ---- | ---------------------------------------- |
+| 5–4  | Parity: 00=none, 10=even, 11=odd         |
+| 3    | Stop bits: 0=one, 1=two                  |
+| 2–1  | Data bits offset: 00=5, 01=6, 10=7, 11=8 |
 
 Common values: `SERIAL_8N1 = 0x06`, `SERIAL_8E1 = 0x26`, `SERIAL_8O1 = 0x36`.
 
@@ -50,40 +50,48 @@ the approach that fits the rest of the codebase style.
 ## Implementation approach
 
 ### Turn 1 — Audit call sites and the `ISerial` interface
+
 Find every call to `begin()` across the codebase. Determine whether the interface is defined
 in a header shared with `SerialPlayer` and other implementations. Decide: bitmask decode vs.
 struct refactor.
 
 ### Turn 2 — Implement the chosen approach
+
 **Option A (bitmask decode):**
+
 ```cpp
 uint8_t dataBits = 5 + ((transferConfig >> 1) & 0x03);
 bool twoStopBits = (transferConfig >> 3) & 0x01;
 uint8_t parityBits = (transferConfig >> 4) & 0x03;
 // map to boost::asio options …
 ```
+
 **Option B (explicit struct):**
+
 ```cpp
 struct SerialConfig { uint8_t dataBits = 8; Parity parity = Parity::none; StopBits stopBits = StopBits::one; };
 ```
+
 Update `ISerial::begin`, `UnixSerial`, `SerialPlayer`, and all call sites.
 
 ### Turn 3 — Add/update tests
+
 Write or extend a unit test that exercises at least three `transferConfig` values and asserts
 the correct Boost ASIO options are set.
 
 ### Turn 4 — Verify build and tests
+
 Build `drqp_serial` and `drqp_a1_16_driver`. Run all serial-related tests.
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
-| `packages/runtime/drqp_serial/src/UnixSerial.cpp` | Implement decoding / remove TODO |
-| `packages/runtime/drqp_serial/include/…/ISerial.h` | Update signature (Option B only) |
+| File                                                | Change                           |
+| --------------------------------------------------- | -------------------------------- |
+| `packages/runtime/drqp_serial/src/UnixSerial.cpp`   | Implement decoding / remove TODO |
+| `packages/runtime/drqp_serial/include/…/ISerial.h`  | Update signature (Option B only) |
 | `packages/runtime/drqp_serial/src/SerialPlayer.cpp` | Update signature (Option B only) |
-| Call sites in `drqp_a1_16_driver` | Update (Option B only) |
-| Relevant test file | Add coverage for non-8N1 configs |
+| Call sites in `drqp_a1_16_driver`                   | Update (Option B only)           |
+| Relevant test file                                  | Add coverage for non-8N1 configs |
 
 ## Dependencies
 

--- a/.github/specs/todo-remediation/t2-b-dynamic-joint-state-test.md
+++ b/.github/specs/todo-remediation/t2-b-dynamic-joint-state-test.md
@@ -1,0 +1,67 @@
+# T2-B · Assert joint position via `dynamic_joint_states` in hardware interface integration test
+
+**Severity:** Medium
+**Agent turns:** 3
+**File:** `packages/runtime/drqp_control/test/test_a1_16_hardware_interface.py:279`
+
+## Background
+
+The integration test's `_assert_position()` helper checks joint positions read from a cached
+subscriber callback:
+
+```python
+# # TODO(anton-matosov): Use dynamic_joint_state to check the actual position
+if expected_position is not None:
+    self.assertTrue(np.allclose(np.array(joint_positions), …))
+```
+
+`joint_positions` comes from a `/joint_states` subscriber that is populated by the joint state
+broadcaster. This validates that the broadcaster published, but it does not confirm that the
+hardware interface's state interfaces (the values the broadcaster reads) actually reflect what
+was commanded. The `/dynamic_joint_states` topic published by `joint_state_broadcaster` carries
+the raw interface values keyed by interface name, making it a more direct readout of hardware
+interface state.
+
+## Goal
+
+Update `_assert_position()` (or add a parallel helper) to subscribe to `/dynamic_joint_states`
+and assert that the named position interfaces reach the expected value, providing a tighter
+coupling between command and hardware-interface state.
+
+## Acceptance criteria
+
+- [ ] The test subscribes to `/dynamic_joint_states`
+      (`control_msgs/msg/DynamicJointState`).
+- [ ] Position assertion queries the `position` interface value from `DynamicJointState.interface_values`.
+- [ ] The assertion timeout and polling strategy are unchanged.
+- [ ] Existing test cases that invoke `_assert_position` continue to pass.
+- [ ] The TODO comment is removed.
+
+## Implementation approach
+
+### Turn 1 — Study message type and existing subscriber pattern
+Read `control_msgs/msg/DynamicJointState.msg`. Note that `interface_values` is a list of
+`InterfaceValue` with `interface_names` and `values` arrays. Map out how to extract a named
+joint's position interface value. Study existing subscriber patterns in the test file.
+
+### Turn 2 — Implement the subscription and helper
+Add a `DynamicJointState` subscriber alongside the existing `JointState` subscriber. Implement
+`_get_dynamic_joint_position(joint_name)` that extracts the `position` interface value for a
+given joint. Update `_assert_position()` to use this when `expected_position is not None`.
+
+### Turn 3 — Run integration tests
+Run the hardware interface integration test suite (against a simulated or mocked controller
+manager). Verify that the new subscriber receives messages and the assertions pass.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `packages/runtime/drqp_control/test/test_a1_16_hardware_interface.py` | Add `DynamicJointState` subscriber; update `_assert_position` |
+
+## Dependencies
+
+- Requires a running ROS 2 system with `joint_state_broadcaster` publishing
+  `/dynamic_joint_states` — no change to CI infrastructure required beyond what the existing
+  integration test already needs.
+- Can be done before or after T1-B; they cover different test layers.

--- a/.github/specs/todo-remediation/t2-b-dynamic-joint-state-test.md
+++ b/.github/specs/todo-remediation/t2-b-dynamic-joint-state-test.md
@@ -40,23 +40,26 @@ coupling between command and hardware-interface state.
 ## Implementation approach
 
 ### Turn 1 — Study message type and existing subscriber pattern
+
 Read `control_msgs/msg/DynamicJointState.msg`. Note that `interface_values` is a list of
 `InterfaceValue` with `interface_names` and `values` arrays. Map out how to extract a named
 joint's position interface value. Study existing subscriber patterns in the test file.
 
 ### Turn 2 — Implement the subscription and helper
+
 Add a `DynamicJointState` subscriber alongside the existing `JointState` subscriber. Implement
 `_get_dynamic_joint_position(joint_name)` that extracts the `position` interface value for a
 given joint. Update `_assert_position()` to use this when `expected_position is not None`.
 
 ### Turn 3 — Run integration tests
+
 Run the hardware interface integration test suite (against a simulated or mocked controller
 manager). Verify that the new subscriber receives messages and the assertions pass.
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
+| File                                                                  | Change                                                        |
+| --------------------------------------------------------------------- | ------------------------------------------------------------- |
 | `packages/runtime/drqp_control/test/test_a1_16_hardware_interface.py` | Add `DynamicJointState` subscriber; update `_assert_position` |
 
 ## Dependencies

--- a/.github/specs/todo-remediation/t2-c-rotation-viz-decoupling.md
+++ b/.github/specs/todo-remediation/t2-c-rotation-viz-decoupling.md
@@ -1,0 +1,87 @@
+# T2-C · Remove rotation-gait branch from gait visualiser
+
+**Severity:** Medium
+**Agent turns:** 5
+**File:** `docs/source/notebooks/plotting/gaits.py:230`
+
+## Background
+
+The gait plotter contains domain logic that belongs in the gait generator:
+
+```python
+if _rotation_gaits:
+    # TODO(anton-matosov): Why does visualization code need to know about rotations?
+    rotation_transform = AffineTransform.from_rotvec(
+        [0, 0, offset.x], degrees=True
+    )
+    leg_tip = rotation_transform.apply_point(leg_tip) + Point3D([0, 0, offset.z])
+else:
+    leg_tip = leg_tip + offset
+```
+
+`get_offsets_at_phase_for_leg()` returns semantically different data depending on gait type:
+- For translation gaits: a 3D Cartesian displacement (`offset.x` is a length).
+- For rotation gaits: `offset.x` is an **angle in degrees**, not a length.
+
+The plotter compensates by detecting the gait type and applying a rotation transform itself.
+This is a layering violation: the visualiser should receive ready-to-use world-frame points
+regardless of gait type.
+
+## Goal
+
+Make `get_offsets_at_phase_for_leg()` (or a new method) return a consistent world-frame
+`Point3D` leg-tip position for all gait types, so the plotter loop becomes unconditional.
+
+## Acceptance criteria
+
+- [ ] The `if _rotation_gaits:` branch is removed from `gaits.py`.
+- [ ] All existing gait plots (wave, tripod, ripple, rotation variants) produce visually
+      identical output to the current implementation.
+- [ ] The gait generator module (`drqp_brain`) has corresponding unit tests that cover the
+      rotation-gait output format change.
+- [ ] No change to the public API visible to callers outside the plotter.
+
+## Implementation approach
+
+### Turn 1 — Trace the data path
+Identify where `get_offsets_at_phase_for_leg` is defined and all its callers. Understand the
+full contract: what does `offset.x` mean for a rotation gait today? What is `_leg_centers`
+used for? Identify whether changing the return value breaks any other caller.
+
+### Turn 2 — Design the fix
+Two options:
+
+**Option A — Fix in the generator:** Add a `get_world_tip_at_phase_for_leg(leg, phase, leg_center, …)`
+method that internalises the rotation transform. The plotter calls this instead of
+`get_offsets_at_phase_for_leg`.
+
+**Option B — Fix the offset semantics:** Change `get_offsets_at_phase_for_leg` for rotation
+gaits to return a Cartesian displacement computed from the angular offset + leg centre, making
+the return type uniform. Update existing tests.
+
+Option A is lower risk (additive); Option B is a cleaner API but changes existing behaviour.
+
+### Turn 3 — Implement
+Implement the chosen option. Keep `get_offsets_at_phase_for_leg` signature backward compatible
+or update all callers if changing semantics.
+
+### Turn 4 — Update the plotter
+Replace the conditional branch with the unconditional new call. Confirm plots are visually
+identical by running the notebook or the plot helper and diffing or visually comparing output.
+
+### Turn 5 — Update/add tests
+Add or update unit tests in `drqp_brain` that cover the rotation-gait output. Ensure the
+generator tests cover both translation and rotation cases.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `docs/source/notebooks/plotting/gaits.py` | Remove `if _rotation_gaits:` branch |
+| `packages/runtime/drqp_brain/…/gait_generator.py` (or equivalent) | Add/fix method |
+| `packages/runtime/drqp_brain/test/…` | Add/update tests for gait generator |
+
+## Dependencies
+
+- Requires understanding of the gait generator internals before starting.
+- No dependency on other TODO items.

--- a/.github/specs/todo-remediation/t2-c-rotation-viz-decoupling.md
+++ b/.github/specs/todo-remediation/t2-c-rotation-viz-decoupling.md
@@ -20,6 +20,7 @@ else:
 ```
 
 `get_offsets_at_phase_for_leg()` returns semantically different data depending on gait type:
+
 - For translation gaits: a 3D Cartesian displacement (`offset.x` is a length).
 - For rotation gaits: `offset.x` is an **angle in degrees**, not a length.
 
@@ -44,11 +45,13 @@ Make `get_offsets_at_phase_for_leg()` (or a new method) return a consistent worl
 ## Implementation approach
 
 ### Turn 1 — Trace the data path
+
 Identify where `get_offsets_at_phase_for_leg` is defined and all its callers. Understand the
 full contract: what does `offset.x` mean for a rotation gait today? What is `_leg_centers`
 used for? Identify whether changing the return value breaks any other caller.
 
 ### Turn 2 — Design the fix
+
 Two options:
 
 **Option A — Fix in the generator:** Add a `get_world_tip_at_phase_for_leg(leg, phase, leg_center, …)`
@@ -62,24 +65,27 @@ the return type uniform. Update existing tests.
 Option A is lower risk (additive); Option B is a cleaner API but changes existing behaviour.
 
 ### Turn 3 — Implement
+
 Implement the chosen option. Keep `get_offsets_at_phase_for_leg` signature backward compatible
 or update all callers if changing semantics.
 
 ### Turn 4 — Update the plotter
+
 Replace the conditional branch with the unconditional new call. Confirm plots are visually
 identical by running the notebook or the plot helper and diffing or visually comparing output.
 
 ### Turn 5 — Update/add tests
+
 Add or update unit tests in `drqp_brain` that cover the rotation-gait output. Ensure the
 generator tests cover both translation and rotation cases.
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
-| `docs/source/notebooks/plotting/gaits.py` | Remove `if _rotation_gaits:` branch |
-| `packages/runtime/drqp_brain/…/gait_generator.py` (or equivalent) | Add/fix method |
-| `packages/runtime/drqp_brain/test/…` | Add/update tests for gait generator |
+| File                                                              | Change                              |
+| ----------------------------------------------------------------- | ----------------------------------- |
+| `docs/source/notebooks/plotting/gaits.py`                         | Remove `if _rotation_gaits:` branch |
+| `packages/runtime/drqp_brain/…/gait_generator.py` (or equivalent) | Add/fix method                      |
+| `packages/runtime/drqp_brain/test/…`                              | Add/update tests for gait generator |
 
 ## Dependencies
 

--- a/.github/specs/todo-remediation/t3-a-package-description.md
+++ b/.github/specs/todo-remediation/t3-a-package-description.md
@@ -1,0 +1,35 @@
+# T3-A · Fill in `drqp_control` package description
+
+**Severity:** Low (housekeeping)
+**Agent turns:** 1
+**File:** `packages/runtime/drqp_control/package.xml:6`
+
+## Background
+
+```xml
+<description>TODO: Package description</description>
+```
+
+The ROS 2 package manifest has a placeholder description. This shows up in `ros2 pkg list`,
+`rosdep`, and any tooling that reads the manifest.
+
+## Acceptance criteria
+
+- [ ] `<description>` contains a one-sentence summary of what the package provides.
+- [ ] The TODO placeholder is gone.
+
+## Suggested text
+
+```xml
+<description>ROS 2 control hardware interface and controllers for the Dr.QP hexapod robot.</description>
+```
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `packages/runtime/drqp_control/package.xml` | Replace placeholder with real description |
+
+## Dependencies
+
+None. Standalone one-line edit.

--- a/.github/specs/todo-remediation/t3-a-package-description.md
+++ b/.github/specs/todo-remediation/t3-a-package-description.md
@@ -26,8 +26,8 @@ The ROS 2 package manifest has a placeholder description. This shows up in `ros2
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
+| File                                        | Change                                    |
+| ------------------------------------------- | ----------------------------------------- |
 | `packages/runtime/drqp_control/package.xml` | Replace placeholder with real description |
 
 ## Dependencies

--- a/.github/specs/todo-remediation/t3-a-package-description.md
+++ b/.github/specs/todo-remediation/t3-a-package-description.md
@@ -21,7 +21,7 @@ The ROS 2 package manifest has a placeholder description. This shows up in `ros2
 ## Suggested text
 
 ```xml
-<description>ROS 2 control hardware interface and controllers for the Dr.QP hexapod robot.</description>
+<description>ROS 2 hardware interface plugin for the Dr.QP hexapod robot, bridging ros2_control to the A1-16 servo driver.</description>
 ```
 
 ## Files to modify

--- a/.github/specs/todo-remediation/t3-b-serial-player-optimization.md
+++ b/.github/specs/todo-remediation/t3-b-serial-player-optimization.md
@@ -1,0 +1,58 @@
+# T3-B · Replace erase-from-front with a position index in `SerialPlayer`
+
+**Severity:** Low (micro-optimisation)
+**Agent turns:** 2
+**File:** `packages/runtime/drqp_serial/src/SerialPlayer.cpp:70`
+
+## Background
+
+After verifying each written byte sequence, `SerialPlayer` erases the consumed bytes from the
+front of the recording buffer:
+
+```cpp
+// TODO(anton-matosov): Consider keeping a lastWritePosition instead of erasing.
+//  Or use range and update it every write
+record.request.bytes.erase(record.request.bytes.begin(), record.request.bytes.begin() + size);
+```
+
+`std::vector::erase` from the front is O(n) because it shifts all remaining elements.
+For large recordings this degrades performance quadratically. Using an index avoids the copies.
+
+## Goal
+
+Replace the erase-from-front with a `size_t writeOffset` that advances past verified bytes.
+The underlying `bytes` vector is never mutated; the offset is reset when a new recording is
+loaded.
+
+## Acceptance criteria
+
+- [ ] `SerialPlayer` no longer calls `erase` on `request.bytes`.
+- [ ] A `size_t writeOffset` (or equivalent) is maintained per recording entry.
+- [ ] All existing `SerialPlayer` tests pass.
+- [ ] The TODO comment is removed.
+
+## Implementation approach
+
+### Turn 1 — Implement
+Locate the `Recording` (or `Record`) struct that holds `request.bytes`. Add a `size_t writeOffset = 0`
+field. Replace the erase call with `writeOffset += size`. Update the comparison loop to index
+from `writeOffset`.
+
+### Turn 2 — Verify
+Run all tests in `drqp_serial` and `drqp_a1_16_driver`. Ensure replay-based tests still pass.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `packages/runtime/drqp_serial/src/SerialPlayer.cpp` | Remove erase; add offset tracking |
+| `packages/runtime/drqp_serial/include/…/SerialPlayer.h` (if struct is there) | Add `writeOffset` field |
+
+## Priority note
+
+Only address if `SerialPlayer` appears in a profiling hot-path. Otherwise this is opportunistic
+cleanup — pick it up when touching this file for another reason.
+
+## Dependencies
+
+None.

--- a/.github/specs/todo-remediation/t3-b-serial-player-optimization.md
+++ b/.github/specs/todo-remediation/t3-b-serial-player-optimization.md
@@ -34,19 +34,21 @@ loaded.
 ## Implementation approach
 
 ### Turn 1 — Implement
+
 Locate the `Recording` (or `Record`) struct that holds `request.bytes`. Add a `size_t writeOffset = 0`
 field. Replace the erase call with `writeOffset += size`. Update the comparison loop to index
 from `writeOffset`.
 
 ### Turn 2 — Verify
+
 Run all tests in `drqp_serial` and `drqp_a1_16_driver`. Ensure replay-based tests still pass.
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
-| `packages/runtime/drqp_serial/src/SerialPlayer.cpp` | Remove erase; add offset tracking |
-| `packages/runtime/drqp_serial/include/…/SerialPlayer.h` (if struct is there) | Add `writeOffset` field |
+| File                                                                         | Change                            |
+| ---------------------------------------------------------------------------- | --------------------------------- |
+| `packages/runtime/drqp_serial/src/SerialPlayer.cpp`                          | Remove erase; add offset tracking |
+| `packages/runtime/drqp_serial/include/…/SerialPlayer.h` (if struct is there) | Add `writeOffset` field           |
 
 ## Priority note
 

--- a/.github/specs/todo-remediation/t3-c-test-cli-options.md
+++ b/.github/specs/todo-remediation/t3-c-test-cli-options.md
@@ -41,7 +41,9 @@ recompiling.
 ## Implementation approach
 
 ### Turn 1 — Choose a parsing library
+
 Check what is already available in the build graph. Options:
+
 - `cxxopts` (header-only, likely available).
 - `boost::program_options` (already a transitive dependency via Boost ASIO).
 - Manual `argv` loop (no new dependency).
@@ -49,20 +51,22 @@ Check what is already available in the build graph. Options:
 Prefer re-using an existing dependency to avoid adding a new one.
 
 ### Turn 2 — Implement parsing in `main()`
+
 Call the chosen parser before `testing::InitGoogleTest`. Pass `argc`/`argv` through. Populate
 `testOptions`. Print usage if `--help` is passed.
 
 ### Turn 3 — Verify
+
 Build the test. Run without flags (verify defaults), run with `--use-real-hardware` (verify
 override), run with an unknown flag (verify error). Update any CI scripts that invoke this test
 binary directly to confirm they still work with no arguments.
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
-| `packages/runtime/drqp_a1_16_driver/test/TestXYZrobotServo.cpp` | Add CLI parsing in `main()` |
-| `packages/runtime/drqp_a1_16_driver/CMakeLists.txt` | Add new link dependency if needed |
+| File                                                            | Change                            |
+| --------------------------------------------------------------- | --------------------------------- |
+| `packages/runtime/drqp_a1_16_driver/test/TestXYZrobotServo.cpp` | Add CLI parsing in `main()`       |
+| `packages/runtime/drqp_a1_16_driver/CMakeLists.txt`             | Add new link dependency if needed |
 
 ## Dependencies
 

--- a/.github/specs/todo-remediation/t3-c-test-cli-options.md
+++ b/.github/specs/todo-remediation/t3-c-test-cli-options.md
@@ -1,0 +1,69 @@
+# T3-C · Add CLI argument parsing to `TestXYZrobotServo`
+
+**Severity:** Low (developer ergonomics)
+**Agent turns:** 3
+**File:** `packages/runtime/drqp_a1_16_driver/test/TestXYZrobotServo.cpp:49`
+
+## Background
+
+The hardware integration test for the A1-16 servo has a `TestOptions` struct with settings
+that control whether real hardware is used, which serial port to target, and whether to reset
+torque on exit:
+
+```cpp
+// TODO(anton-matosov): Add command line options for these options
+struct TestOptions {
+  std::string serialAddress = "/dev/ttySC0";
+  bool useRealHardware = false;
+  bool resetTorque = false;
+  bool skipReturnToNeutral = false;
+};
+static TestOptions testOptions;
+```
+
+Currently the only way to change these is to recompile. Engineers testing against real hardware
+must edit the source and rebuild.
+
+## Goal
+
+Parse the `TestOptions` fields from `argv` in `main()`, allowing `--serial-address`,
+`--use-real-hardware`, `--reset-torque`, and `--skip-return-to-neutral` flags without
+recompiling.
+
+## Acceptance criteria
+
+- [ ] All four options are configurable from the command line.
+- [ ] Unknown arguments are reported and cause a non-zero exit code.
+- [ ] `--help` prints a usage summary.
+- [ ] Default values are unchanged (CI, which passes no flags, continues to work).
+- [ ] The TODO comment is removed.
+
+## Implementation approach
+
+### Turn 1 — Choose a parsing library
+Check what is already available in the build graph. Options:
+- `cxxopts` (header-only, likely available).
+- `boost::program_options` (already a transitive dependency via Boost ASIO).
+- Manual `argv` loop (no new dependency).
+
+Prefer re-using an existing dependency to avoid adding a new one.
+
+### Turn 2 — Implement parsing in `main()`
+Call the chosen parser before `testing::InitGoogleTest`. Pass `argc`/`argv` through. Populate
+`testOptions`. Print usage if `--help` is passed.
+
+### Turn 3 — Verify
+Build the test. Run without flags (verify defaults), run with `--use-real-hardware` (verify
+override), run with an unknown flag (verify error). Update any CI scripts that invoke this test
+binary directly to confirm they still work with no arguments.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `packages/runtime/drqp_a1_16_driver/test/TestXYZrobotServo.cpp` | Add CLI parsing in `main()` |
+| `packages/runtime/drqp_a1_16_driver/CMakeLists.txt` | Add new link dependency if needed |
+
+## Dependencies
+
+None. Purely additive; default behaviour is unchanged.

--- a/.github/specs/todo-remediation/t3-d-ik-notebook-diagram.md
+++ b/.github/specs/todo-remediation/t3-d-ik-notebook-diagram.md
@@ -1,0 +1,55 @@
+# T3-D · Update IK notebook diagram to match Dr.QP leg geometry
+
+**Severity:** Low (documentation)
+**Agent turns:** 2
+**File:** `docs/source/notebooks/1_getting_started_with_robot_ik.md:291`
+
+## Background
+
+```
+TODO: Update diagram with the one from Dr.QP leg and names of angles and planes
+      matching this notebook
+```
+
+The getting-started IK notebook has a placeholder referencing a diagram that should show the
+Dr.QP leg geometry with labelled angles (coxa, femur, tibia) and the coordinate planes used
+in the notebook's derivations. The current diagram is either absent or shows a generic robot
+leg that does not match Dr.QP's physical dimensions and angle conventions.
+
+## Goal
+
+Replace or add a diagram that shows:
+- The Dr.QP leg link layout (coxa / femur / tibia).
+- The angle names as used in the notebook (`theta_coxa`, `theta_femur`, `theta_tibia` or
+  equivalent).
+- The relevant planes (horizontal plane for coxa rotation, sagittal plane for femur/tibia).
+- Approximate link lengths from the URDF or the notebook constants.
+
+## Acceptance criteria
+
+- [ ] The diagram is present and referenced correctly in the notebook.
+- [ ] Angle and plane labels match the variable names used in the notebook's IK equations.
+- [ ] The TODO comment is removed from the notebook source.
+
+## Implementation approach
+
+### Turn 1 — Extract geometry from URDF and notebook
+Read the URDF (or xacro) to get link lengths and joint axis definitions. Read the notebook to
+identify which angle/plane names are used in the derivations. Produce a schematic (SVG, PNG,
+or an embedded matplotlib diagram generated in a notebook cell).
+
+### Turn 2 — Embed and verify
+Insert the image reference or the generative notebook cell at line 291. Build the docs
+(`sphinx-build` or `jupyter nbconvert`) and confirm the diagram renders correctly.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `docs/source/notebooks/1_getting_started_with_robot_ik.md` | Remove TODO; add diagram reference or cell |
+| `docs/source/notebooks/images/` (or equivalent) | Add diagram file (if static image) |
+
+## Dependencies
+
+- Best done alongside any other notebook refresh to avoid touching the file twice.
+- No dependency on other TODO items.

--- a/.github/specs/todo-remediation/t3-d-ik-notebook-diagram.md
+++ b/.github/specs/todo-remediation/t3-d-ik-notebook-diagram.md
@@ -19,6 +19,7 @@ leg that does not match Dr.QP's physical dimensions and angle conventions.
 ## Goal
 
 Replace or add a diagram that shows:
+
 - The Dr.QP leg link layout (coxa / femur / tibia).
 - The angle names as used in the notebook (`theta_coxa`, `theta_femur`, `theta_tibia` or
   equivalent).
@@ -34,20 +35,22 @@ Replace or add a diagram that shows:
 ## Implementation approach
 
 ### Turn 1 — Extract geometry from URDF and notebook
+
 Read the URDF (or xacro) to get link lengths and joint axis definitions. Read the notebook to
 identify which angle/plane names are used in the derivations. Produce a schematic (SVG, PNG,
 or an embedded matplotlib diagram generated in a notebook cell).
 
 ### Turn 2 — Embed and verify
+
 Insert the image reference or the generative notebook cell at line 291. Build the docs
 (`sphinx-build` or `jupyter nbconvert`) and confirm the diagram renders correctly.
 
 ## Files to modify
 
-| File | Change |
-|------|--------|
+| File                                                       | Change                                     |
+| ---------------------------------------------------------- | ------------------------------------------ |
 | `docs/source/notebooks/1_getting_started_with_robot_ik.md` | Remove TODO; add diagram reference or cell |
-| `docs/source/notebooks/images/` (or equivalent) | Add diagram file (if static image) |
+| `docs/source/notebooks/images/` (or equivalent)            | Add diagram file (if static image)         |
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Audited 38 raw TODO/FIXME/XXX annotations across the codebase
- Classified 29 as vendored/meta — no action required (upstream `ros2/launch`, `rapidjson`, Ansible template, docs examples)
- Produced implementation specs for the remaining **9 actionable items** in `.github/specs/todo-remediation/`
- Each spec includes acceptance criteria, a turn-by-turn agent implementation approach, files to modify, and dependencies

## Effort unit

Estimates use **agent turns** — one focused agent session (research → implement → verify) without human intervention.

## Spec index

| ID | Title | Agent turns |
|----|-------|-------------|
| [T1-A](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t1-a-fix-rotation-test.md) | Fix commented-out rotation assertion in walk controller test | 3 |
| [T1-B](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t1-b-gmock-hardware-interface-tests.md) | Add gmock unit tests for the A1-16 hardware interface | 10 |
| [T2-A](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t2-a-unix-serial-options-parsing.md) | Parse `transferConfig` in `UnixSerial::begin()` instead of hardcoding 8N1 | 4 |
| [T2-B](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t2-b-dynamic-joint-state-test.md) | Assert joint position via `dynamic_joint_states` in HW interface integration test | 3 |
| [T2-C](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t2-c-rotation-viz-decoupling.md) | Remove rotation-gait branch from gait visualiser | 5 |
| [T3-A](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t3-a-package-description.md) | Fill in `drqp_control` package description | 1 |
| [T3-B](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t3-b-serial-player-optimization.md) | Replace erase-from-front with position index in `SerialPlayer` | 2 |
| [T3-C](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t3-c-test-cli-options.md) | Add CLI argument parsing to `TestXYZrobotServo` | 3 |
| [T3-D](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/t3-d-ik-notebook-diagram.md) | Update IK notebook diagram to match Dr.QP leg geometry | 2 |
| [DROP](https://github.com/Dr-QP/Dr.QP/blob/claude/codebase-todo-audit-1s9lgv/.github/specs/todo-remediation/drop-vendored-meta.md) | Vendored and meta TODOs — no action + recommended suppression paths | 0 |

**Total agent turns to clear all actionable debt: ~33 turns**

## Test plan

- [ ] Review each spec for accuracy against the referenced source locations
- [ ] Verify the DROP list correctly identifies all vendored paths
- [ ] Confirm recommended suppression paths in `drop-vendored-meta.md` cover all noise sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Kpubun1Vi94N44XjS5U5H

---
_Generated by [Claude Code](https://claude.ai/code/session_015Kpubun1Vi94N44XjS5U5H)_