### PR TITLE
Skip track_progress on unsupported pull_request actions

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -159,8 +159,10 @@ jobs:
           prompt: ${{ steps.agent_prompt.outputs.prompt }}
           # Automation mode (non-empty prompt, used for the fixed pr-review prompt)
           # suppresses the action's tracking/progress comment by default. track_progress
-          # forces it back on
-          track_progress: true
+          # forces it back on, but the action only allows it for pull_request actions
+          # opened/reopened/synchronize/ready_for_review — e.g. our own "assigned"
+          # trigger errors out if track_progress is unconditionally true.
+          track_progress: ${{ github.event_name != 'pull_request' || contains(fromJson('["opened", "reopened", "synchronize", "ready_for_review"]'), github.event.action) }}
 
       - name: Attach responder output file
         if: steps.claude_responder.outputs.execution_file != ''


### PR DESCRIPTION
# Summary

Fixes the `claude-review.yml` workflow so `track_progress` is only forced on for `pull_request` events where `claude-code-action` actually supports it, preventing the run from erroring out on our `assigned` trigger.

## What Changed

- **`claude-review.yml`**: Changed `track_progress` on the Claude Responder step from an unconditional `true` to a conditional expression that only enables it for `pull_request` actions `opened`, `reopened`, `synchronize`, or `ready_for_review` (or for any non-`pull_request` event), with an updated comment explaining the constraint.

## Why

`claude-code-action` only allows `track_progress: true` for `pull_request` actions `opened`/`reopened`/`synchronize`/`ready_for_review`. The `assigned` trigger, used for our `claude-bot` assignee automation, was unconditionally passing `track_progress: true` and causing the run to fail.

## How to Test

1. Reviewed the diff manually; the change is limited to one workflow input plus an explanatory comment.
2. No build/test suite applies — this is CI workflow configuration only.
3. Verification will come from observing that the `assigned`-triggered workflow run no longer fails, while `opened`/`reopened`/`synchronize`/`ready_for_review` runs continue to post the progress comment.

## Breaking Changes

- None.

## Migration

- None.
