### PR TITLE
Fix Claude review workflow: ROS container runner, quoting, and duplicate-run guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,11 +27,6 @@
       "/opt/ros/overlay_ws"
     ]
   },
-  "allowedMcpServers": [
-    {
-      "serverName": "gateway"
-    }
-  ],
   "hooks": {
     "SessionStart": [
       {

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  CLAUDE_PR_REVIEW_ARGS: "Skill,Agent(general-purpose),ToolSearch,mcp__github__add_comment_to_pending_review,mcp__github__pull_request_review_write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/*/pulls/*/reviews:*),Bash(gh api repos/*/pulls/*/reviews/*:*),Bash(gh api repos/*/pulls/*/comments:*)"
+  CLAUDE_PR_REVIEW_ARGS: "Skill,Agent(general-purpose),ToolSearch,mcp__github__add_comment_to_pending_review,mcp__github__pull_request_review_write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/*/pulls/*/reviews:*),Bash(gh api repos/*/pulls/*/reviews/*:*),Bash(gh api repos/*/pulls/*/comments:*),Bash(git *),Bash(gh auth status:*)"
 
 jobs:
   review:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -100,7 +100,7 @@ jobs:
             Use the pr-review skill to review this pull request
 
           claude_args: >-
-            --allowedTools ${{ env.CLAUDE_PR_REVIEW_ARGS }}
+            --allowedTools '${{ env.CLAUDE_PR_REVIEW_ARGS }}'
 
 
       # Comment/mention-driven requests (issue_comment, pull_request_review_comment,
@@ -116,7 +116,7 @@ jobs:
           assignee_trigger: 'claude-bot'
           show_full_output: true
           claude_args: >-
-            --allowedTools "${{ env.CLAUDE_PR_REVIEW_ARGS }},Bash(gh api repos/*/issues/comments/*:*)"
+            --allowedTools '${{ env.CLAUDE_PR_REVIEW_ARGS }},Bash(gh api repos/*/issues/comments/*:*)'
 
       - name: Log debug stats
         if: ${{ always() }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -85,6 +85,7 @@ jobs:
 
         # Automated review when a PR is opened/reopened: always run the pr-review skill.
       - name: Claude PR Review
+        id: claude_pr_review
         if: github.event_name == 'pull_request' || contains(github.event.comment.body, '@claude review')
         uses: anthropics/claude-code-action@v1
         with:
@@ -107,7 +108,7 @@ jobs:
       # was actually asked in the comment. It can invoke the pr-review skill itself
       # if the request is a review.
       - name: Claude Code Respond
-        if: ${{ github.event_name != 'pull_request' }}
+        if: steps.claude_pr_review.outcome == 'skipped'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,7 +38,9 @@ jobs:
         (github.event_name == 'pull_request')
       )
     name: Claude Responder
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AMD_ONLY == '1' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    container:
+      image: ghcr.io/dr-qp/jazzy-ros-desktop:edge
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
# Summary

Fixes the Claude PR review GitHub Action so it actually has the tools and runtime it needs: it now runs in the ROS container image (on ARM or AMD runners), gets `git`/`gh auth status` access and properly quoted `allowedTools`, and no longer double-runs the respond step after a review already ran. Also drops an MCP server restriction in `.claude/settings.json` that was blocking local Claude Code sessions from using needed servers.

## What Changed

- **Review runner environment**: `claude-review.yml` now runs the `Claude Responder` job inside the `ghcr.io/dr-qp/jazzy-ros-desktop:edge` container, on `ubuntu-24.04-arm` by default (or `ubuntu-24.04` when the `AMD_ONLY` repo variable is set), so the review agent has the same ROS toolchain available as the rest of CI.
- **Review tool access**: added `Bash(git *)` and `Bash(gh auth status:*)` to `CLAUDE_PR_REVIEW_ARGS` so the review skill can inspect repo state and verify GitHub auth.
- **Quoting fix**: wrapped `--allowedTools ${{ env.CLAUDE_PR_REVIEW_ARGS }}` in single quotes in both the `Claude PR Review` and `Claude Code Respond` steps so the comma/parenthesis-heavy tool list is passed through as one shell argument instead of being split.
- **Avoid duplicate runs**: the `Claude PR Review` step now sets `id: claude_pr_review`, and `Claude Code Respond` only runs `if: steps.claude_pr_review.outcome == 'skipped'`, instead of the previous `github.event_name != 'pull_request'` check — this prevents both steps from running for the same PR-opened event.
- **Local settings**: removed the `allowedMcpServers` restriction (limited to the `gateway` server) from `.claude/settings.json`, since it was blocking access to other configured MCP servers during local sessions.

## Why

The review workflow was failing/misbehaving because the runner lacked the ROS-specific tooling the `pr-review` skill relies on, the unquoted `allowedTools` string was being word-split by the shell, and the old `if` condition could trigger both the dedicated PR-review step and the generic respond step for the same event.

## How to Test

- Reviewed the workflow diff and confirmed the `if` conditions are mutually exclusive per job run.
- No automated tests apply to workflow YAML or local `.claude/settings.json`; verification is via the next PR triggering this workflow on GitHub Actions.

## Breaking Changes

- None.

## Migration

- None.

## Related

- None.
