### PR TITLE
Integrate cc-filter security layer for Claude Code via Ansible

### DIFF
--- a/docker/ros/ansible/playbooks/roles/agentic_tools/README.md
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/README.md
@@ -45,8 +45,8 @@ These variables are not defined by this role and must be supplied by the
 playbook or inventory (the `extra_facts` and `ros_user_setup` roles provide them
 in this repository):
 
-| Variable                                | Description                                                      |
-| --------------------------------------- | ---------------------------------------------------------------- |
-| `system_arch`                                | Target CPU architecture (`amd64` or `arm64`) for the binary URL.       |
-| `user_home`                                  | Home directory of the target user (locates `~/.claude/settings.json`). |
-| `ros_user_setup_uid` / `ros_user_setup_gid`  | UID/GID used for ownership of the Claude config files.                 |
+| Variable                                    | Description                                                            |
+| ------------------------------------------- | ---------------------------------------------------------------------- |
+| `system_arch`                               | Target CPU architecture (`amd64` or `arm64`) for the binary URL.       |
+| `user_home`                                 | Home directory of the target user (locates `~/.claude/settings.json`). |
+| `ros_user_setup_uid` / `ros_user_setup_gid` | UID/GID used for ownership of the Claude config files.                 |

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/README.md
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/README.md
@@ -1,0 +1,34 @@
+# Agentic Tools Role
+
+Installs the agentic CLI tooling used in the workspace and the security layer
+that guards it:
+
+- **Bun-managed globals**: `@modelcontextprotocol/inspector`, `@github/copilot`,
+  and `@anthropic-ai/claude-code`.
+- **[cc-filter](https://github.com/wissem/cc-filter)**: a hard security layer in
+  front of Claude Code hooks. It blocks sensitive file access, blocks risky
+  shell/search commands, and redacts secrets. The role downloads the
+  architecture-appropriate release binary and wires it into the user's Claude
+  Code hooks (`~/.claude/settings.json`).
+
+Gated by `install_agentic_tools` in the playbook.
+
+## Example Usage
+
+```yaml
+- name: Install agentic tools
+  hosts: all
+  become: true
+  roles:
+    - { role: agentic_tools, tags: ["agentic_tools"], when: install_agentic_tools | default(false) | bool }
+```
+
+## Variables
+
+| Variable                     | Default                     | Description                                       |
+| ---------------------------- | --------------------------- | ------------------------------------------------- |
+| `cc_filter_install`          | `true`                      | Install the cc-filter binary.                     |
+| `cc_filter_version`          | `v0.0.6`                    | cc-filter release tag to download.                |
+| `cc_filter_install_path`     | `/usr/local/bin/cc-filter`  | Destination for the cc-filter binary.             |
+| `cc_filter_configure_hooks`  | `true`                      | Merge cc-filter hooks into Claude `settings.json`. |
+| `cc_filter_download_url`     | derived from version/arch   | Override to pin a custom binary URL.              |

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/README.md
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/README.md
@@ -34,5 +34,19 @@ Gated by `install_agentic_tools` in the playbook.
 | `cc_filter_install`         | `true`                     | Install the cc-filter binary.                      |
 | `cc_filter_version`         | `v0.0.6`                   | cc-filter release tag to download.                 |
 | `cc_filter_install_path`    | `/usr/local/bin/cc-filter` | Destination for the cc-filter binary.              |
+| `cc_filter_binary_mode`     | `"0755"`                   | File mode for the installed binary.                |
+| `cc_filter_checksums`       | per-arch sha256 map        | Expected binary checksums; bump with the version.  |
 | `cc_filter_configure_hooks` | `true`                     | Merge cc-filter hooks into Claude `settings.json`. |
 | `cc_filter_download_url`    | derived from version/arch  | Override to pin a custom binary URL.               |
+
+## Required External Variables
+
+These variables are not defined by this role and must be supplied by the
+playbook or inventory (the `extra_facts` and `ros_user_setup` roles provide them
+in this repository):
+
+| Variable                                | Description                                                      |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| `system_arch`                                | Target CPU architecture (`amd64` or `arm64`) for the binary URL.       |
+| `user_home`                                  | Home directory of the target user (locates `~/.claude/settings.json`). |
+| `ros_user_setup_uid` / `ros_user_setup_gid`  | UID/GID used for ownership of the Claude config files.                 |

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/README.md
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/README.md
@@ -20,15 +20,19 @@ Gated by `install_agentic_tools` in the playbook.
   hosts: all
   become: true
   roles:
-    - { role: agentic_tools, tags: ["agentic_tools"], when: install_agentic_tools | default(false) | bool }
+    - {
+        role: agentic_tools,
+        tags: ['agentic_tools'],
+        when: install_agentic_tools | default(false) | bool,
+      }
 ```
 
 ## Variables
 
-| Variable                     | Default                     | Description                                       |
-| ---------------------------- | --------------------------- | ------------------------------------------------- |
-| `cc_filter_install`          | `true`                      | Install the cc-filter binary.                     |
-| `cc_filter_version`          | `v0.0.6`                    | cc-filter release tag to download.                |
-| `cc_filter_install_path`     | `/usr/local/bin/cc-filter`  | Destination for the cc-filter binary.             |
-| `cc_filter_configure_hooks`  | `true`                      | Merge cc-filter hooks into Claude `settings.json`. |
-| `cc_filter_download_url`     | derived from version/arch   | Override to pin a custom binary URL.              |
+| Variable                    | Default                    | Description                                        |
+| --------------------------- | -------------------------- | -------------------------------------------------- |
+| `cc_filter_install`         | `true`                     | Install the cc-filter binary.                      |
+| `cc_filter_version`         | `v0.0.6`                   | cc-filter release tag to download.                 |
+| `cc_filter_install_path`    | `/usr/local/bin/cc-filter` | Destination for the cc-filter binary.              |
+| `cc_filter_configure_hooks` | `true`                     | Merge cc-filter hooks into Claude `settings.json`. |
+| `cc_filter_download_url`    | derived from version/arch  | Override to pin a custom binary URL.               |

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/defaults/main.yml
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/defaults/main.yml
@@ -8,6 +8,13 @@ cc_filter_binary_mode: "0755"
 cc_filter_download_url: >-
   https://github.com/wissem/cc-filter/releases/download/{{ cc_filter_version }}/cc-filter-linux-{{ system_arch }}
 
+# SHA-256 checksums of the release binaries, keyed by architecture. Bump
+# alongside cc_filter_version so a compromised or tag-floated asset is rejected.
+cc_filter_checksums:
+  amd64: sha256:5c9dbfa6cc24027277661a0fe17fca130fdb5d2bd46ac1474bdaa843c38cf308
+  arm64: sha256:2eeb50a337123b5f897070a3f0604c79fa48a54acdd1f6eb77878cf9ea14d236
+cc_filter_checksum: "{{ cc_filter_checksums[system_arch] }}"
+
 # Wire cc-filter into the user's Claude Code hooks (settings.json).
 cc_filter_configure_hooks: true
 cc_filter_claude_settings_path: "{{ user_home }}/.claude/settings.json"

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/defaults/main.yml
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# cc-filter: security layer in front of Claude Code hooks.
+# https://github.com/wissem/cc-filter
+cc_filter_install: true
+cc_filter_version: v0.0.6
+cc_filter_install_path: /usr/local/bin/cc-filter
+cc_filter_binary_mode: "0755"
+cc_filter_download_url: >-
+  https://github.com/wissem/cc-filter/releases/download/{{ cc_filter_version }}/cc-filter-linux-{{ system_arch }}
+
+# Wire cc-filter into the user's Claude Code hooks (settings.json).
+cc_filter_configure_hooks: true
+cc_filter_claude_settings_path: "{{ user_home }}/.claude/settings.json"

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/cc_filter.yml
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/cc_filter.yml
@@ -12,6 +12,7 @@
   ansible.builtin.get_url:
     url: "{{ cc_filter_download_url }}"
     dest: "{{ cc_filter_install_path }}"
+    checksum: "{{ cc_filter_checksum }}"
     owner: root
     group: root
     mode: "{{ cc_filter_binary_mode }}"
@@ -27,17 +28,31 @@
         group: "{{ ros_user_setup_gid }}"
         mode: "0755"
 
+    - name: Stat existing Claude settings
+      ansible.builtin.stat:
+        path: "{{ cc_filter_claude_settings_path }}"
+      register: cc_filter_settings_stat
+
     - name: Read existing Claude settings
       ansible.builtin.slurp:
         src: "{{ cc_filter_claude_settings_path }}"
       register: cc_filter_existing_settings
-      failed_when: false
+      when: cc_filter_settings_stat.stat.exists
+
+    - name: Warn when existing hooks will be replaced
+      ansible.builtin.debug:
+        msg: >-
+          Existing Claude settings already define a 'hooks' key; cc-filter will
+          replace the PreToolUse, UserPromptSubmit, and SessionEnd entries.
+      when:
+        - cc_filter_existing_settings.content is defined
+        - "'hooks' in (cc_filter_existing_settings.content | b64decode | trim | default('{}', true) | from_json)"
 
     - name: Merge cc-filter hooks into Claude settings
       ansible.builtin.copy:
         content: >-
           {{
-            (cc_filter_existing_settings.content | default('') | b64decode | from_json
+            (cc_filter_existing_settings.content | b64decode | trim | default('{}', true) | from_json
              if cc_filter_existing_settings.content is defined
              else {})
             | combine({'hooks': cc_filter_hooks}, recursive=true)

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/cc_filter.yml
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/cc_filter.yml
@@ -1,0 +1,62 @@
+---
+# Install and configure cc-filter, a security layer in front of Claude Code hooks.
+# https://github.com/wissem/cc-filter
+- name: Fail when cc-filter architecture is unsupported
+  ansible.builtin.fail:
+    msg: >-
+      Unsupported architecture '{{ system_arch }}' for cc-filter. Set
+      cc_filter_download_url to a compatible binary URL.
+  when: system_arch not in ["amd64", "arm64"]
+
+- name: Download cc-filter binary
+  ansible.builtin.get_url:
+    url: "{{ cc_filter_download_url }}"
+    dest: "{{ cc_filter_install_path }}"
+    owner: root
+    group: root
+    mode: "{{ cc_filter_binary_mode }}"
+
+- name: Configure Claude Code hooks for cc-filter
+  when: cc_filter_configure_hooks | bool
+  block:
+    - name: Ensure Claude config directory exists
+      ansible.builtin.file:
+        path: "{{ cc_filter_claude_settings_path | dirname }}"
+        state: directory
+        owner: "{{ ros_user_setup_uid }}"
+        group: "{{ ros_user_setup_gid }}"
+        mode: "0755"
+
+    - name: Read existing Claude settings
+      ansible.builtin.slurp:
+        src: "{{ cc_filter_claude_settings_path }}"
+      register: cc_filter_existing_settings
+      failed_when: false
+
+    - name: Merge cc-filter hooks into Claude settings
+      ansible.builtin.copy:
+        content: >-
+          {{
+            (cc_filter_existing_settings.content | default('') | b64decode | from_json
+             if cc_filter_existing_settings.content is defined
+             else {})
+            | combine({'hooks': cc_filter_hooks}, recursive=true)
+            | to_nice_json
+          }}
+        dest: "{{ cc_filter_claude_settings_path }}"
+        owner: "{{ ros_user_setup_uid }}"
+        group: "{{ ros_user_setup_gid }}"
+        mode: "0644"
+  vars:
+    cc_filter_hook: # noqa: var-naming[no-role-prefix]
+      - hooks:
+          - type: command
+            command: "{{ cc_filter_install_path }}"
+    cc_filter_hooks: # noqa: var-naming[no-role-prefix]
+      PreToolUse:
+        - matcher: "*"
+          hooks:
+            - type: command
+              command: "{{ cc_filter_install_path }}"
+      UserPromptSubmit: "{{ cc_filter_hook }}"
+      SessionEnd: "{{ cc_filter_hook }}"

--- a/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/main.yml
+++ b/docker/ros/ansible/playbooks/roles/agentic_tools/tasks/main.yml
@@ -18,3 +18,7 @@
       bin: claude
   loop_control:
     label: "{{ item.package }}"
+
+- name: Install cc-filter security layer for Claude Code
+  ansible.builtin.import_tasks: cc_filter.yml
+  when: cc_filter_install | bool


### PR DESCRIPTION
## Summary

Integrates [cc-filter](https://github.com/wissem/cc-filter) — a Go security layer that sits in front of Claude Code's hooks — into the workspace's Ansible provisioning. cc-filter blocks sensitive file access (`.env`, certs, secrets), blocks risky shell/search commands, and redacts secrets from text.

The integration lives in the existing `agentic_tools` role, which is where Claude Code (`@anthropic-ai/claude-code`) is already installed, so the security layer is provisioned alongside the tool it guards and shares the same `install_agentic_tools` gate.

## Changes

- **`tasks/cc_filter.yml`** (new):
  - Downloads the architecture-appropriate release binary (`cc-filter-linux-amd64` / `cc-filter-linux-arm64`, selected via the existing `system_arch` fact) to `/usr/local/bin/cc-filter`.
  - Fails fast on unsupported architectures.
  - Merges cc-filter hooks (`PreToolUse` with `*` matcher, `UserPromptSubmit`, `SessionEnd`) into the user's `~/.claude/settings.json`. Existing settings are slurped and recursively combined, so the task is idempotent and preserves unrelated settings.
- **`tasks/main.yml`**: imports the new task file after the Bun global installs, gated by `cc_filter_install`.
- **`defaults/main.yml`** (new): pins `cc_filter_version` to `v0.0.6` (latest release) for reproducible provisioning, plus install path, derived download URL, and the `cc_filter_install` / `cc_filter_configure_hooks` toggles.
- **`README.md`** (new): documents the role and the cc-filter variables.

## Testing

- Validated YAML syntax of the new/changed task and defaults files with `yaml.safe_load`.
- `ansible-lint` is not available in the provisioning container, so a full lint pass was not run.

## Notes

- The version is **pinned** (`v0.0.6`) rather than tracking `latest` for reproducibility — bump `cc_filter_version` to upgrade.
- Hook configuration defaults to **on** so cc-filter actively guards Claude Code; set `cc_filter_configure_hooks: false` to install the binary only.
- The recursive merge replaces the `PreToolUse` / `UserPromptSubmit` / `SessionEnd` lists, overriding any pre-existing hooks under those keys — acceptable for fresh-container provisioning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbKdY35yTnRx7Y1G57v4Ah)_