### PR TITLE
Claude code review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -84,12 +84,13 @@ jobs:
 
         # Automated review when a PR is opened/reopened: always run the pr-review skill.
       - name: Claude PR Review
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude review'))
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Trigger when specific user is assigned to an issue
           assignee_trigger: 'claude-bot'
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -107,6 +108,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Trigger when specific user is assigned to an issue
           assignee_trigger: 'claude-bot'
+          show_full_output: true
 
       - name: Log debug stats
         if: ${{ always() }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -97,6 +97,10 @@ jobs:
 
             Use the pr-review skill to review this pull request
 
+          claude_args: >-
+            --allowedTools
+            "Skill,mcp__github__add_comment_to_pending_review,mcp__github__pull_request_review_write,Bash(gh pr diff:*),Bash(gh pr view:*)"
+
       # Comment/mention-driven requests (issue_comment, pull_request_review_comment,
       # pull_request_review, issues): no fixed prompt, so Claude responds to whatever
       # was actually asked in the comment. It can invoke the pr-review skill itself


### PR DESCRIPTION
This pull request updates the `claude-review.yml` GitHub Actions workflow to improve how Claude automated reviews are triggered and to enhance the output and control of the review process. The most important changes are:

**Workflow trigger improvements:**

* The "Claude PR Review" job now also triggers when a pull request review comment contains `@claude review`, in addition to when a pull request is opened or reopened. This allows manual review requests via comments.

**Claude action configuration enhancements:**

* The Claude action now includes the `show_full_output: true` parameter, ensuring that the full output from Claude is shown for both the PR review and assignee-triggered review jobs. [[1]](diffhunk://#diff-a16b9cfdaf9b59acd95f3f8af7be93c559d14c7e581e809acdc53106fb73971eL87-R103) [[2]](diffhunk://#diff-a16b9cfdaf9b59acd95f3f8af7be93c559d14c7e581e809acdc53106fb73971eR115)
* The `claude_args` parameter is added to restrict the allowed tools Claude can use during the review, improving security and predictability.