### PR TITLE
Re-enable Claude Responder progress comment

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -157,6 +157,10 @@ jobs:
           assignee_trigger: 'claude-bot'
           show_full_output: true
           prompt: ${{ steps.agent_prompt.outputs.prompt }}
+          # Automation mode (non-empty prompt, used for the fixed pr-review prompt)
+          # suppresses the action's tracking/progress comment by default. track_progress
+          # forces it back on
+          track_progress: true
 
       - name: Attach responder output file
         if: steps.claude_responder.outputs.execution_file != ''


### PR DESCRIPTION
# Summary

Re-enables the Claude Responder's progress/tracking comment on pull requests. The prior workflow rework (#414) merged the PR-review and comment-responder steps and, as a side effect, left the action's automation-mode default (no tracking comment) in place, so PR runs stopped posting the intermediate progress comment.

## What Changed

- **`claude-review.yml`**: Adds `track_progress: true` to the `Claude Responder` step, with a comment explaining that automation mode (a non-empty fixed prompt, used for `pr-review`) suppresses the action's tracking comment by default and this input forces it back on.

## Why

Without `track_progress: true`, reviewers lose visibility into an in-flight Claude run until the final review/comment is posted, making longer `pr-review` passes look stalled or unresponsive on the PR.

## How to Test

1. Reviewed the diff manually; change is limited to one workflow input plus an explanatory comment.
2. No build/test suite applies — this is CI workflow configuration only. Verification will come from observing that the next PR run posts a progress comment.

## Breaking Changes

- None.

## Migration

- None.
