### PR TITLE
Do NOT set track_progress for code reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -157,12 +157,9 @@ jobs:
           assignee_trigger: 'claude-bot'
           show_full_output: true
           prompt: ${{ steps.agent_prompt.outputs.prompt }}
-          # Automation mode (non-empty prompt, used for the fixed pr-review prompt)
-          # suppresses the action's tracking/progress comment by default. track_progress
-          # forces it back on, but the action only allows it for pull_request actions
-          # opened/reopened/synchronize/ready_for_review — e.g. our own "assigned"
-          # trigger errors out if track_progress is unconditionally true.
-          track_progress: ${{ github.event_name != 'pull_request' || contains(fromJson('["opened", "reopened", "synchronize", "ready_for_review"]'), github.event.action) }}
+          # Do NOT set track_progress for code reviews, it breaks agent's instructions to submit review,
+          # it ends up posting it as a comment.
+          # track_progress: true
 
       - name: Attach responder output file
         if: steps.claude_responder.outputs.execution_file != ''


### PR DESCRIPTION
# Summary

Disable `track_progress` for the Claude code-review workflow entirely instead of conditionally enabling it. The conditional flag was still causing the review action to post its findings as a plain top-level comment rather than submitting them as a proper PR review.

## What Changed

- Removed the conditional `track_progress` expression in `.github/workflows/claude-review.yml` that enabled progress tracking for `opened`/`reopened`/`synchronize`/`ready_for_review` pull request actions.
- Left the setting commented out with a note explaining that enabling it breaks the agent's instructions to submit a full review, causing it to fall back to posting a plain comment instead.

## Why

`track_progress` was found to interfere with the code-review agent's ability to submit its output as a structured GitHub PR review — with it enabled, the review ends up posted as a regular issue comment instead. Since the code-review workflow does not need progress tracking, the flag is disabled unconditionally rather than re-introducing the same problem for a subset of trigger actions.

## How to Test

1. Reviewed the workflow diff manually to confirm `track_progress` is no longer set (`git diff origin/main...HEAD`).
2. No functional ROS code changed; no build/test suite applies to this CI workflow-only change.

## Breaking Changes

- None.

## Migration

- None.

## Related

- Follow-up to #419 / #420.
