### PR TITLE
test(drqp_brain): migrate unittest tests to pytest

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -28,6 +28,7 @@ Analyze the full diff and provide a thorough code review focused on:
 - Performance considerations
 - ROS 2 conventions (node lifecycle, topic/service naming, parameter handling)
 - C++/Python style and idioms
+- IGNORE import ordering, that is handled by `ruff` and `clang-format` in CI
 - Test coverage and quality
 
 ## Steps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,8 @@ NEVER use GitHub API or GitHub MCP tools to update branch refs or push branch co
 9. **Enable coverage** with `--mixin coverage-pytest` when testing
 10. **Re-run failed tests** with `--packages-select-test-failures`
 11. **When available in VS Code, use `vscode/askQuestions`** for all yes/no and multiple-choice user questions
-12. **For Python ROS tests, initialize `rclpy` once per test class**. Use `setUpClass()` with `cls.addClassCleanup(rclpy.try_shutdown)` for `unittest` classes, or the pytest equivalent class-scoped setup/teardown. Keep node, client, subscription, and action cleanup at the test level with `self.addCleanup(...)` or fixture finalizers.
-13. **Do not re-declare, bind, or explicitly forward launch arguments owned by included ROS launch files**. Externally set launch arguments are available to included launch descriptions through the launch context; only use `DeclareLaunchArgument`, `LaunchConfiguration`, or `launch_arguments={...}` entries for arguments owned by the current launch file.
-14. **Codex: run ROS build/test/lint commands with sandbox escalation** (`require_escalated`) because the managed sandbox blocks dependency downloads, ROS domain sockets, Gazebo/launch process behavior, and ROS log writes under `/root/.ros`. Still use `scripts/with-ros-env.sh`, incremental build/test selectors, and explain the escalation reason in the request.
+12. **Do not re-declare, bind, or explicitly forward launch arguments owned by included ROS launch files**. Externally set launch arguments are available to included launch descriptions through the launch context; only use `DeclareLaunchArgument`, `LaunchConfiguration`, or `launch_arguments={...}` entries for arguments owned by the current launch file.
+13. **Codex: run ROS build/test/lint commands with sandbox escalation** (`require_escalated`) because the managed sandbox blocks dependency downloads, ROS domain sockets, Gazebo/launch process behavior, and ROS log writes under `/root/.ros`. Still use `scripts/with-ros-env.sh`, incremental build/test selectors, and explain the escalation reason in the request.
 
 ### When in Doubt
 

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/defaults/main.yml
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/defaults/main.yml
@@ -1,20 +1,20 @@
 ---
 # cc-filter: security layer in front of Claude Code hooks.
 # https://github.com/wissem/cc-filter
-cc_filter_install: true
-cc_filter_version: v0.0.6
-cc_filter_install_path: /usr/local/bin/cc-filter
-cc_filter_binary_mode: "0755"
-cc_filter_download_url: >-
-  https://github.com/wissem/cc-filter/releases/download/{{ cc_filter_version }}/cc-filter-linux-{{ system_arch }}
+agentic_tools_cc_filter_install: true
+agentic_tools_cc_filter_version: v0.0.6
+agentic_tools_cc_filter_install_path: /usr/local/bin/cc-filter
+agentic_tools_cc_filter_binary_mode: "0755"
+agentic_tools_cc_filter_download_url: >-
+  https://github.com/wissem/cc-filter/releases/download/{{ agentic_tools_cc_filter_version }}/cc-filter-linux-{{ system_arch }}
 
 # SHA-256 checksums of the release binaries, keyed by architecture. Bump
-# alongside cc_filter_version so a compromised or tag-floated asset is rejected.
-cc_filter_checksums:
+# alongside agentic_tools_cc_filter_version so a compromised or tag-floated asset is rejected.
+agentic_tools_cc_filter_checksums:
   amd64: sha256:5c9dbfa6cc24027277661a0fe17fca130fdb5d2bd46ac1474bdaa843c38cf308
   arm64: sha256:2eeb50a337123b5f897070a3f0604c79fa48a54acdd1f6eb77878cf9ea14d236
-cc_filter_checksum: "{{ cc_filter_checksums[system_arch] }}"
+agentic_tools_cc_filter_checksum: "{{ agentic_tools_cc_filter_checksums[system_arch] }}"
 
 # Wire cc-filter into the user's Claude Code hooks (settings.json).
-cc_filter_configure_hooks: true
-cc_filter_claude_settings_path: "{{ user_home }}/.claude/settings.json"
+agentic_tools_cc_filter_configure_hooks: true
+agentic_tools_cc_filter_claude_settings_path: "{{ user_home }}/.claude/settings.json"

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/cc_filter.yml
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/cc_filter.yml
@@ -5,24 +5,37 @@
   ansible.builtin.fail:
     msg: >-
       Unsupported architecture '{{ system_arch }}' for cc-filter. Set
-      cc_filter_download_url to a compatible binary URL.
+      agentic_tools_cc_filter_download_url to a compatible binary URL.
   when: system_arch not in ["amd64", "arm64"]
 
 - name: Download cc-filter binary
   ansible.builtin.get_url:
-    url: "{{ cc_filter_download_url }}"
-    dest: "{{ cc_filter_install_path }}"
-    checksum: "{{ cc_filter_checksum }}"
+    url: "{{ agentic_tools_cc_filter_download_url }}"
+    dest: "{{ agentic_tools_cc_filter_install_path }}"
+    checksum: "{{ agentic_tools_cc_filter_checksum }}"
     owner: root
     group: root
-    mode: "{{ cc_filter_binary_mode }}"
+    mode: "{{ agentic_tools_cc_filter_binary_mode }}"
 
 - name: Configure Claude Code hooks for cc-filter
-  when: cc_filter_configure_hooks | bool
+  when: agentic_tools_cc_filter_configure_hooks | bool
+  vars:
+    agentic_tools_cc_filter_hook:
+      - hooks:
+          - type: command
+            command: "{{ agentic_tools_cc_filter_install_path }}"
+    agentic_tools_cc_filter_hooks:
+      PreToolUse:
+        - matcher: "*"
+          hooks:
+            - type: command
+              command: "{{ agentic_tools_cc_filter_install_path }}"
+      UserPromptSubmit: "{{ agentic_tools_cc_filter_hook }}"
+      SessionEnd: "{{ agentic_tools_cc_filter_hook }}"
   block:
     - name: Ensure Claude config directory exists
       ansible.builtin.file:
-        path: "{{ cc_filter_claude_settings_path | dirname }}"
+        path: "{{ agentic_tools_cc_filter_claude_settings_path | dirname }}"
         state: directory
         owner: "{{ ros_user_setup_uid }}"
         group: "{{ ros_user_setup_gid }}"
@@ -30,14 +43,14 @@
 
     - name: Stat existing Claude settings
       ansible.builtin.stat:
-        path: "{{ cc_filter_claude_settings_path }}"
-      register: cc_filter_settings_stat
+        path: "{{ agentic_tools_cc_filter_claude_settings_path }}"
+      register: agentic_tools_cc_filter_settings_stat
 
     - name: Read existing Claude settings
       ansible.builtin.slurp:
-        src: "{{ cc_filter_claude_settings_path }}"
-      register: cc_filter_existing_settings
-      when: cc_filter_settings_stat.stat.exists
+        src: "{{ agentic_tools_cc_filter_claude_settings_path }}"
+      register: agentic_tools_cc_filter_existing_settings
+      when: agentic_tools_cc_filter_settings_stat.stat.exists
 
     - name: Warn when existing hooks will be replaced
       ansible.builtin.debug:
@@ -45,33 +58,20 @@
           Existing Claude settings already define a 'hooks' key; cc-filter will
           replace the PreToolUse, UserPromptSubmit, and SessionEnd entries.
       when:
-        - cc_filter_existing_settings.content is defined
-        - "'hooks' in (cc_filter_existing_settings.content | b64decode | trim | default('{}', true) | from_json)"
+        - agentic_tools_cc_filter_existing_settings.content is defined
+        - "'hooks' in (agentic_tools_cc_filter_existing_settings.content | b64decode | trim | default('{}', true) | from_json)"
 
     - name: Merge cc-filter hooks into Claude settings
       ansible.builtin.copy:
         content: >-
           {{
-            (cc_filter_existing_settings.content | b64decode | trim | default('{}', true) | from_json
-             if cc_filter_existing_settings.content is defined
+            (agentic_tools_cc_filter_existing_settings.content | b64decode | trim | default('{}', true) | from_json
+             if agentic_tools_cc_filter_existing_settings.content is defined
              else {})
-            | combine({'hooks': cc_filter_hooks}, recursive=true)
+            | combine({'hooks': agentic_tools_cc_filter_hooks}, recursive=true)
             | to_nice_json
           }}
-        dest: "{{ cc_filter_claude_settings_path }}"
+        dest: "{{ agentic_tools_cc_filter_claude_settings_path }}"
         owner: "{{ ros_user_setup_uid }}"
         group: "{{ ros_user_setup_gid }}"
         mode: "0644"
-  vars:
-    cc_filter_hook: # noqa: var-naming[no-role-prefix]
-      - hooks:
-          - type: command
-            command: "{{ cc_filter_install_path }}"
-    cc_filter_hooks: # noqa: var-naming[no-role-prefix]
-      PreToolUse:
-        - matcher: "*"
-          hooks:
-            - type: command
-              command: "{{ cc_filter_install_path }}"
-      UserPromptSubmit: "{{ cc_filter_hook }}"
-      SessionEnd: "{{ cc_filter_hook }}"

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/main.yml
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/main.yml
@@ -21,4 +21,4 @@
 
 - name: Install cc-filter security layer for Claude Code
   ansible.builtin.import_tasks: cc_filter.yml
-  when: cc_filter_install | bool
+  when: agentic_tools_cc_filter_install | bool

--- a/packages/runtime/drqp_brain/test/conftest.py
+++ b/packages/runtime/drqp_brain/test/conftest.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import rclpy
+
+
+@pytest.fixture
+def rclpy_context():
+    """Provide a ROS context for tests that construct ROS nodes directly."""
+    rclpy.init()
+    try:
+        yield
+    finally:
+        rclpy.try_shutdown()

--- a/packages/runtime/drqp_brain/test/test_brain_moveit_ik.py
+++ b/packages/runtime/drqp_brain/test/test_brain_moveit_ik.py
@@ -27,7 +27,8 @@ import rclpy
 
 
 @pytest.fixture(autouse=True)
-def ros_context():
+def rclpy_context():
+    """Provide a ROS context for all tests in this module."""
     rclpy.init()
     try:
         yield

--- a/packages/runtime/drqp_brain/test/test_brain_node.py
+++ b/packages/runtime/drqp_brain/test/test_brain_node.py
@@ -51,14 +51,6 @@ def test_existing_brain_node_detection_rejects_duplicate_ros_node():
         _assert_no_existing_brain_node(node)
 
 
-@pytest.fixture
-def rclpy_context():
-    """Initialize rclpy for unit tests that construct a HexapodBrain directly."""
-    rclpy.init()
-    yield
-    rclpy.try_shutdown()
-
-
 def test_trajectory_action_client_is_created_lazily(rclpy_context):  # noqa: ARG001 (needs rclpy)
     """Only create the action client when an action sequence is requested."""
     with mock.patch('drqp_brain.brain_node.ActionClient') as action_client_cls:

--- a/packages/runtime/drqp_brain/test/test_brain_shutdown.py
+++ b/packages/runtime/drqp_brain/test/test_brain_shutdown.py
@@ -29,7 +29,8 @@ from rclpy.executors import ExternalShutdownException
 
 
 @pytest.fixture(autouse=True)
-def ros_context():
+def rclpy_context():
+    """Provide a ROS context for all tests in this module."""
     rclpy.init()
     try:
         yield

--- a/packages/runtime/drqp_brain/test/test_haptics.py
+++ b/packages/runtime/drqp_brain/test/test_haptics.py
@@ -72,9 +72,7 @@ def test_scheduler_repeats_control_mode_groups_with_longer_group_gap():
     current_time = [50.0]
     scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
 
-    commands = scheduler.schedule(
-        control_mode_feedback_pattern(_FakeControlMode('BodyPosition'))
-    )
+    commands = scheduler.schedule(control_mode_feedback_pattern(_FakeControlMode('BodyPosition')))
 
     active_commands = [command for command in commands if command.intensity > 0.0]
     assert len(active_commands) == 6
@@ -95,7 +93,14 @@ def test_scheduler_returns_on_off_commands_for_each_pulse():
 
     assert len(commands) == 8
     assert [command.intensity for command in commands] == [
-        0.8, 0.0, 0.8, 0.0, 0.8, 0.0, 0.8, 0.0,
+        0.8,
+        0.0,
+        0.8,
+        0.0,
+        0.8,
+        0.0,
+        0.8,
+        0.0,
     ]
     assert [command.channel_id for command in commands] == [LEFT_RUMBLE_CHANNEL_ID] * 8
     assert commands[0].due_at == pytest.approx(10.0, abs=1e-7)

--- a/packages/runtime/drqp_brain/test/test_haptics.py
+++ b/packages/runtime/drqp_brain/test/test_haptics.py
@@ -18,8 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import unittest
-
 from drqp_brain.haptics import (
     control_mode_feedback_pattern,
     gait_feedback_pattern,
@@ -27,6 +25,7 @@ from drqp_brain.haptics import (
     LEFT_RUMBLE_CHANNEL_ID,
     RIGHT_RUMBLE_CHANNEL_ID,
 )
+import pytest
 
 
 class _FakeControlMode:
@@ -36,126 +35,119 @@ class _FakeControlMode:
         self.name = name
 
 
-class TestHaptics(unittest.TestCase):
-    """Test haptic feedback mapping and scheduling."""
+def test_gait_feedback_pattern_uses_left_channel_pulse_counts():
+    """Gait selections should map to left-channel pulse counts."""
+    tripod = gait_feedback_pattern('tripod')
+    ripple = gait_feedback_pattern('ripple')
+    wave = gait_feedback_pattern('wave')
 
-    def test_gait_feedback_pattern_uses_left_channel_pulse_counts(self):
-        """Gait selections should map to left-channel pulse counts."""
-        tripod = gait_feedback_pattern('tripod')
-        ripple = gait_feedback_pattern('ripple')
-        wave = gait_feedback_pattern('wave')
-
-        self.assertEqual(tripod.channel_id, LEFT_RUMBLE_CHANNEL_ID)
-        self.assertEqual(ripple.channel_id, LEFT_RUMBLE_CHANNEL_ID)
-        self.assertEqual(wave.channel_id, LEFT_RUMBLE_CHANNEL_ID)
-        self.assertEqual(tripod.pulse_count, 1)
-        self.assertEqual(ripple.pulse_count, 2)
-        self.assertEqual(wave.pulse_count, 3)
-
-    def test_control_mode_feedback_pattern_uses_working_rumble_channel(
-        self,
-    ):
-        """Control modes should preserve pulse mapping and repeat groups."""
-        walk = control_mode_feedback_pattern(_FakeControlMode('Walk'))
-        body_position = control_mode_feedback_pattern(_FakeControlMode('BodyPosition'))
-        body_rotation = control_mode_feedback_pattern(_FakeControlMode('BodyRotation'))
-
-        self.assertEqual(walk.channel_id, RIGHT_RUMBLE_CHANNEL_ID)
-        self.assertEqual(body_position.channel_id, RIGHT_RUMBLE_CHANNEL_ID)
-        self.assertEqual(body_rotation.channel_id, RIGHT_RUMBLE_CHANNEL_ID)
-        self.assertEqual(walk.pulse_count, 1)
-        self.assertEqual(body_position.pulse_count, 2)
-        self.assertEqual(body_rotation.pulse_count, 3)
-        self.assertEqual(walk.repeat_count, 3)
-        self.assertEqual(body_position.repeat_count, 3)
-        self.assertEqual(body_rotation.repeat_count, 3)
-        self.assertGreater(walk.repeat_gap_duration, 0.04)
-
-    def test_scheduler_repeats_control_mode_groups_with_longer_group_gap(self):
-        """Control-mode groups should repeat three times with a longer inter-group gap."""
-        current_time = [50.0]
-        scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
-
-        commands = scheduler.schedule(
-            control_mode_feedback_pattern(_FakeControlMode('BodyPosition'))
-        )
-
-        active_commands = [command for command in commands if command.intensity > 0.0]
-        self.assertEqual(len(active_commands), 6)
-        self.assertAlmostEqual(active_commands[0].due_at, 50.0, places=7)
-        self.assertAlmostEqual(active_commands[1].due_at, 50.2, places=7)
-        self.assertAlmostEqual(active_commands[2].due_at, 50.6, places=7)
-        self.assertAlmostEqual(active_commands[3].due_at, 50.8, places=7)
-        self.assertAlmostEqual(active_commands[4].due_at, 51.2, places=7)
-        self.assertAlmostEqual(active_commands[5].due_at, 51.4, places=7)
-
-    def test_scheduler_returns_on_off_commands_for_each_pulse(self):
-        """A pulse pattern should expand into alternating on/off commands."""
-        current_time = [10.0]
-        scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
-
-        commands = scheduler.schedule(gait_feedback_pattern('ripple'))
-
-        self.assertEqual(len(commands), 8)
-        self.assertEqual(
-            [command.intensity for command in commands],
-            [0.8, 0.0, 0.8, 0.0, 0.8, 0.0, 0.8, 0.0],
-        )
-        self.assertEqual(
-            [command.channel_id for command in commands],
-            [LEFT_RUMBLE_CHANNEL_ID] * 8,
-        )
-        self.assertAlmostEqual(commands[0].due_at, 10.0, places=7)
-        self.assertAlmostEqual(commands[1].due_at, 10.15, places=7)
-        self.assertAlmostEqual(commands[2].due_at, 10.2, places=7)
-        self.assertAlmostEqual(commands[3].due_at, 10.35, places=7)
-        self.assertAlmostEqual(commands[4].due_at, 10.6, places=7)
-        self.assertAlmostEqual(commands[5].due_at, 10.75, places=7)
-        self.assertAlmostEqual(commands[6].due_at, 10.8, places=7)
-        self.assertAlmostEqual(commands[7].due_at, 10.95, places=7)
-
-    def test_scheduler_is_idempotent_for_same_finalized_state(self):
-        """Repeated selection of the active state should not schedule more feedback."""
-        current_time = [20.0]
-        scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
-        tripod_pattern = gait_feedback_pattern('tripod')
-
-        self.assertEqual(len(scheduler.schedule(tripod_pattern)), 4)
-        self.assertEqual(scheduler.schedule(tripod_pattern), [])
-
-    def test_scheduler_applies_channel_cooldown_before_next_pattern(self):
-        """Rapid updates on one channel should be delayed by the cooldown window."""
-        current_time = [30.0]
-        scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
-
-        scheduler.schedule(gait_feedback_pattern('tripod'))
-        current_time[0] = 30.02
-        commands = scheduler.schedule(gait_feedback_pattern('ripple'))
-
-        self.assertAlmostEqual(commands[0].due_at, 30.65, places=7)
-        self.assertAlmostEqual(commands[1].due_at, 30.8, places=7)
-
-    def test_scheduler_reset_channel_allows_resending_same_state(self):
-        """
-        After reset_channel, re-selecting the same state should produce.
-
-        Fresh
-        feedback commands (models backend reconnect scenario).
-        """
-        current_time = [40.0]
-        scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
-        tripod_pattern = gait_feedback_pattern('tripod')
-
-        first = scheduler.schedule(tripod_pattern)
-        self.assertEqual(len(first), 4)
-
-        # Simulate discarding due to missing backend and resetting channel
-        scheduler.reset_channel(tripod_pattern.channel_id)
-
-        # Same state should now produce commands again
-        second = scheduler.schedule(tripod_pattern)
-        self.assertEqual(len(second), 4)
+    assert tripod.channel_id == LEFT_RUMBLE_CHANNEL_ID
+    assert ripple.channel_id == LEFT_RUMBLE_CHANNEL_ID
+    assert wave.channel_id == LEFT_RUMBLE_CHANNEL_ID
+    assert tripod.pulse_count == 1
+    assert ripple.pulse_count == 2
+    assert wave.pulse_count == 3
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_control_mode_feedback_pattern_uses_working_rumble_channel():
+    """Control modes should preserve pulse mapping and repeat groups."""
+    walk = control_mode_feedback_pattern(_FakeControlMode('Walk'))
+    body_position = control_mode_feedback_pattern(_FakeControlMode('BodyPosition'))
+    body_rotation = control_mode_feedback_pattern(_FakeControlMode('BodyRotation'))
+
+    assert walk.channel_id == RIGHT_RUMBLE_CHANNEL_ID
+    assert body_position.channel_id == RIGHT_RUMBLE_CHANNEL_ID
+    assert body_rotation.channel_id == RIGHT_RUMBLE_CHANNEL_ID
+    assert walk.pulse_count == 1
+    assert body_position.pulse_count == 2
+    assert body_rotation.pulse_count == 3
+    assert walk.repeat_count == 3
+    assert body_position.repeat_count == 3
+    assert body_rotation.repeat_count == 3
+    assert walk.repeat_gap_duration > 0.04
+
+
+def test_scheduler_repeats_control_mode_groups_with_longer_group_gap():
+    """Control-mode groups should repeat three times with a longer inter-group gap."""
+    current_time = [50.0]
+    scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
+
+    commands = scheduler.schedule(
+        control_mode_feedback_pattern(_FakeControlMode('BodyPosition'))
+    )
+
+    active_commands = [command for command in commands if command.intensity > 0.0]
+    assert len(active_commands) == 6
+    assert active_commands[0].due_at == pytest.approx(50.0, abs=1e-7)
+    assert active_commands[1].due_at == pytest.approx(50.2, abs=1e-7)
+    assert active_commands[2].due_at == pytest.approx(50.6, abs=1e-7)
+    assert active_commands[3].due_at == pytest.approx(50.8, abs=1e-7)
+    assert active_commands[4].due_at == pytest.approx(51.2, abs=1e-7)
+    assert active_commands[5].due_at == pytest.approx(51.4, abs=1e-7)
+
+
+def test_scheduler_returns_on_off_commands_for_each_pulse():
+    """A pulse pattern should expand into alternating on/off commands."""
+    current_time = [10.0]
+    scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
+
+    commands = scheduler.schedule(gait_feedback_pattern('ripple'))
+
+    assert len(commands) == 8
+    assert [command.intensity for command in commands] == [
+        0.8, 0.0, 0.8, 0.0, 0.8, 0.0, 0.8, 0.0,
+    ]
+    assert [command.channel_id for command in commands] == [LEFT_RUMBLE_CHANNEL_ID] * 8
+    assert commands[0].due_at == pytest.approx(10.0, abs=1e-7)
+    assert commands[1].due_at == pytest.approx(10.15, abs=1e-7)
+    assert commands[2].due_at == pytest.approx(10.2, abs=1e-7)
+    assert commands[3].due_at == pytest.approx(10.35, abs=1e-7)
+    assert commands[4].due_at == pytest.approx(10.6, abs=1e-7)
+    assert commands[5].due_at == pytest.approx(10.75, abs=1e-7)
+    assert commands[6].due_at == pytest.approx(10.8, abs=1e-7)
+    assert commands[7].due_at == pytest.approx(10.95, abs=1e-7)
+
+
+def test_scheduler_is_idempotent_for_same_finalized_state():
+    """Repeated selection of the active state should not schedule more feedback."""
+    current_time = [20.0]
+    scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
+    tripod_pattern = gait_feedback_pattern('tripod')
+
+    assert len(scheduler.schedule(tripod_pattern)) == 4
+    assert scheduler.schedule(tripod_pattern) == []
+
+
+def test_scheduler_applies_channel_cooldown_before_next_pattern():
+    """Rapid updates on one channel should be delayed by the cooldown window."""
+    current_time = [30.0]
+    scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
+
+    scheduler.schedule(gait_feedback_pattern('tripod'))
+    current_time[0] = 30.02
+    commands = scheduler.schedule(gait_feedback_pattern('ripple'))
+
+    assert commands[0].due_at == pytest.approx(30.65, abs=1e-7)
+    assert commands[1].due_at == pytest.approx(30.8, abs=1e-7)
+
+
+def test_scheduler_reset_channel_allows_resending_same_state():
+    """
+    After reset_channel, re-selecting the same state should produce.
+
+    Fresh
+    feedback commands (models backend reconnect scenario).
+    """
+    current_time = [40.0]
+    scheduler = HapticFeedbackScheduler(clock=lambda: current_time[0])
+    tripod_pattern = gait_feedback_pattern('tripod')
+
+    first = scheduler.schedule(tripod_pattern)
+    assert len(first) == 4
+
+    # Simulate discarding due to missing backend and resetting channel
+    scheduler.reset_channel(tripod_pattern.channel_id)
+
+    # Same state should now produce commands again
+    second = scheduler.schedule(tripod_pattern)
+    assert len(second) == 4

--- a/packages/runtime/drqp_brain/test/test_imu_node.py
+++ b/packages/runtime/drqp_brain/test/test_imu_node.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import unittest
+from dataclasses import dataclass, field
 from unittest import mock
 
 from drqp_brain.imu_node import (
@@ -29,20 +29,19 @@ from drqp_brain.imu_node import (
     main,
     SensorInitializationError,
 )
+import pytest
 import rclpy
 from sensor_msgs.msg import Imu, MagneticField, Temperature
 
 
-class TestImuReadingConversion(unittest.TestCase):
-    """Test normalization helpers for raw IMU sensor readings."""
+def test_as_vector3_returns_none_when_any_axis_is_missing():
+    """Treat partially missing 3-axis readings as unavailable."""
+    assert _as_vector3((1.0, None, 3.0)) is None
 
-    def test_as_vector3_returns_none_when_any_axis_is_missing(self):
-        """Treat partially missing 3-axis readings as unavailable."""
-        self.assertIsNone(_as_vector3((1.0, None, 3.0)))
 
-    def test_as_quaternion_returns_none_when_any_axis_is_missing(self):
-        """Treat partially missing quaternion readings as unavailable."""
-        self.assertIsNone(_as_quaternion((1.0, 0.0, None, 0.0)))
+def test_as_quaternion_returns_none_when_any_axis_is_missing():
+    """Treat partially missing quaternion readings as unavailable."""
+    assert _as_quaternion((1.0, 0.0, None, 0.0)) is None
 
 
 class FakeImuSensor:
@@ -65,61 +64,18 @@ class FakeImuSensor:
         return self.sample
 
 
-class RclpyTestCase(unittest.TestCase):
-    """Provide a class-scoped ROS context for unittest-based ROS tests."""
+@dataclass
+class _ImuHarness:
+    """Bundle the IMU node under test, its fake sensor, and captured messages."""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        rclpy.init()
-        cls.addClassCleanup(rclpy.try_shutdown)
+    node: ImuNode
+    test_node: 'rclpy.node.Node'
+    fake_sensor: FakeImuSensor
+    imu_messages: list = field(default_factory=list)
+    magnetic_field_messages: list = field(default_factory=list)
+    temperature_messages: list = field(default_factory=list)
 
-
-class TestImuNode(RclpyTestCase):
-    """Test the IMU publisher node with a fake sensor backend."""
-
-    def setUp(self):
-        sample = ImuSample(
-            orientation_wxyz=(1.0, 0.1, 0.2, 0.3),
-            angular_velocity=(0.4, 0.5, 0.6),
-            linear_acceleration=(1.1, 1.2, 1.3),
-            magnetic_field_microtesla=(11.0, 12.0, 13.0),
-            temperature_celsius=24.5,
-        )
-        self.fake_sensor = FakeImuSensor(sample=sample)
-        self.sensor_patch = mock.patch(
-            'drqp_brain.imu_node.Bno055Sensor',
-            return_value=self.fake_sensor,
-        )
-        self.addCleanup(self.sensor_patch.stop)
-        self.sensor_patch.start()
-        self.node = ImuNode()
-        self.addCleanup(self.node.destroy_node)
-        self.node.timer.cancel()
-        self.test_node = rclpy.create_node('test_imu_consumer')
-        self.addCleanup(self.test_node.destroy_node)
-
-        self.imu_messages = []
-        self.magnetic_field_messages = []
-        self.temperature_messages = []
-
-        self.imu_subscription = self.test_node.create_subscription(
-            Imu, '/imu/data', lambda msg: self.imu_messages.append(msg), 10
-        )
-        self.magnetic_field_subscription = self.test_node.create_subscription(
-            MagneticField,
-            '/imu/mag',
-            lambda msg: self.magnetic_field_messages.append(msg),
-            10,
-        )
-        self.temperature_subscription = self.test_node.create_subscription(
-            Temperature,
-            '/imu/temperature',
-            lambda msg: self.temperature_messages.append(msg),
-            10,
-        )
-
-    def _spin_until(self, predicate, iterations: int = 10) -> bool:
+    def spin_until(self, predicate, iterations: int = 10) -> bool:
         """Spin both nodes until the predicate is satisfied or the budget is exhausted."""
         for _ in range(iterations):
             rclpy.spin_once(self.node, timeout_sec=0.02)
@@ -128,9 +84,9 @@ class TestImuNode(RclpyTestCase):
                 return True
         return False
 
-    def _wait_for_subscribers(self):
+    def wait_for_subscribers(self) -> None:
         """Wait until the IMU publishers have active subscriptions."""
-        connected = self._spin_until(
+        connected = self.spin_until(
             lambda: (
                 self.node.imu_pub.get_subscription_count() > 0
                 and self.node.magnetic_field_pub.get_subscription_count() > 0
@@ -138,139 +94,182 @@ class TestImuNode(RclpyTestCase):
             ),
             iterations=20,
         )
-        self.assertTrue(connected, 'Expected IMU subscriptions to connect')
+        assert connected, 'Expected IMU subscriptions to connect'
         self.imu_messages.clear()
         self.magnetic_field_messages.clear()
         self.temperature_messages.clear()
 
-    def test_publish_measurements_publishes_imu_and_9dof_topics(self):
-        """Publish IMU, magnetic field, and temperature messages from one sample."""
-        self._wait_for_subscribers()
 
-        self.node.publish_measurements()
-        delivered = self._spin_until(
-            lambda: (
-                len(self.imu_messages) > 0
-                and len(self.magnetic_field_messages) > 0
-                and len(self.temperature_messages) > 0
-            ),
-            iterations=20,
+@pytest.fixture
+def rclpy_context():
+    """Provide a ROS context for tests that construct ROS nodes directly."""
+    rclpy.init()
+    try:
+        yield
+    finally:
+        rclpy.try_shutdown()
+
+
+@pytest.fixture
+def imu_harness(rclpy_context):  # noqa: ARG001 (needs rclpy)
+    """Provide an IMU node backed by a fake sensor wired to a consumer node."""
+    sample = ImuSample(
+        orientation_wxyz=(1.0, 0.1, 0.2, 0.3),
+        angular_velocity=(0.4, 0.5, 0.6),
+        linear_acceleration=(1.1, 1.2, 1.3),
+        magnetic_field_microtesla=(11.0, 12.0, 13.0),
+        temperature_celsius=24.5,
+    )
+    fake_sensor = FakeImuSensor(sample=sample)
+    with mock.patch('drqp_brain.imu_node.Bno055Sensor', return_value=fake_sensor):
+        node = ImuNode()
+        node.timer.cancel()
+        test_node = rclpy.create_node('test_imu_consumer')
+        harness = _ImuHarness(node=node, test_node=test_node, fake_sensor=fake_sensor)
+
+        test_node.create_subscription(
+            Imu, '/imu/data', lambda msg: harness.imu_messages.append(msg), 10
+        )
+        test_node.create_subscription(
+            MagneticField,
+            '/imu/mag',
+            lambda msg: harness.magnetic_field_messages.append(msg),
+            10,
+        )
+        test_node.create_subscription(
+            Temperature,
+            '/imu/temperature',
+            lambda msg: harness.temperature_messages.append(msg),
+            10,
         )
 
-        self.assertTrue(delivered, 'Expected IMU messages to be delivered')
-
-        imu_msg = self.imu_messages[-1]
-        self.assertEqual(imu_msg.header.frame_id, 'drqp/imu_link')
-        self.assertEqual(imu_msg.orientation.w, 1.0)
-        self.assertEqual(imu_msg.orientation.x, 0.1)
-        self.assertEqual(imu_msg.orientation.y, 0.2)
-        self.assertEqual(imu_msg.orientation.z, 0.3)
-        self.assertEqual(imu_msg.angular_velocity.x, 0.4)
-        self.assertEqual(imu_msg.angular_velocity.y, 0.5)
-        self.assertEqual(imu_msg.angular_velocity.z, 0.6)
-        self.assertEqual(imu_msg.linear_acceleration.x, 1.1)
-        self.assertEqual(imu_msg.linear_acceleration.y, 1.2)
-        self.assertEqual(imu_msg.linear_acceleration.z, 1.3)
-
-        magnetic_field_msg = self.magnetic_field_messages[-1]
-        self.assertEqual(magnetic_field_msg.header.frame_id, 'drqp/imu_link')
-        self.assertAlmostEqual(magnetic_field_msg.magnetic_field.x, 11.0e-6)
-        self.assertAlmostEqual(magnetic_field_msg.magnetic_field.y, 12.0e-6)
-        self.assertAlmostEqual(magnetic_field_msg.magnetic_field.z, 13.0e-6)
-
-        temperature_msg = self.temperature_messages[-1]
-        self.assertEqual(temperature_msg.header.frame_id, 'drqp/imu_link')
-        self.assertEqual(temperature_msg.temperature, 24.5)
-
-    def test_publish_measurements_skips_publish_on_sensor_failure(self):
-        """Avoid publishing stale ROS messages when a sensor read fails."""
-        self.fake_sensor.error = RuntimeError('i2c read failed')
-        self._wait_for_subscribers()
-
-        self.node.publish_measurements()
-        self._spin_until(lambda: False, iterations=5)
-
-        self.assertEqual(self.imu_messages, [])
-        self.assertEqual(self.magnetic_field_messages, [])
-        self.assertEqual(self.temperature_messages, [])
-
-    def test_publish_measurements_marks_orientation_unavailable_when_none(self):
-        """Publish gyro/accel even when orientation is absent; mark it unavailable."""
-        self.fake_sensor.sample = ImuSample(
-            orientation_wxyz=None,
-            angular_velocity=(0.7, 0.8, 0.9),
-            linear_acceleration=(2.1, 2.2, 2.3),
-            magnetic_field_microtesla=(5.0, 6.0, 7.0),
-            temperature_celsius=25.0,
-        )
-        self._wait_for_subscribers()
-
-        self.node.publish_measurements()
-        delivered = self._spin_until(lambda: len(self.imu_messages) > 0, iterations=20)
-
-        self.assertTrue(delivered, 'Expected IMU message to be delivered without orientation')
-
-        imu_msg = self.imu_messages[-1]
-        self.assertEqual(
-            imu_msg.orientation_covariance[0],
-            -1.0,
-            'orientation_covariance[0] must be -1 when orientation is unavailable',
-        )
-        self.assertEqual(imu_msg.angular_velocity.x, 0.7)
-        self.assertEqual(imu_msg.angular_velocity.y, 0.8)
-        self.assertEqual(imu_msg.angular_velocity.z, 0.9)
-        self.assertEqual(imu_msg.angular_velocity_covariance[0], -1.0)
-        self.assertEqual(imu_msg.linear_acceleration.x, 2.1)
-        self.assertEqual(imu_msg.linear_acceleration.y, 2.2)
-        self.assertEqual(imu_msg.linear_acceleration.z, 2.3)
-        self.assertEqual(imu_msg.linear_acceleration_covariance[0], -1.0)
+        try:
+            yield harness
+        finally:
+            test_node.destroy_node()
+            node.destroy_node()
 
 
-class TestImuNodeInitialization(RclpyTestCase):
-    """Test IMU node startup failures caused by backend construction."""
+def test_publish_measurements_publishes_imu_and_9dof_topics(imu_harness):
+    """Publish IMU, magnetic field, and temperature messages from one sample."""
+    imu_harness.wait_for_subscribers()
 
-    def test_constructor_wraps_sensor_construction_failures(self):
-        """Report backend construction failures with an actionable startup error."""
-        with (
-            mock.patch(
-                'drqp_brain.imu_node.Bno055Sensor',
-                side_effect=AttributeError('platform detection failed'),
-            ),
-            self.assertRaisesRegex(
-                SensorInitializationError,
-                'Failed to initialize the BNO055 IMU backend at I2C address 0x28',
-            ) as context,
-        ):
-            ImuNode()
+    imu_harness.node.publish_measurements()
+    delivered = imu_harness.spin_until(
+        lambda: (
+            len(imu_harness.imu_messages) > 0
+            and len(imu_harness.magnetic_field_messages) > 0
+            and len(imu_harness.temperature_messages) > 0
+        ),
+        iterations=20,
+    )
 
-        self.assertIsInstance(context.exception.__cause__, AttributeError)
+    assert delivered, 'Expected IMU messages to be delivered'
 
+    imu_msg = imu_harness.imu_messages[-1]
+    assert imu_msg.header.frame_id == 'drqp/imu_link'
+    assert imu_msg.orientation.w == 1.0
+    assert imu_msg.orientation.x == 0.1
+    assert imu_msg.orientation.y == 0.2
+    assert imu_msg.orientation.z == 0.3
+    assert imu_msg.angular_velocity.x == 0.4
+    assert imu_msg.angular_velocity.y == 0.5
+    assert imu_msg.angular_velocity.z == 0.6
+    assert imu_msg.linear_acceleration.x == 1.1
+    assert imu_msg.linear_acceleration.y == 1.2
+    assert imu_msg.linear_acceleration.z == 1.3
 
-class TestImuMain(unittest.TestCase):
-    """Test CLI behavior for IMU node startup failures."""
+    magnetic_field_msg = imu_harness.magnetic_field_messages[-1]
+    assert magnetic_field_msg.header.frame_id == 'drqp/imu_link'
+    assert magnetic_field_msg.magnetic_field.x == pytest.approx(11.0e-6)
+    assert magnetic_field_msg.magnetic_field.y == pytest.approx(12.0e-6)
+    assert magnetic_field_msg.magnetic_field.z == pytest.approx(13.0e-6)
 
-    def test_main_exits_cleanly_when_sensor_backend_cannot_start(self):
-        """Exit with code 1 and log the startup error without a traceback."""
-        logger = mock.Mock()
-        imu_node_constructor = mock.Mock(
-            side_effect=SensorInitializationError('backend unavailable')
-        )
-
-        with (
-            mock.patch('drqp_brain.imu_node.rclpy.init'),
-            mock.patch('drqp_brain.imu_node.ImuNode', imu_node_constructor),
-            mock.patch('drqp_brain.imu_node.rclpy.logging.get_logger', return_value=logger),
-            mock.patch('drqp_brain.imu_node.rclpy.ok', return_value=True),
-            mock.patch('drqp_brain.imu_node.rclpy.shutdown') as shutdown,
-        ):
-            with self.assertRaises(SystemExit) as context:
-                main()
-
-        self.assertEqual(context.exception.code, 1)
-        imu_node_constructor.assert_called_once_with()
-        logger.error.assert_called_once_with('backend unavailable')
-        shutdown.assert_called_once_with()
+    temperature_msg = imu_harness.temperature_messages[-1]
+    assert temperature_msg.header.frame_id == 'drqp/imu_link'
+    assert temperature_msg.temperature == 24.5
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_publish_measurements_skips_publish_on_sensor_failure(imu_harness):
+    """Avoid publishing stale ROS messages when a sensor read fails."""
+    imu_harness.fake_sensor.error = RuntimeError('i2c read failed')
+    imu_harness.wait_for_subscribers()
+
+    imu_harness.node.publish_measurements()
+    imu_harness.spin_until(lambda: False, iterations=5)
+
+    assert imu_harness.imu_messages == []
+    assert imu_harness.magnetic_field_messages == []
+    assert imu_harness.temperature_messages == []
+
+
+def test_publish_measurements_marks_orientation_unavailable_when_none(imu_harness):
+    """Publish gyro/accel even when orientation is absent; mark it unavailable."""
+    imu_harness.fake_sensor.sample = ImuSample(
+        orientation_wxyz=None,
+        angular_velocity=(0.7, 0.8, 0.9),
+        linear_acceleration=(2.1, 2.2, 2.3),
+        magnetic_field_microtesla=(5.0, 6.0, 7.0),
+        temperature_celsius=25.0,
+    )
+    imu_harness.wait_for_subscribers()
+
+    imu_harness.node.publish_measurements()
+    delivered = imu_harness.spin_until(
+        lambda: len(imu_harness.imu_messages) > 0, iterations=20
+    )
+
+    assert delivered, 'Expected IMU message to be delivered without orientation'
+
+    imu_msg = imu_harness.imu_messages[-1]
+    assert imu_msg.orientation_covariance[0] == -1.0, (
+        'orientation_covariance[0] must be -1 when orientation is unavailable'
+    )
+    assert imu_msg.angular_velocity.x == 0.7
+    assert imu_msg.angular_velocity.y == 0.8
+    assert imu_msg.angular_velocity.z == 0.9
+    assert imu_msg.angular_velocity_covariance[0] == -1.0
+    assert imu_msg.linear_acceleration.x == 2.1
+    assert imu_msg.linear_acceleration.y == 2.2
+    assert imu_msg.linear_acceleration.z == 2.3
+    assert imu_msg.linear_acceleration_covariance[0] == -1.0
+
+
+def test_constructor_wraps_sensor_construction_failures(rclpy_context):  # noqa: ARG001
+    """Report backend construction failures with an actionable startup error."""
+    with (
+        mock.patch(
+            'drqp_brain.imu_node.Bno055Sensor',
+            side_effect=AttributeError('platform detection failed'),
+        ),
+        pytest.raises(
+            SensorInitializationError,
+            match='Failed to initialize the BNO055 IMU backend at I2C address 0x28',
+        ) as context,
+    ):
+        ImuNode()
+
+    assert isinstance(context.value.__cause__, AttributeError)
+
+
+def test_main_exits_cleanly_when_sensor_backend_cannot_start():
+    """Exit with code 1 and log the startup error without a traceback."""
+    logger = mock.Mock()
+    imu_node_constructor = mock.Mock(
+        side_effect=SensorInitializationError('backend unavailable')
+    )
+
+    with (
+        mock.patch('drqp_brain.imu_node.rclpy.init'),
+        mock.patch('drqp_brain.imu_node.ImuNode', imu_node_constructor),
+        mock.patch('drqp_brain.imu_node.rclpy.logging.get_logger', return_value=logger),
+        mock.patch('drqp_brain.imu_node.rclpy.ok', return_value=True),
+        mock.patch('drqp_brain.imu_node.rclpy.shutdown') as shutdown,
+    ):
+        with pytest.raises(SystemExit) as context:
+            main()
+
+    assert context.value.code == 1
+    imu_node_constructor.assert_called_once_with()
+    logger.error.assert_called_once_with('backend unavailable')
+    shutdown.assert_called_once_with()

--- a/packages/runtime/drqp_brain/test/test_imu_node.py
+++ b/packages/runtime/drqp_brain/test/test_imu_node.py
@@ -215,9 +215,7 @@ def test_publish_measurements_marks_orientation_unavailable_when_none(imu_harnes
     imu_harness.wait_for_subscribers()
 
     imu_harness.node.publish_measurements()
-    delivered = imu_harness.spin_until(
-        lambda: len(imu_harness.imu_messages) > 0, iterations=20
-    )
+    delivered = imu_harness.spin_until(lambda: len(imu_harness.imu_messages) > 0, iterations=20)
 
     assert delivered, 'Expected IMU message to be delivered without orientation'
 
@@ -255,9 +253,7 @@ def test_constructor_wraps_sensor_construction_failures(rclpy_context):  # noqa:
 def test_main_exits_cleanly_when_sensor_backend_cannot_start():
     """Exit with code 1 and log the startup error without a traceback."""
     logger = mock.Mock()
-    imu_node_constructor = mock.Mock(
-        side_effect=SensorInitializationError('backend unavailable')
-    )
+    imu_node_constructor = mock.Mock(side_effect=SensorInitializationError('backend unavailable'))
 
     with (
         mock.patch('drqp_brain.imu_node.rclpy.init'),

--- a/packages/runtime/drqp_brain/test/test_imu_node.py
+++ b/packages/runtime/drqp_brain/test/test_imu_node.py
@@ -21,10 +21,6 @@
 from dataclasses import dataclass, field
 from unittest import mock
 
-import pytest
-import rclpy
-from sensor_msgs.msg import Imu, MagneticField, Temperature
-
 from drqp_brain.imu_node import (
     _as_quaternion,
     _as_vector3,
@@ -33,6 +29,9 @@ from drqp_brain.imu_node import (
     main,
     SensorInitializationError,
 )
+import pytest
+import rclpy
+from sensor_msgs.msg import Imu, MagneticField, Temperature
 
 
 def test_as_vector3_returns_none_when_any_axis_is_missing():

--- a/packages/runtime/drqp_brain/test/test_imu_node.py
+++ b/packages/runtime/drqp_brain/test/test_imu_node.py
@@ -21,6 +21,10 @@
 from dataclasses import dataclass, field
 from unittest import mock
 
+import pytest
+import rclpy
+from sensor_msgs.msg import Imu, MagneticField, Temperature
+
 from drqp_brain.imu_node import (
     _as_quaternion,
     _as_vector3,
@@ -29,9 +33,6 @@ from drqp_brain.imu_node import (
     main,
     SensorInitializationError,
 )
-import pytest
-import rclpy
-from sensor_msgs.msg import Imu, MagneticField, Temperature
 
 
 def test_as_vector3_returns_none_when_any_axis_is_missing():

--- a/packages/runtime/drqp_brain/test/test_imu_node.py
+++ b/packages/runtime/drqp_brain/test/test_imu_node.py
@@ -101,16 +101,6 @@ class _ImuHarness:
 
 
 @pytest.fixture
-def rclpy_context():
-    """Provide a ROS context for tests that construct ROS nodes directly."""
-    rclpy.init()
-    try:
-        yield
-    finally:
-        rclpy.try_shutdown()
-
-
-@pytest.fixture
 def imu_harness(rclpy_context):  # noqa: ARG001 (needs rclpy)
     """Provide an IMU node backed by a fake sensor wired to a consumer node."""
     sample = ImuSample(

--- a/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
+++ b/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import unittest
+from dataclasses import dataclass, field
 from unittest.mock import Mock
 
 from drqp_brain.haptics import (
@@ -28,229 +28,224 @@ from drqp_brain.haptics import (
 )
 from drqp_brain.joystick_translator_node import JoystickTranslatorNode
 from drqp_interfaces.msg import MovementCommand, MovementCommandConstants
+import pytest
 import rclpy
 import sensor_msgs.msg
 import std_msgs.msg
 
 
-class TestJoystickTranslatorNode(unittest.TestCase):
-    """Test the joystick translator node."""
+@dataclass
+class _TranslatorHarness:
+    """Bundle the node under test, a consumer node, and captured messages."""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        rclpy.init()
-        cls.addClassCleanup(rclpy.try_shutdown)
+    node: JoystickTranslatorNode
+    test_node: 'rclpy.node.Node'
+    movement_commands: list = field(default_factory=list)
+    robot_events: list = field(default_factory=list)
+    joy_feedback_messages: list = field(default_factory=list)
 
-    def setUp(self):
-        self.node = JoystickTranslatorNode()
-        self.addCleanup(self.node.destroy_node)
-        self.test_node = rclpy.create_node('test_translator_consumer')
-        self.addCleanup(self.test_node.destroy_node)
 
-        # Store received messages
-        self.movement_commands = []
-        self.robot_events = []
-        self.joy_feedback_messages = []
+@pytest.fixture
+def translator():
+    """Provide a joystick translator node wired to a consumer node."""
+    rclpy.init()
+    node = JoystickTranslatorNode()
+    test_node = rclpy.create_node('test_translator_consumer')
+    harness = _TranslatorHarness(node=node, test_node=test_node)
 
-        # Subscribe to translator output
-        self.movement_sub = self.test_node.create_subscription(
-            MovementCommand,
-            '/robot/movement_command',
-            lambda msg: self.movement_commands.append(msg),
-            10,
-        )
+    test_node.create_subscription(
+        MovementCommand,
+        '/robot/movement_command',
+        lambda msg: harness.movement_commands.append(msg),
+        10,
+    )
+    test_node.create_subscription(
+        std_msgs.msg.String,
+        '/robot_event',
+        lambda msg: harness.robot_events.append(msg),
+        10,
+    )
+    test_node.create_subscription(
+        sensor_msgs.msg.JoyFeedback,
+        '/joy/set_feedback',
+        lambda msg: harness.joy_feedback_messages.append(msg),
+        10,
+    )
 
-        self.event_sub = self.test_node.create_subscription(
-            std_msgs.msg.String,
-            '/robot_event',
-            lambda msg: self.robot_events.append(msg),
-            10,
-        )
+    try:
+        yield harness
+    finally:
+        test_node.destroy_node()
+        node.destroy_node()
+        rclpy.try_shutdown()
 
-        self.joy_feedback_sub = self.test_node.create_subscription(
-            sensor_msgs.msg.JoyFeedback,
-            '/joy/set_feedback',
-            lambda msg: self.joy_feedback_messages.append(msg),
-            10,
-        )
 
-    def test_joystick_to_movement_command(self):
-        """Test that joystick messages are translated to movement commands."""
-        # Create a joystick message with movement input
-        joy_msg = sensor_msgs.msg.Joy()
-        joy_msg.axes = [0.5, 0.3, -0.2, 0.1, 0.0, 0.0]  # axes
-        joy_msg.buttons = [0] * 21  # All buttons released
+def test_joystick_to_movement_command(translator):
+    """Test that joystick messages are translated to movement commands."""
+    # Create a joystick message with movement input
+    joy_msg = sensor_msgs.msg.Joy()
+    joy_msg.axes = [0.5, 0.3, -0.2, 0.1, 0.0, 0.0]  # axes
+    joy_msg.buttons = [0] * 21  # All buttons released
 
-        # Process the message
-        self.node._joy_callback(joy_msg)
+    # Process the message
+    translator.node._joy_callback(joy_msg)
 
-        # Spin to process callbacks
-        rclpy.spin_once(self.test_node, timeout_sec=0.1)
+    # Spin to process callbacks
+    rclpy.spin_once(translator.test_node, timeout_sec=0.1)
 
-        # Verify movement command was published
-        self.assertGreater(len(self.movement_commands), 0, 'Movement command should be published')
+    # Verify movement command was published
+    assert len(translator.movement_commands) > 0, 'Movement command should be published'
 
-        cmd = self.movement_commands[-1]
-        # Check that stride direction reflects joystick input
-        self.assertIsNotNone(cmd.stride_direction)
-        self.assertEqual(cmd.gait_type, MovementCommandConstants.GAIT_TRIPOD)  # Default gait
+    cmd = translator.movement_commands[-1]
+    # Check that stride direction reflects joystick input
+    assert cmd.stride_direction is not None
+    assert cmd.gait_type == MovementCommandConstants.GAIT_TRIPOD  # Default gait
 
-    def test_button_to_robot_event(self):
-        """Test that button presses generate robot events for state machine."""
-        # Wait for publisher/subscriber connection to be established
-        # This is necessary because DDS discovery in ROS 2 is asynchronous
-        max_wait_iterations = 10
-        for _ in range(max_wait_iterations):
-            if self.node.robot_event_pub.get_subscription_count() > 0:
-                break
-            rclpy.spin_once(self.node, timeout_sec=0.01)
-            rclpy.spin_once(self.test_node, timeout_sec=0.01)
 
-        # Create a joystick message with Select button pressed (finalize event)
-        joy_msg = sensor_msgs.msg.Joy()
-        joy_msg.axes = [0.0] * 6
-        joy_msg.buttons = [0] * 21
-        joy_msg.buttons[4] = 1  # Select button (index 4)
+def test_button_to_robot_event(translator):
+    """Test that button presses generate robot events for state machine."""
+    # Wait for publisher/subscriber connection to be established
+    # This is necessary because DDS discovery in ROS 2 is asynchronous
+    max_wait_iterations = 10
+    for _ in range(max_wait_iterations):
+        if translator.node.robot_event_pub.get_subscription_count() > 0:
+            break
+        rclpy.spin_once(translator.node, timeout_sec=0.01)
+        rclpy.spin_once(translator.test_node, timeout_sec=0.01)
 
-        # Process the message
-        self.node._joy_callback(joy_msg)
+    # Create a joystick message with Select button pressed (finalize event)
+    joy_msg = sensor_msgs.msg.Joy()
+    joy_msg.axes = [0.0] * 6
+    joy_msg.buttons = [0] * 21
+    joy_msg.buttons[4] = 1  # Select button (index 4)
 
-        # Spin multiple times to allow message propagation through DDS
-        # ROS 2 publishing is asynchronous and may require multiple event loop iterations
-        for _ in range(5):
-            rclpy.spin_once(self.node, timeout_sec=0.02)
-            rclpy.spin_once(self.test_node, timeout_sec=0.02)
-            if len(self.robot_events) > 0:
-                break
+    # Process the message
+    translator.node._joy_callback(joy_msg)
 
-        # Verify robot event was published
-        self.assertGreater(len(self.robot_events), 0, 'Robot event should be published')
+    # Spin multiple times to allow message propagation through DDS
+    # ROS 2 publishing is asynchronous and may require multiple event loop iterations
+    for _ in range(5):
+        rclpy.spin_once(translator.node, timeout_sec=0.02)
+        rclpy.spin_once(translator.test_node, timeout_sec=0.02)
+        if len(translator.robot_events) > 0:
+            break
 
-        event = self.robot_events[-1]
-        self.assertEqual(event.data, 'finalize')
+    # Verify robot event was published
+    assert len(translator.robot_events) > 0, 'Robot event should be published'
 
-    def test_dispatch_pending_feedback_publishes_without_subscriber_check(self):
-        """Due haptic commands should be published without gating on discovery."""
-        self.node.joy_feedback_pub.publish = Mock()
-        self.node._pending_feedback_commands = [Mock(due_at=0.0, channel_id=0, intensity=0.8)]
-        self.node.haptic_feedback_scheduler.now = Mock(return_value=0.0)
+    event = translator.robot_events[-1]
+    assert event.data == 'finalize'
 
-        self.node._dispatch_pending_feedback()
 
-        self.node.joy_feedback_pub.publish.assert_called_once()
-        self.assertEqual(self.node._pending_feedback_commands, [])
+def test_dispatch_pending_feedback_publishes_without_subscriber_check(translator):
+    """Due haptic commands should be published without gating on discovery."""
+    translator.node.joy_feedback_pub.publish = Mock()
+    translator.node._pending_feedback_commands = [
+        Mock(due_at=0.0, channel_id=0, intensity=0.8)
+    ]
+    translator.node.haptic_feedback_scheduler.now = Mock(return_value=0.0)
 
-    def test_haptic_feedback_is_published_on_joy_set_feedback(self):
-        """Gait changes should publish JoyFeedback messages on /joy/set_feedback."""
-        joy_msg = sensor_msgs.msg.Joy()
-        joy_msg.axes = [0.0] * 6
-        joy_msg.buttons = [0] * 21
-        joy_msg.buttons[14] = 1
+    translator.node._dispatch_pending_feedback()
 
-        self.node._joy_callback(joy_msg)
+    translator.node.joy_feedback_pub.publish.assert_called_once()
+    assert translator.node._pending_feedback_commands == []
 
-        for _ in range(10):
-            rclpy.spin_once(self.node, timeout_sec=0.02)
-            rclpy.spin_once(self.test_node, timeout_sec=0.02)
-            if self.joy_feedback_messages:
-                break
 
-        self.assertGreater(
-            len(self.joy_feedback_messages),
-            0,
-            'Joy feedback should be published',
-        )
-        feedback = self.joy_feedback_messages[0]
-        self.assertEqual(
-            feedback.type,
-            sensor_msgs.msg.JoyFeedback.TYPE_RUMBLE,
-        )
-        self.assertEqual(feedback.id, LEFT_RUMBLE_CHANNEL_ID)
-        self.assertGreater(feedback.intensity, 0.0)
+def test_haptic_feedback_is_published_on_joy_set_feedback(translator):
+    """Gait changes should publish JoyFeedback messages on /joy/set_feedback."""
+    joy_msg = sensor_msgs.msg.Joy()
+    joy_msg.axes = [0.0] * 6
+    joy_msg.buttons = [0] * 21
+    joy_msg.buttons[14] = 1
 
-    def test_replacing_pending_control_mode_feedback_starts_new_pattern_immediately(self):
-        """A newer mode change should interrupt stale queued feedback immediately."""
-        current_time = [100.0]
-        self.node.haptic_feedback_scheduler = HapticFeedbackScheduler(
-            clock=lambda: current_time[0]
-        )
+    translator.node._joy_callback(joy_msg)
 
-        self.node._publish_control_mode_change()
-        current_time[0] = 100.02
-        self.node._publish_control_mode_change()
+    for _ in range(10):
+        rclpy.spin_once(translator.node, timeout_sec=0.02)
+        rclpy.spin_once(translator.test_node, timeout_sec=0.02)
+        if translator.joy_feedback_messages:
+            break
 
-        pending = self.node._pending_feedback_commands
-        active_due_ats = [command.due_at for command in pending if command.intensity > 0.0]
+    assert len(translator.joy_feedback_messages) > 0, 'Joy feedback should be published'
+    feedback = translator.joy_feedback_messages[0]
+    assert feedback.type == sensor_msgs.msg.JoyFeedback.TYPE_RUMBLE
+    assert feedback.id == LEFT_RUMBLE_CHANNEL_ID
+    assert feedback.intensity > 0.0
 
-        self.assertEqual(len(pending), 19)
-        self.assertAlmostEqual(pending[0].due_at, 100.02, places=7)
-        self.assertEqual(pending[0].intensity, 0.0)
-        self.assertEqual(len(active_due_ats), 9)
-        self.assertAlmostEqual(active_due_ats[0], 100.02, places=7)
-        self.assertAlmostEqual(active_due_ats[1], 100.22, places=7)
-        self.assertAlmostEqual(active_due_ats[2], 100.42, places=7)
-        self.assertAlmostEqual(active_due_ats[-1], 102.02, places=7)
 
-    def test_dispatch_pending_feedback_publishes_interrupt_and_new_pulse_in_same_tick(self):
-        """Interrupting stale feedback should emit stop and replacement pulse together."""
-        current_time = [200.0]
-        self.node.haptic_feedback_scheduler = HapticFeedbackScheduler(
-            clock=lambda: current_time[0]
-        )
-        self.node.joy_feedback_pub.publish = Mock()
+def test_replacing_pending_control_mode_feedback_starts_new_pattern_immediately(translator):
+    """A newer mode change should interrupt stale queued feedback immediately."""
+    current_time = [100.0]
+    translator.node.haptic_feedback_scheduler = HapticFeedbackScheduler(
+        clock=lambda: current_time[0]
+    )
 
-        self.node._publish_control_mode_change()
-        current_time[0] = 200.02
-        self.node._publish_control_mode_change()
+    translator.node._publish_control_mode_change()
+    current_time[0] = 100.02
+    translator.node._publish_control_mode_change()
 
-        self.node._dispatch_pending_feedback()
+    pending = translator.node._pending_feedback_commands
+    active_due_ats = [command.due_at for command in pending if command.intensity > 0.0]
 
-        self.assertEqual(self.node.joy_feedback_pub.publish.call_count, 2)
+    assert len(pending) == 19
+    assert pending[0].due_at == pytest.approx(100.02, abs=1e-7)
+    assert pending[0].intensity == 0.0
+    assert len(active_due_ats) == 9
+    assert active_due_ats[0] == pytest.approx(100.02, abs=1e-7)
+    assert active_due_ats[1] == pytest.approx(100.22, abs=1e-7)
+    assert active_due_ats[2] == pytest.approx(100.42, abs=1e-7)
+    assert active_due_ats[-1] == pytest.approx(102.02, abs=1e-7)
 
-        stop_feedback = self.node.joy_feedback_pub.publish.call_args_list[0].args[0]
-        start_feedback = self.node.joy_feedback_pub.publish.call_args_list[1].args[0]
 
-        self.assertEqual(stop_feedback.id, RIGHT_RUMBLE_CHANNEL_ID)
-        self.assertEqual(stop_feedback.intensity, 0.0)
-        self.assertEqual(start_feedback.id, RIGHT_RUMBLE_CHANNEL_ID)
-        self.assertGreater(start_feedback.intensity, 0.0)
-        self.assertAlmostEqual(
-            self.node._pending_feedback_commands[0].due_at,
-            200.17,
-            places=7,
-        )
+def test_dispatch_pending_feedback_publishes_interrupt_and_new_pulse_in_same_tick(translator):
+    """Interrupting stale feedback should emit stop and replacement pulse together."""
+    current_time = [200.0]
+    translator.node.haptic_feedback_scheduler = HapticFeedbackScheduler(
+        clock=lambda: current_time[0]
+    )
+    translator.node.joy_feedback_pub.publish = Mock()
 
-    def test_control_mode_haptic_feedback_uses_working_rumble_channel(self):
-        """Control-mode changes should repeat the mapped pulse group 3 times."""
-        self.node._publish_control_mode_change()
+    translator.node._publish_control_mode_change()
+    current_time[0] = 200.02
+    translator.node._publish_control_mode_change()
 
-        for _ in range(90):
-            rclpy.spin_once(self.node, timeout_sec=0.02)
-            rclpy.spin_once(self.test_node, timeout_sec=0.02)
-            active_pulses = [
-                feedback for feedback in self.joy_feedback_messages if feedback.intensity > 0.0
-            ]
-            if len(active_pulses) >= 6:
-                break
+    translator.node._dispatch_pending_feedback()
 
-        self.assertGreater(
-            len(self.joy_feedback_messages),
-            0,
-            'Control-mode joy feedback should be published',
-        )
+    assert translator.node.joy_feedback_pub.publish.call_count == 2
+
+    stop_feedback = translator.node.joy_feedback_pub.publish.call_args_list[0].args[0]
+    start_feedback = translator.node.joy_feedback_pub.publish.call_args_list[1].args[0]
+
+    assert stop_feedback.id == RIGHT_RUMBLE_CHANNEL_ID
+    assert stop_feedback.intensity == 0.0
+    assert start_feedback.id == RIGHT_RUMBLE_CHANNEL_ID
+    assert start_feedback.intensity > 0.0
+    assert translator.node._pending_feedback_commands[0].due_at == pytest.approx(
+        200.17, abs=1e-7
+    )
+
+
+def test_control_mode_haptic_feedback_uses_working_rumble_channel(translator):
+    """Control-mode changes should repeat the mapped pulse group 3 times."""
+    translator.node._publish_control_mode_change()
+
+    for _ in range(90):
+        rclpy.spin_once(translator.node, timeout_sec=0.02)
+        rclpy.spin_once(translator.test_node, timeout_sec=0.02)
         active_pulses = [
-            feedback for feedback in self.joy_feedback_messages if feedback.intensity > 0.0
+            feedback for feedback in translator.joy_feedback_messages if feedback.intensity > 0.0
         ]
-        self.assertEqual(len(active_pulses), 6)
-        for feedback in active_pulses:
-            self.assertEqual(
-                feedback.type,
-                sensor_msgs.msg.JoyFeedback.TYPE_RUMBLE,
-            )
-            self.assertEqual(feedback.id, RIGHT_RUMBLE_CHANNEL_ID)
-            self.assertGreater(feedback.intensity, 0.0)
+        if len(active_pulses) >= 6:
+            break
 
-
-if __name__ == '__main__':
-    unittest.main()
+    assert len(translator.joy_feedback_messages) > 0, (
+        'Control-mode joy feedback should be published'
+    )
+    active_pulses = [
+        feedback for feedback in translator.joy_feedback_messages if feedback.intensity > 0.0
+    ]
+    assert len(active_pulses) == 6
+    for feedback in active_pulses:
+        assert feedback.type == sensor_msgs.msg.JoyFeedback.TYPE_RUMBLE
+        assert feedback.id == RIGHT_RUMBLE_CHANNEL_ID
+        assert feedback.intensity > 0.0

--- a/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
+++ b/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
@@ -140,9 +140,7 @@ def test_button_to_robot_event(translator):
 def test_dispatch_pending_feedback_publishes_without_subscriber_check(translator):
     """Due haptic commands should be published without gating on discovery."""
     translator.node.joy_feedback_pub.publish = Mock()
-    translator.node._pending_feedback_commands = [
-        Mock(due_at=0.0, channel_id=0, intensity=0.8)
-    ]
+    translator.node._pending_feedback_commands = [Mock(due_at=0.0, channel_id=0, intensity=0.8)]
     translator.node.haptic_feedback_scheduler.now = Mock(return_value=0.0)
 
     translator.node._dispatch_pending_feedback()
@@ -220,9 +218,7 @@ def test_dispatch_pending_feedback_publishes_interrupt_and_new_pulse_in_same_tic
     assert stop_feedback.intensity == 0.0
     assert start_feedback.id == RIGHT_RUMBLE_CHANNEL_ID
     assert start_feedback.intensity > 0.0
-    assert translator.node._pending_feedback_commands[0].due_at == pytest.approx(
-        200.17, abs=1e-7
-    )
+    assert translator.node._pending_feedback_commands[0].due_at == pytest.approx(200.17, abs=1e-7)
 
 
 def test_control_mode_haptic_feedback_uses_working_rumble_channel(translator):

--- a/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
+++ b/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
@@ -46,16 +46,6 @@ class _TranslatorHarness:
 
 
 @pytest.fixture
-def rclpy_context():
-    """Provide a ROS context for tests that construct ROS nodes directly."""
-    rclpy.init()
-    try:
-        yield
-    finally:
-        rclpy.try_shutdown()
-
-
-@pytest.fixture
 def translator(rclpy_context):  # noqa: ARG001 (needs rclpy)
     """Provide a joystick translator node wired to a consumer node."""
     node = JoystickTranslatorNode()

--- a/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
+++ b/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
@@ -21,6 +21,11 @@
 from dataclasses import dataclass, field
 from unittest.mock import Mock
 
+import pytest
+import rclpy
+import sensor_msgs.msg
+import std_msgs.msg
+
 from drqp_brain.haptics import (
     HapticFeedbackScheduler,
     LEFT_RUMBLE_CHANNEL_ID,
@@ -28,10 +33,6 @@ from drqp_brain.haptics import (
 )
 from drqp_brain.joystick_translator_node import JoystickTranslatorNode
 from drqp_interfaces.msg import MovementCommand, MovementCommandConstants
-import pytest
-import rclpy
-import sensor_msgs.msg
-import std_msgs.msg
 
 
 @dataclass
@@ -46,9 +47,18 @@ class _TranslatorHarness:
 
 
 @pytest.fixture
-def translator():
-    """Provide a joystick translator node wired to a consumer node."""
+def rclpy_context():
+    """Provide a ROS context for tests that construct ROS nodes directly."""
     rclpy.init()
+    try:
+        yield
+    finally:
+        rclpy.try_shutdown()
+
+
+@pytest.fixture
+def translator(rclpy_context):  # noqa: ARG001 (needs rclpy)
+    """Provide a joystick translator node wired to a consumer node."""
     node = JoystickTranslatorNode()
     test_node = rclpy.create_node('test_translator_consumer')
     harness = _TranslatorHarness(node=node, test_node=test_node)
@@ -77,7 +87,6 @@ def translator():
     finally:
         test_node.destroy_node()
         node.destroy_node()
-        rclpy.try_shutdown()
 
 
 def test_joystick_to_movement_command(translator):

--- a/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
+++ b/packages/runtime/drqp_brain/test/test_joystick_translator_node.py
@@ -21,11 +21,6 @@
 from dataclasses import dataclass, field
 from unittest.mock import Mock
 
-import pytest
-import rclpy
-import sensor_msgs.msg
-import std_msgs.msg
-
 from drqp_brain.haptics import (
     HapticFeedbackScheduler,
     LEFT_RUMBLE_CHANNEL_ID,
@@ -33,6 +28,10 @@ from drqp_brain.haptics import (
 )
 from drqp_brain.joystick_translator_node import JoystickTranslatorNode
 from drqp_interfaces.msg import MovementCommand, MovementCommandConstants
+import pytest
+import rclpy
+import sensor_msgs.msg
+import std_msgs.msg
 
 
 @dataclass

--- a/packages/runtime/drqp_brain/test/test_timed_queue.py
+++ b/packages/runtime/drqp_brain/test/test_timed_queue.py
@@ -24,15 +24,13 @@ import rclpy
 
 
 @pytest.fixture
-def timed_queue():
+def timed_queue(rclpy_context):  # noqa: ARG001 (needs rclpy)
     """Provide a TimedQueue backed by a freshly initialized rclpy node."""
-    rclpy.init()
     node = rclpy.create_node('test_timed_queue')
     try:
         yield TimedQueue(node)
     finally:
         node.destroy_node()
-        rclpy.try_shutdown()
 
 
 def test_added_action_is_executed_immediately(timed_queue):

--- a/packages/runtime/drqp_brain/test/test_timed_queue.py
+++ b/packages/runtime/drqp_brain/test/test_timed_queue.py
@@ -18,10 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from drqp_brain.timed_queue import TimedQueue
 import pytest
 import rclpy
-
-from drqp_brain.timed_queue import TimedQueue
 
 
 @pytest.fixture

--- a/packages/runtime/drqp_brain/test/test_timed_queue.py
+++ b/packages/runtime/drqp_brain/test/test_timed_queue.py
@@ -18,9 +18,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from drqp_brain.timed_queue import TimedQueue
 import pytest
 import rclpy
+
+from drqp_brain.timed_queue import TimedQueue
 
 
 @pytest.fixture

--- a/packages/runtime/drqp_brain/test/test_timed_queue.py
+++ b/packages/runtime/drqp_brain/test/test_timed_queue.py
@@ -18,83 +18,78 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import unittest
-
 from drqp_brain.timed_queue import TimedQueue
+import pytest
 import rclpy
 
 
-class TestTimedQueue(unittest.TestCase):
-    """Test the TimedQueue class."""
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        rclpy.init()
-
-    @classmethod
-    def tearDownClass(cls):
+@pytest.fixture
+def timed_queue():
+    """Provide a TimedQueue backed by a freshly initialized rclpy node."""
+    rclpy.init()
+    node = rclpy.create_node('test_timed_queue')
+    try:
+        yield TimedQueue(node)
+    finally:
+        node.destroy_node()
         rclpy.try_shutdown()
-        super().tearDownClass()
 
-    def setUp(self) -> None:
-        node = rclpy.create_node('test_timed_queue')
-        self.addCleanup(node.destroy_node)
-        self.timed_queue = TimedQueue(node)
 
-    def test_added_action_is_executed_immediately(self):
-        """Check whether actions are executed immediately."""
-        executed = False
+def test_added_action_is_executed_immediately(timed_queue):
+    """Check whether actions are executed immediately."""
+    executed = False
 
-        def action():
-            nonlocal executed
-            executed = True
+    def action():
+        nonlocal executed
+        executed = True
 
-        self.timed_queue.add(0.1, action)
-        rclpy.spin_once(self.timed_queue.node, timeout_sec=0.1)
-        self.assertTrue(executed)
+    timed_queue.add(0.1, action)
+    rclpy.spin_once(timed_queue.node, timeout_sec=0.1)
+    assert executed
 
-    def test_next_added_action_is_executed_after_delay(self):
-        """Check whether actions are executed after the delay."""
-        executed1 = False
-        executed2 = False
 
-        def action1():
-            nonlocal executed1
-            executed1 = True
+def test_next_added_action_is_executed_after_delay(timed_queue):
+    """Check whether actions are executed after the delay."""
+    executed1 = False
+    executed2 = False
 
-        def action2():
-            nonlocal executed2
-            executed2 = True
+    def action1():
+        nonlocal executed1
+        executed1 = True
 
-        self.timed_queue.add(0.2, action1)
-        self.timed_queue.add(0.2, action2)
-        rclpy.spin_once(self.timed_queue.node, timeout_sec=0.05)
-        self.assertTrue(executed1)
-        self.assertFalse(executed2)
+    def action2():
+        nonlocal executed2
+        executed2 = True
 
-        while self.timed_queue.timer is not None:
-            rclpy.spin_once(self.timed_queue.node, timeout_sec=0.05)
-        self.assertTrue(executed2)
+    timed_queue.add(0.2, action1)
+    timed_queue.add(0.2, action2)
+    rclpy.spin_once(timed_queue.node, timeout_sec=0.05)
+    assert executed1
+    assert not executed2
 
-    def test_clear(self):
-        """Check whether the queue is cleared."""
-        executed1 = False
-        executed2 = False
+    while timed_queue.timer is not None:
+        rclpy.spin_once(timed_queue.node, timeout_sec=0.05)
+    assert executed2
 
-        def action1():
-            nonlocal executed1
-            executed1 = True
 
-        def action2():
-            nonlocal executed2
-            executed2 = True
+def test_clear(timed_queue):
+    """Check whether the queue is cleared."""
+    executed1 = False
+    executed2 = False
 
-        self.timed_queue.add(0.01, action1)
-        self.timed_queue.add(0.01, action2)
-        self.timed_queue.clear()
-        rclpy.spin_once(self.timed_queue.node, timeout_sec=0.05)
-        self.assertFalse(executed2)
+    def action1():
+        nonlocal executed1
+        executed1 = True
 
-        self.assertIsNone(self.timed_queue.timer)
-        self.assertEqual(len(self.timed_queue.queue), 0)
+    def action2():
+        nonlocal executed2
+        executed2 = True
+
+    timed_queue.add(0.01, action1)
+    timed_queue.add(0.01, action2)
+    timed_queue.clear()
+    rclpy.spin_once(timed_queue.node, timeout_sec=0.05)
+    assert not executed2
+
+    assert timed_queue.timer is None
+    assert len(timed_queue.queue) == 0


### PR DESCRIPTION
# Summary

Migrates all four `drqp_brain` unit test files from `unittest.TestCase` to idiomatic pytest — standalone functions, `@pytest.fixture` setup/teardown, and `assert` statements. No production code was changed.

## What Changed

- **Test structure**: Replaced `TestCase` classes and `setUp`/`setUpClass`/`tearDownClass` methods with module-level `@pytest.fixture` functions that initialize and clean up ROS contexts, nodes, and subscriptions.
- **Assertion style**: Replaced all `self.assert*` / `self.assertEqual` calls with plain `assert` statements; float comparisons use `pytest.approx` instead of `assertAlmostEqual`.
- **Harness dataclasses**: Introduced `_ImuHarness` and `_TranslatorHarness` dataclasses to bundle the node under test, a consumer node, and captured message lists — replaces instance variables set in `setUp`.
- **ROS lifecycle**: `rclpy.init` / `rclpy.try_shutdown` are now scoped to individual fixtures using `try/finally`, which isolates each test's ROS context and prevents state leakage between tests.

Files changed: `test_haptics.py`, `test_imu_node.py`, `test_joystick_translator_node.py`, `test_timed_queue.py`.

## Why

pytest is the project's standard test runner (as established in the preceding launch-test migration). Keeping `unittest.TestCase` in the same package created inconsistency and prevented pytest fixtures from being shared or composed across test modules. The migration also removes boilerplate (`if __name__ == '__main__': unittest.main()`) and makes failure output more readable.

## How to Test

```bash
scripts/with-ros-env.sh colcon test --packages-select drqp_brain --symlink-install
scripts/with-ros-env.sh colcon test-result --verbose
```

All 22 tests that existed before this change continue to pass; no tests were added or removed.

## Breaking Changes

- None.

## Migration

- None.