### PR TITLE
Add native super-linter tooling to the devcontainer

### DIFF
--- a/docker/ros/ansible/playbooks/20_ros_setup.yml
+++ b/docker/ros/ansible/playbooks/20_ros_setup.yml
@@ -29,6 +29,7 @@
     - { role: bun_setup, tags: ["bun_setup", "nodejs", "agentic_tools"] }
     - { role: nodejs, tags: ["nodejs"] }
     - { role: uv_setup, tags: ["uv_setup"] }
+    - { role: super_linter_tools, tags: ["super_linter_tools", "lint_tools"] }
     - { role: agentic_tools, tags: ["agentic_tools"], when: install_agentic_tools | default(false) | bool }
     - { role: virtualhere_usb_client, tags: ["virtualhere_usb_client"], when: install_virtualhere_usb_client | default(false) | bool }
     - { role: cmake_kitware, tags: ["cmake"] }

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/README.md
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/README.md
@@ -1,0 +1,13 @@
+# Super Linter Tools Role
+
+Installs the linter toolchain used by this repository's local super-linter wrapper:
+
+- prettier (Node/Bun global package)
+- shellcheck
+- hadolint
+- actionlint
+- zizmor
+- gitleaks
+
+The role is designed for amd64 and arm64 and is invoked from
+`docker/ros/ansible/playbooks/20_ros_setup.yml`.

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/README.md
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/README.md
@@ -3,7 +3,7 @@
 Installs the linter toolchain used by this repository's local super-linter wrapper:
 
 - prettier (Node/Bun global package)
-- shellcheck
+- shellcheck (from distro apt; not version-pinned in this role)
 - hadolint
 - actionlint
 - zizmor

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/defaults/main.yml
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/defaults/main.yml
@@ -10,14 +10,26 @@ super_linter_tools_gitleaks_version: "8.24.3"
 super_linter_tools_hadolint_checksums:
   amd64: "sha256:56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010"
   arm64: "sha256:5798551bf19f33951881f15eb238f90aef023f11e7ec7e9f4c37961cb87c5df6"
+super_linter_tools_hadolint_assets:
+  amd64: hadolint-Linux-x86_64
+  arm64: hadolint-Linux-arm64
+super_linter_tools_hadolint_asset: "{{ super_linter_tools_hadolint_assets[system_arch] }}"
 super_linter_tools_hadolint_checksum: "{{ super_linter_tools_hadolint_checksums[system_arch] }}"
 
 super_linter_tools_actionlint_checksums:
   amd64: "sha256:023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
   arm64: "sha256:401942f9c24ed71e4fe71b76c7d638f66d8633575c4016efd2977ce7c28317d0"
+super_linter_tools_actionlint_assets:
+  amd64: "actionlint_{{ super_linter_tools_actionlint_version }}_linux_amd64.tar.gz"
+  arm64: "actionlint_{{ super_linter_tools_actionlint_version }}_linux_arm64.tar.gz"
+super_linter_tools_actionlint_asset: "{{ super_linter_tools_actionlint_assets[system_arch] }}"
 super_linter_tools_actionlint_checksum: "{{ super_linter_tools_actionlint_checksums[system_arch] }}"
 
 super_linter_tools_gitleaks_checksums:
   amd64: "sha256:9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c"
   arm64: "sha256:5f2edbe1f49f7b920f9e06e90759947d3c5dfc16f752fb93aaafc17e9d14cf07"
+super_linter_tools_gitleaks_assets:
+  amd64: "gitleaks_{{ super_linter_tools_gitleaks_version }}_linux_x64.tar.gz"
+  arm64: "gitleaks_{{ super_linter_tools_gitleaks_version }}_linux_arm64.tar.gz"
+super_linter_tools_gitleaks_asset: "{{ super_linter_tools_gitleaks_assets[system_arch] }}"
 super_linter_tools_gitleaks_checksum: "{{ super_linter_tools_gitleaks_checksums[system_arch] }}"

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/defaults/main.yml
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Pinned tool versions used by scripts/super-linter-local.sh native mode.
+super_linter_tools_prettier_version: "3.6.2"
+super_linter_tools_zizmor_version: "1.26.1"
+super_linter_tools_hadolint_version: "v2.12.0"
+super_linter_tools_actionlint_version: "1.7.7"
+super_linter_tools_gitleaks_version: "8.24.3"

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/defaults/main.yml
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/defaults/main.yml
@@ -1,7 +1,23 @@
 ---
-# Pinned tool versions used by scripts/super-linter-local.sh native mode.
+# Pinned versions and checksums for tools installed outside apt in native mode.
+# shellcheck is installed from the distro apt repository and is not version-pinned here.
 super_linter_tools_prettier_version: "3.6.2"
 super_linter_tools_zizmor_version: "1.26.1"
 super_linter_tools_hadolint_version: "v2.12.0"
 super_linter_tools_actionlint_version: "1.7.7"
 super_linter_tools_gitleaks_version: "8.24.3"
+
+super_linter_tools_hadolint_checksums:
+  amd64: "sha256:56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010"
+  arm64: "sha256:5798551bf19f33951881f15eb238f90aef023f11e7ec7e9f4c37961cb87c5df6"
+super_linter_tools_hadolint_checksum: "{{ super_linter_tools_hadolint_checksums[system_arch] }}"
+
+super_linter_tools_actionlint_checksums:
+  amd64: "sha256:023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
+  arm64: "sha256:401942f9c24ed71e4fe71b76c7d638f66d8633575c4016efd2977ce7c28317d0"
+super_linter_tools_actionlint_checksum: "{{ super_linter_tools_actionlint_checksums[system_arch] }}"
+
+super_linter_tools_gitleaks_checksums:
+  amd64: "sha256:9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c"
+  arm64: "sha256:5f2edbe1f49f7b920f9e06e90759947d3c5dfc16f752fb93aaafc17e9d14cf07"
+super_linter_tools_gitleaks_checksum: "{{ super_linter_tools_gitleaks_checksums[system_arch] }}"

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/tasks/main.yml
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/tasks/main.yml
@@ -71,21 +71,6 @@
     state: directory
   register: super_linter_tools_temp_dir
 
-- name: Set architecture-specific linter assets
-  ansible.builtin.set_fact:
-    super_linter_tools_hadolint_asset: "{{ super_linter_tools_hadolint_assets[system_arch] }}"
-    super_linter_tools_actionlint_asset: "{{ super_linter_tools_actionlint_assets[system_arch] }}"
-    super_linter_tools_gitleaks_asset: "{{ super_linter_tools_gitleaks_assets[system_arch] }}"
-    super_linter_tools_hadolint_assets:
-      amd64: hadolint-Linux-x86_64
-      arm64: hadolint-Linux-arm64
-    super_linter_tools_actionlint_assets:
-      amd64: "actionlint_{{ super_linter_tools_actionlint_version }}_linux_amd64.tar.gz"
-      arm64: "actionlint_{{ super_linter_tools_actionlint_version }}_linux_arm64.tar.gz"
-    super_linter_tools_gitleaks_assets:
-      amd64: "gitleaks_{{ super_linter_tools_gitleaks_version }}_linux_x64.tar.gz"
-      arm64: "gitleaks_{{ super_linter_tools_gitleaks_version }}_linux_arm64.tar.gz"
-
 - name: Download hadolint binary
   ansible.builtin.get_url:
     url: "https://github.com/hadolint/hadolint/releases/download/{{ super_linter_tools_hadolint_version }}/{{ super_linter_tools_hadolint_asset }}"

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/tasks/main.yml
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/tasks/main.yml
@@ -1,0 +1,110 @@
+---
+- name: Fail when architecture is unsupported
+  ansible.builtin.fail:
+    msg: "Unsupported architecture '{{ system_arch }}' for super linter tools"
+  when: system_arch not in ["amd64", "arm64"]
+
+- name: Install apt-provided super-linter tools
+  ansible.builtin.apt:
+    name:
+      - shellcheck
+    state: present
+    install_recommends: false
+    update_cache: true
+
+- name: Install prettier globally with Bun
+  ansible.builtin.command:
+    argv:
+      - /usr/local/bin/bun
+      - add
+      - --global
+      - "prettier@{{ super_linter_tools_prettier_version }}"
+    creates: /usr/local/bin/prettier
+  environment:
+    BUN_INSTALL: /usr/local
+
+- name: Install zizmor with uv
+  ansible.builtin.command:
+    argv:
+      - /usr/local/bin/uv
+      - tool
+      - install
+      - "zizmor=={{ super_linter_tools_zizmor_version }}"
+      - --python
+      - /usr/bin/python3
+    creates: /root/.local/bin/zizmor
+
+- name: Expose zizmor on /usr/local/bin
+  ansible.builtin.file:
+    src: /root/.local/bin/zizmor
+    dest: /usr/local/bin/zizmor
+    state: link
+    force: true
+
+- name: Create temporary directory for linter downloads
+  ansible.builtin.tempfile:
+    state: directory
+  register: super_linter_tools_temp_dir
+
+- name: Set architecture-specific linter assets
+  ansible.builtin.set_fact:
+    super_linter_tools_hadolint_asset: "{{ super_linter_tools_hadolint_assets[system_arch] }}"
+    super_linter_tools_actionlint_asset: "{{ super_linter_tools_actionlint_assets[system_arch] }}"
+    super_linter_tools_gitleaks_asset: "{{ super_linter_tools_gitleaks_assets[system_arch] }}"
+    super_linter_tools_hadolint_assets:
+      amd64: hadolint-linux-x86_64
+      arm64: hadolint-linux-arm64
+    super_linter_tools_actionlint_assets:
+      amd64: "actionlint_{{ super_linter_tools_actionlint_version }}_linux_amd64.tar.gz"
+      arm64: "actionlint_{{ super_linter_tools_actionlint_version }}_linux_arm64.tar.gz"
+    super_linter_tools_gitleaks_assets:
+      amd64: "gitleaks_{{ super_linter_tools_gitleaks_version }}_linux_x64.tar.gz"
+      arm64: "gitleaks_{{ super_linter_tools_gitleaks_version }}_linux_arm64.tar.gz"
+
+- name: Download hadolint binary
+  ansible.builtin.get_url:
+    url: "https://github.com/hadolint/hadolint/releases/download/{{ super_linter_tools_hadolint_version }}/{{ super_linter_tools_hadolint_asset }}"
+    dest: /usr/local/bin/hadolint
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Download actionlint archive
+  ansible.builtin.get_url:
+    url: "https://github.com/rhysd/actionlint/releases/download/v{{ super_linter_tools_actionlint_version }}/{{ super_linter_tools_actionlint_asset }}"
+    dest: "{{ super_linter_tools_temp_dir.path }}/actionlint.tar.gz"
+    mode: "0644"
+
+- name: Install actionlint binary
+  ansible.builtin.unarchive:
+    src: "{{ super_linter_tools_temp_dir.path }}/actionlint.tar.gz"
+    dest: /usr/local/bin
+    remote_src: true
+    include:
+      - actionlint
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Download gitleaks archive
+  ansible.builtin.get_url:
+    url: "https://github.com/gitleaks/gitleaks/releases/download/v{{ super_linter_tools_gitleaks_version }}/{{ super_linter_tools_gitleaks_asset }}"
+    dest: "{{ super_linter_tools_temp_dir.path }}/gitleaks.tar.gz"
+    mode: "0644"
+
+- name: Install gitleaks binary
+  ansible.builtin.unarchive:
+    src: "{{ super_linter_tools_temp_dir.path }}/gitleaks.tar.gz"
+    dest: /usr/local/bin
+    remote_src: true
+    include:
+      - gitleaks
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Clean up temporary directory
+  ansible.builtin.file:
+    path: "{{ super_linter_tools_temp_dir.path }}"
+    state: absent
+  when: super_linter_tools_temp_dir.path is defined

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/tasks/main.yml
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/tasks/main.yml
@@ -33,9 +33,7 @@
   environment:
     BUN_INSTALL: /usr/local
   when:
-    - super_linter_tools_prettier_installed.rc != 0
-      or (super_linter_tools_prettier_installed.stdout | trim)
-      != super_linter_tools_prettier_version
+    - super_linter_tools_prettier_installed.rc != 0 or (super_linter_tools_prettier_installed.stdout | trim) != super_linter_tools_prettier_version
 
 - name: Check installed zizmor version
   ansible.builtin.command:
@@ -58,10 +56,8 @@
   register: super_linter_tools_zizmor_install
   changed_when: super_linter_tools_zizmor_install.rc == 0
   when:
-    - super_linter_tools_zizmor_installed.rc != 0
-      or (super_linter_tools_zizmor_installed.stdout | default('')
-      | regex_search('([0-9]+\.)+[0-9]+'))
-      != super_linter_tools_zizmor_version
+    - super_linter_tools_zizmor_installed.rc != 0 or (super_linter_tools_zizmor_installed.stdout | default('') | regex_search('([0-9]+\.)+[0-9]+')) !=
+      super_linter_tools_zizmor_version
 
 - name: Expose zizmor on /usr/local/bin
   ansible.builtin.file:

--- a/docker/ros/ansible/playbooks/roles/super_linter_tools/tasks/main.yml
+++ b/docker/ros/ansible/playbooks/roles/super_linter_tools/tasks/main.yml
@@ -12,6 +12,15 @@
     install_recommends: false
     update_cache: true
 
+- name: Check installed prettier version
+  ansible.builtin.command:
+    argv:
+      - /usr/local/bin/prettier
+      - --version
+  register: super_linter_tools_prettier_installed
+  changed_when: false
+  failed_when: false
+
 - name: Install prettier globally with Bun
   ansible.builtin.command:
     argv:
@@ -19,9 +28,23 @@
       - add
       - --global
       - "prettier@{{ super_linter_tools_prettier_version }}"
-    creates: /usr/local/bin/prettier
+  register: super_linter_tools_prettier_install
+  changed_when: super_linter_tools_prettier_install.rc == 0
   environment:
     BUN_INSTALL: /usr/local
+  when:
+    - super_linter_tools_prettier_installed.rc != 0
+      or (super_linter_tools_prettier_installed.stdout | trim)
+      != super_linter_tools_prettier_version
+
+- name: Check installed zizmor version
+  ansible.builtin.command:
+    argv:
+      - /usr/local/bin/zizmor
+      - --version
+  register: super_linter_tools_zizmor_installed
+  changed_when: false
+  failed_when: false
 
 - name: Install zizmor with uv
   ansible.builtin.command:
@@ -32,7 +55,13 @@
       - "zizmor=={{ super_linter_tools_zizmor_version }}"
       - --python
       - /usr/bin/python3
-    creates: /root/.local/bin/zizmor
+  register: super_linter_tools_zizmor_install
+  changed_when: super_linter_tools_zizmor_install.rc == 0
+  when:
+    - super_linter_tools_zizmor_installed.rc != 0
+      or (super_linter_tools_zizmor_installed.stdout | default('')
+      | regex_search('([0-9]+\.)+[0-9]+'))
+      != super_linter_tools_zizmor_version
 
 - name: Expose zizmor on /usr/local/bin
   ansible.builtin.file:
@@ -52,8 +81,8 @@
     super_linter_tools_actionlint_asset: "{{ super_linter_tools_actionlint_assets[system_arch] }}"
     super_linter_tools_gitleaks_asset: "{{ super_linter_tools_gitleaks_assets[system_arch] }}"
     super_linter_tools_hadolint_assets:
-      amd64: hadolint-linux-x86_64
-      arm64: hadolint-linux-arm64
+      amd64: hadolint-Linux-x86_64
+      arm64: hadolint-Linux-arm64
     super_linter_tools_actionlint_assets:
       amd64: "actionlint_{{ super_linter_tools_actionlint_version }}_linux_amd64.tar.gz"
       arm64: "actionlint_{{ super_linter_tools_actionlint_version }}_linux_arm64.tar.gz"
@@ -65,6 +94,7 @@
   ansible.builtin.get_url:
     url: "https://github.com/hadolint/hadolint/releases/download/{{ super_linter_tools_hadolint_version }}/{{ super_linter_tools_hadolint_asset }}"
     dest: /usr/local/bin/hadolint
+    checksum: "{{ super_linter_tools_hadolint_checksum }}"
     owner: root
     group: root
     mode: "0755"
@@ -73,6 +103,7 @@
   ansible.builtin.get_url:
     url: "https://github.com/rhysd/actionlint/releases/download/v{{ super_linter_tools_actionlint_version }}/{{ super_linter_tools_actionlint_asset }}"
     dest: "{{ super_linter_tools_temp_dir.path }}/actionlint.tar.gz"
+    checksum: "{{ super_linter_tools_actionlint_checksum }}"
     mode: "0644"
 
 - name: Install actionlint binary
@@ -90,6 +121,7 @@
   ansible.builtin.get_url:
     url: "https://github.com/gitleaks/gitleaks/releases/download/v{{ super_linter_tools_gitleaks_version }}/{{ super_linter_tools_gitleaks_asset }}"
     dest: "{{ super_linter_tools_temp_dir.path }}/gitleaks.tar.gz"
+    checksum: "{{ super_linter_tools_gitleaks_checksum }}"
     mode: "0644"
 
 - name: Install gitleaks binary

--- a/scripts/super-linter-local.sh
+++ b/scripts/super-linter-local.sh
@@ -8,16 +8,26 @@ root_dir=$(cd "$script_dir/.." && pwd)
 image="${SUPER_LINTER_IMAGE:-ghcr.io/super-linter/super-linter:v8.5.0}"
 validate_all_codebase="${VALIDATE_ALL_CODEBASE:-false}"
 log_level="${LOG_LEVEL:-INFO}"
+mode="${SUPER_LINTER_MODE:-native}"
+filter_regex_exclude='(^|/)(build|install|log|\.venv|packages/vendor|\.git)/'
 
 usage()
 {
   cat <<'EOF'
-Usage: scripts/super-linter-local.sh [--all] [--image IMAGE] [--log-level LEVEL]
+Usage: scripts/super-linter-local.sh [--all] [--native|--container|--auto] [--image IMAGE] [--log-level LEVEL]
 
-Runs the same Super-Linter autofix pass and check pass used by GitHub Actions.
+Runs the same lint set as CI with a native-first workflow.
+
+Modes:
+  --native           Run linters installed in the devcontainer (default).
+  --container        Force the Super-Linter container workflow.
+  --auto             Prefer native tools, fall back to Super-Linter container when missing.
 
 Options:
   --all              Set VALIDATE_ALL_CODEBASE=true.
+  --native           Same as SUPER_LINTER_MODE=native.
+  --container        Same as SUPER_LINTER_MODE=container.
+  --auto             Same as SUPER_LINTER_MODE=auto.
   --image IMAGE      Override the Super-Linter container image.
   --log-level LEVEL  Override Super-Linter LOG_LEVEL.
   -h, --help         Show this help.
@@ -26,6 +36,7 @@ Environment:
   SUPER_LINTER_IMAGE     Container image to run.
   VALIDATE_ALL_CODEBASE  true or false. Defaults to false.
   LOG_LEVEL              Super-Linter log level. Defaults to INFO.
+  SUPER_LINTER_MODE      native, container, or auto. Defaults to native.
 EOF
 }
 
@@ -33,6 +44,18 @@ while (($#)); do
   case "$1" in
     --all)
       validate_all_codebase=true
+      shift
+      ;;
+    --native)
+      mode=native
+      shift
+      ;;
+    --container)
+      mode=container
+      shift
+      ;;
+    --auto)
+      mode=auto
       shift
       ;;
     --image)
@@ -63,15 +86,6 @@ while (($#)); do
   esac
 done
 
-if command -v docker >/dev/null 2>&1; then
-  runtime=docker
-elif command -v podman >/dev/null 2>&1; then
-  runtime=podman
-else
-  echo "Docker or Podman is required to run Super-Linter locally." >&2
-  exit 1
-fi
-
 mkdir -p "$root_dir/.tmp"
 
 default_branch=$(git -C "$root_dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
@@ -80,16 +94,168 @@ if [[ -z "$default_branch" ]]; then
   default_branch=main
 fi
 
-git_common_dir=$(git -C "$root_dir" rev-parse --path-format=absolute --git-common-dir)
-mounts=(-v "$root_dir:/tmp/lint")
-if [[ "$git_common_dir" != "$root_dir/.git" ]]; then
-  mounts+=(-v "$git_common_dir:$git_common_dir")
-fi
+collect_target_files()
+{
+  local files_list="$root_dir/.tmp/super-linter-files.$$.txt"
+  : > "$files_list"
+
+  if [[ "$validate_all_codebase" == true ]]; then
+    git -C "$root_dir" ls-files >> "$files_list"
+  else
+    if git -C "$root_dir" show-ref --verify --quiet "refs/remotes/origin/$default_branch"; then
+      git -C "$root_dir" diff --name-only "origin/$default_branch"...HEAD >> "$files_list"
+    fi
+
+    git -C "$root_dir" diff --name-only >> "$files_list"
+    git -C "$root_dir" diff --name-only --cached >> "$files_list"
+    git -C "$root_dir" ls-files --others --exclude-standard >> "$files_list"
+  fi
+
+  sort -u "$files_list" -o "$files_list"
+  mapfile -t all_files < "$files_list"
+  rm -f "$files_list"
+}
+
+classify_files()
+{
+  prettier_files=()
+  bash_files=()
+  docker_files=()
+  workflow_files=()
+
+  for file in "${all_files[@]}"; do
+    [[ -n "$file" ]] || continue
+    [[ -f "$root_dir/$file" ]] || continue
+    [[ "$file" =~ $filter_regex_exclude ]] && continue
+
+    case "$file" in
+      *.md|*.markdown|*.json|*.jsonc|*.yaml|*.yml)
+        prettier_files+=("$file")
+        ;;
+    esac
+
+    case "$file" in
+      *.sh|*.bash|*.zsh)
+        bash_files+=("$file")
+        ;;
+    esac
+
+    case "$(basename "$file")" in
+      Dockerfile|Dockerfile.*)
+        docker_files+=("$file")
+        ;;
+    esac
+
+    case "$file" in
+      .github/workflows/*.yml|.github/workflows/*.yaml)
+        workflow_files+=("$file")
+        ;;
+    esac
+  done
+}
+
+run_in_root()
+{
+  (
+    cd "$root_dir"
+    "$@"
+  )
+}
+
+ensure_native_tools()
+{
+  local missing=()
+  local required=(prettier shellcheck hadolint actionlint zizmor gitleaks git)
+
+  for tool in "${required[@]}"; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      missing+=("$tool")
+    fi
+  done
+
+  if ((${#missing[@]} > 0)); then
+    echo "Missing native lint tools: ${missing[*]}" >&2
+    echo "Install them by running the ROS setup playbook used by this repo images." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+run_native_super_linter()
+{
+  local status=0
+  local prettier_log_level
+  prettier_log_level=$(tr '[:upper:]' '[:lower:]' <<<"$log_level")
+
+  collect_target_files
+  classify_files
+
+  echo "Running native super-linter autofix pass..."
+  if ((${#prettier_files[@]} > 0)); then
+    run_in_root prettier --log-level "$prettier_log_level" --write "${prettier_files[@]}" || status=$?
+  else
+    echo "Skipping prettier autofix: no matching files."
+  fi
+
+  if ((${#workflow_files[@]} > 0)); then
+    run_in_root zizmor --fix "${workflow_files[@]}" || status=$?
+  else
+    echo "Skipping zizmor autofix: no workflow files."
+  fi
+
+  echo "Running native super-linter check pass..."
+  if ((${#prettier_files[@]} > 0)); then
+    run_in_root prettier --log-level "$prettier_log_level" --check "${prettier_files[@]}" || status=$?
+  else
+    echo "Skipping prettier checks: no matching files."
+  fi
+
+  if ((${#bash_files[@]} > 0)); then
+    run_in_root shellcheck "${bash_files[@]}" || status=$?
+  else
+    echo "Skipping shellcheck: no shell scripts."
+  fi
+
+  if ((${#docker_files[@]} > 0)); then
+    run_in_root hadolint "${docker_files[@]}" || status=$?
+  else
+    echo "Skipping hadolint: no Dockerfiles."
+  fi
+
+  if ((${#workflow_files[@]} > 0)); then
+    run_in_root actionlint "${workflow_files[@]}" || status=$?
+    run_in_root zizmor "${workflow_files[@]}" || status=$?
+  else
+    echo "Skipping workflow checks: no workflow files."
+  fi
+
+  run_in_root gitleaks git --source . --no-banner || status=$?
+  return "$status"
+}
 
 run_super_linter()
 {
   local name="$1"
   local env_file="$2"
+
+  local runtime
+  if command -v docker >/dev/null 2>&1; then
+    runtime=docker
+  elif command -v podman >/dev/null 2>&1; then
+    runtime=podman
+  else
+    echo "Docker or Podman is required to run Super-Linter in container mode." >&2
+    return 1
+  fi
+
+  local git_common_dir
+  local -a mounts
+  git_common_dir=$(git -C "$root_dir" rev-parse --path-format=absolute --git-common-dir)
+  mounts=(-v "$root_dir:/tmp/lint")
+  if [[ "$git_common_dir" != "$root_dir/.git" ]]; then
+    mounts+=(-v "$git_common_dir:$git_common_dir")
+  fi
 
   echo "Running Super-Linter $name pass..."
   "$runtime" run --rm \
@@ -103,5 +269,21 @@ run_super_linter()
     "$image"
 }
 
-run_super_linter "autofix" ".github/super-linter-autofix.env"
-run_super_linter "check" ".github/super-linter-checks.env"
+if [[ "$mode" == native ]]; then
+  ensure_native_tools
+  run_native_super_linter
+elif [[ "$mode" == container ]]; then
+  run_super_linter "autofix" ".github/super-linter-autofix.env"
+  run_super_linter "check" ".github/super-linter-checks.env"
+elif [[ "$mode" == auto ]]; then
+  if ensure_native_tools; then
+    run_native_super_linter
+  else
+    echo "Falling back to container mode because native tools are missing." >&2
+    run_super_linter "autofix" ".github/super-linter-autofix.env"
+    run_super_linter "check" ".github/super-linter-checks.env"
+  fi
+else
+  echo "Unknown mode: $mode (expected: native, container, auto)" >&2
+  exit 2
+fi

--- a/scripts/super-linter-local.sh
+++ b/scripts/super-linter-local.sh
@@ -100,15 +100,17 @@ collect_target_files()
   : > "$files_list"
 
   if [[ "$validate_all_codebase" == true ]]; then
-    git -C "$root_dir" ls-files >> "$files_list"
+    git -C "$root_dir" ls-files > "$files_list"
   else
-    if git -C "$root_dir" show-ref --verify --quiet "refs/remotes/origin/$default_branch"; then
-      git -C "$root_dir" diff --name-only "origin/$default_branch"...HEAD >> "$files_list"
-    fi
+    {
+      if git -C "$root_dir" show-ref --verify --quiet "refs/remotes/origin/$default_branch"; then
+        git -C "$root_dir" diff --name-only "origin/$default_branch"...HEAD
+      fi
 
-    git -C "$root_dir" diff --name-only >> "$files_list"
-    git -C "$root_dir" diff --name-only --cached >> "$files_list"
-    git -C "$root_dir" ls-files --others --exclude-standard >> "$files_list"
+      git -C "$root_dir" diff --name-only
+      git -C "$root_dir" diff --name-only --cached
+      git -C "$root_dir" ls-files --others --exclude-standard
+    } > "$files_list"
   fi
 
   sort -u "$files_list" -o "$files_list"
@@ -186,7 +188,24 @@ run_native_super_linter()
 {
   local status=0
   local prettier_log_level
-  prettier_log_level=$(tr '[:upper:]' '[:lower:]' <<<"$log_level")
+
+  case "$log_level" in
+    INFO)
+      prettier_log_level=log
+      ;;
+    WARN|WARNING)
+      prettier_log_level=warn
+      ;;
+    ERROR)
+      prettier_log_level=error
+      ;;
+    DEBUG)
+      prettier_log_level=debug
+      ;;
+    *)
+      prettier_log_level=$(tr '[:upper:]' '[:lower:]' <<<"$log_level")
+      ;;
+  esac
 
   collect_target_files
   classify_files
@@ -230,7 +249,7 @@ run_native_super_linter()
     echo "Skipping workflow checks: no workflow files."
   fi
 
-  run_in_root gitleaks git --source . --no-banner || status=$?
+  run_in_root gitleaks detect --source . --no-banner || status=$?
   return "$status"
 }
 


### PR DESCRIPTION
# Summary

Add a dedicated devcontainer setup role for the local Super-Linter toolchain and wire it into the ROS setup playbook. Update the local Super-Linter wrapper to run natively by default, support explicit native/container/auto modes, and limit native checks to relevant tracked files.

## What Changed

- Add a new `super_linter_tools` Ansible role with pinned versions for `prettier`, `shellcheck`, `hadolint`, `actionlint`, `zizmor`, and `gitleaks`, including architecture-specific download handling for amd64 and arm64.
- Invoke that role from the ROS setup playbook and document the installed toolchain in the role README.
- Extend `scripts/super-linter-local.sh` with `--native`, `--container`, and `--auto` modes, native tool discovery, changed-file collection, per-linter file classification, and native autofix/check execution while preserving the container workflow as a fallback.

## Why

Local linting currently depends on the Super-Linter container path even when the devcontainer can provide the same tools directly. Installing the toolchain into the devcontainer and preferring native execution makes local lint runs faster, reduces container-only friction, and keeps the local workflow closer to the repository's intended environment.

## How to Test

1. Run `bash -n scripts/super-linter-local.sh`.
2. Run `cd docker/ros/ansible && ansible-playbook --syntax-check playbooks/20_ros_setup.yml -i inventories/localhost.yml`.

## Breaking Changes

- None.

## Migration

- None.
