### PR TITLE
Rework keyboard control GUI: layout engine, component architecture, latched body-pose joysticks

### DIFF
--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -22,6 +22,11 @@ For general engineering principles, code quality standards, and best practices, 
 ### Code Style and Formatting
 
 - Follow the **PEP 8** style guide for Python
+- Add ROS and workspace packages to Ruff's `lint.isort.known-third-party`
+  configuration when that classification aligns its import order with
+  `ament_flake8`. Use a targeted `# noqa: <rule>` only for a formatter-required
+  incompatibility such as `E203` on a slice; do not disable rules for a whole
+  file or package.
 - Maintain proper indentation (use 4 spaces for each level of indentation)
 - Ensure lines do not exceed 79 characters
 - Place function and class docstrings immediately after the `def` or `class` keyword

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/control_state.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/control_state.py
@@ -1,0 +1,371 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Input model for the GUI keyboard controller.
+
+Pygame-free and rclpy-free so the whole model is unit testable. Keyboard keys
+and pointer drags drive two ``VirtualStick`` instances; ``GuiControlState``
+turns them into ``MovementCommand`` messages, mirroring the semantics of the
+physical joystick translator (``drqp_brain.joystick_translator_node``).
+
+Latching: a real gamepad stick can be held while pressing the mode button, so
+body pose survives mode switches. A mouse cannot hold a stick and click a
+button at once, so in the body position/rotation modes the virtual sticks
+latch in place on release instead of springing back to center. Walk mode
+always springs back — releasing input must stop the robot.
+"""
+
+from dataclasses import dataclass
+
+from drqp_brain.joystick_input_handler import all_control_modes, ControlMode
+from drqp_interfaces.msg import MovementCommand, MovementCommandConstants
+from drqp_keyboard_control.layout import clamp, clamp_vector
+from geometry_msgs.msg import Vector3
+
+LEFT_STICK_KEYS = frozenset({'w', 'a', 's', 'd'})
+RIGHT_STICK_KEYS = frozenset({'up', 'down', 'left', 'right'})
+MOTION_KEYS = LEFT_STICK_KEYS | RIGHT_STICK_KEYS
+
+# Per-key unit contribution to the owning stick, scaled by sensitivity.
+LEFT_KEY_VECTORS = {'d': (1.0, 0.0), 'a': (-1.0, 0.0), 'w': (0.0, 1.0), 's': (0.0, -1.0)}
+RIGHT_KEY_VECTORS = {
+    'right': (1.0, 0.0),
+    'left': (-1.0, 0.0),
+    'up': (0.0, 1.0),
+    'down': (0.0, -1.0),
+}
+
+# Modes where stick values must survive pointer release (see module docstring).
+LATCHING_MODES = frozenset({ControlMode.BodyPosition, ControlMode.BodyRotation})
+
+ZERO_VECTOR = (0.0, 0.0, 0.0)
+
+
+@dataclass(frozen=True)
+class VirtualAxes:
+    """Virtual controller axes used to build movement commands."""
+
+    left_x: float = 0.0
+    left_y: float = 0.0
+    right_x: float = 0.0
+    right_y: float = 0.0
+    left_trigger: float = 0.0
+    right_trigger: float = 0.0
+
+
+@dataclass
+class VirtualStick:
+    """
+    One virtual thumb stick driven by pointer drags or keyboard keys.
+
+    ``dragging`` marks an active pointer drag (pointer wins over keyboard).
+    ``latched`` marks a value held in place after release in a latching mode.
+    """
+
+    x: float = 0.0
+    y: float = 0.0
+    dragging: bool = False
+    latched: bool = False
+
+    @property
+    def value(self) -> tuple[float, float]:
+        """Return current (x, y) axes."""
+        return (self.x, self.y)
+
+    def set_axes(self, x: float, y: float):
+        """Assign raw axis values."""
+        self.x = x
+        self.y = y
+
+    def reset(self):
+        """Return to center and clear pointer/latch flags."""
+        self.x = 0.0
+        self.y = 0.0
+        self.dragging = False
+        self.latched = False
+
+
+class GuiControlState:
+    """Track GUI and keyboard input as joystick-like movement state."""
+
+    gaits = [
+        MovementCommandConstants.GAIT_TRIPOD,
+        MovementCommandConstants.GAIT_RIPPLE,
+        MovementCommandConstants.GAIT_WAVE,
+    ]
+
+    def __init__(
+        self,
+        *,
+        sensitivity: float = 0.5,
+        sensitivity_step: float = 0.1,
+        minimum_sensitivity: float = 0.1,
+        maximum_sensitivity: float = 1.0,
+    ):
+        self.sensitivity = sensitivity
+        self.sensitivity_step = sensitivity_step
+        self.minimum_sensitivity = minimum_sensitivity
+        self.maximum_sensitivity = maximum_sensitivity
+
+        self.held_keys: set[str] = set()
+        self.gait_index = 0
+        self.left_stick = VirtualStick()
+        self.right_stick = VirtualStick()
+        self.left_trigger = 0.0
+        self.right_trigger = 0.0
+
+        # Persistent command state, mirroring JoystickInputHandler: only the
+        # active mode's fields are driven by the axes, the rest keep their
+        # last values so body pose survives mode switches.
+        self.stride_direction = ZERO_VECTOR
+        self.rotation_speed = 0.0
+        self.body_translation = ZERO_VECTOR
+        self.body_rotation = ZERO_VECTOR
+
+        self._control_mode = ControlMode.Walk
+        self._mode_stick_memory: dict[ControlMode, tuple] = {}
+
+    @property
+    def control_mode(self) -> ControlMode:
+        """Return the current semantic control mode (set via set_control_mode)."""
+        return self._control_mode
+
+    # ---------------------------------------------------------------- keyboard
+
+    def key_down(self, key: str) -> bool:
+        """Apply a normalized key press and return whether state changed."""
+        key = key.lower()
+        if key in MOTION_KEYS:
+            if key in self.held_keys:
+                return False
+            self.held_keys.add(key)
+            self._sync_stick_with_keyboard(key)
+            return True
+        if key == 'tab':
+            self.next_control_mode()
+            return True
+        if key in {'+', '='}:
+            self.adjust_sensitivity(self.sensitivity_step)
+            return True
+        if key in {'-', '_'}:
+            self.adjust_sensitivity(-self.sensitivity_step)
+            return True
+        if key in {'1', '2', '3'}:
+            self.set_gait_index(int(key) - 1)
+            return True
+        return False
+
+    def key_up(self, key: str) -> bool:
+        """Apply a normalized key release and return whether state changed."""
+        key = key.lower()
+        if key not in MOTION_KEYS or key not in self.held_keys:
+            return False
+        self.held_keys.remove(key)
+        self._sync_stick_with_keyboard(key)
+        return True
+
+    def adjust_sensitivity(self, delta: float):
+        """Adjust keyboard emulation magnitude, re-applying held keys live."""
+        self.sensitivity = clamp(
+            self.sensitivity + delta,
+            self.minimum_sensitivity,
+            self.maximum_sensitivity,
+        )
+        self.sensitivity = round(self.sensitivity, 2)
+        for stick, key_vectors in (
+            (self.left_stick, LEFT_KEY_VECTORS),
+            (self.right_stick, RIGHT_KEY_VECTORS),
+        ):
+            if not stick.dragging and self._any_keys_held(key_vectors):
+                self._apply_keyboard(stick, key_vectors)
+
+    # ----------------------------------------------------------------- pointer
+
+    def set_left_stick(self, x: float, y: float):
+        """Drive the left stick from a pointer drag (unit-circle clamped)."""
+        self._pointer_set(self.left_stick, x, y)
+
+    def release_left_stick(self):
+        """End the left stick pointer drag (latches in body modes)."""
+        self._pointer_release(self.left_stick, LEFT_KEY_VECTORS)
+
+    def set_right_stick(self, x: float, y: float):
+        """Drive the right stick from a pointer drag (unit-circle clamped)."""
+        self._pointer_set(self.right_stick, x, y)
+
+    def release_right_stick(self):
+        """End the right stick pointer drag (latches in body modes)."""
+        self._pointer_release(self.right_stick, RIGHT_KEY_VECTORS)
+
+    def set_left_trigger(self, value: float):
+        """Set left trigger slider value."""
+        self.left_trigger = clamp(value, 0.0, 1.0)
+
+    def set_right_trigger(self, value: float):
+        """Set right trigger slider value."""
+        self.right_trigger = clamp(value, 0.0, 1.0)
+
+    # ------------------------------------------------------------ mode / gait
+
+    @property
+    def gait(self) -> str:
+        """Return the currently selected gait name."""
+        return self.gaits[self.gait_index]
+
+    def set_gait_index(self, gait_index: int):
+        """Set selected gait by index."""
+        self.gait_index = max(0, min(len(self.gaits) - 1, gait_index))
+
+    def set_control_mode(self, control_mode: ControlMode):
+        """Switch control mode, preserving latched body pose per mode."""
+        if control_mode == self._control_mode:
+            return
+
+        self._update_active_mode_fields()
+        if self._control_mode in LATCHING_MODES:
+            self._mode_stick_memory[self._control_mode] = (
+                self.left_stick.value,
+                self.right_stick.value,
+            )
+        else:
+            # Leaving Walk: unlike a held gamepad stick, GUI input cannot be
+            # carried across the switch, so walking must stop immediately.
+            self.stride_direction = ZERO_VECTOR
+            self.rotation_speed = 0.0
+
+        self._control_mode = control_mode
+
+        if control_mode in LATCHING_MODES:
+            left, right = self._mode_stick_memory.get(control_mode, ((0.0, 0.0), (0.0, 0.0)))
+            for stick, value in ((self.left_stick, left), (self.right_stick, right)):
+                stick.set_axes(*value)
+                stick.dragging = False
+                stick.latched = True
+        else:
+            for stick, key_vectors in (
+                (self.left_stick, LEFT_KEY_VECTORS),
+                (self.right_stick, RIGHT_KEY_VECTORS),
+            ):
+                stick.dragging = False
+                stick.latched = False
+                self._apply_keyboard(stick, key_vectors)
+
+    def next_control_mode(self):
+        """Cycle through the same control modes as the joystick translator."""
+        current_index = all_control_modes.index(self._control_mode)
+        self.set_control_mode(all_control_modes[(current_index + 1) % len(all_control_modes)])
+
+    # ---------------------------------------------------------------- commands
+
+    def axes(self) -> VirtualAxes:
+        """Return the merged keyboard and pointer controller axes."""
+        return VirtualAxes(
+            left_x=self.left_stick.x,
+            left_y=self.left_stick.y,
+            right_x=self.right_stick.x,
+            right_y=self.right_stick.y,
+            left_trigger=self.left_trigger,
+            right_trigger=self.right_trigger,
+        )
+
+    def movement_command(self) -> MovementCommand:
+        """Update the active mode's command fields and build the full command."""
+        self._update_active_mode_fields()
+
+        command = MovementCommand()
+        command.gait_type = self.gait
+        command.stride_direction = _vector3(self.stride_direction)
+        command.rotation_speed = float(self.rotation_speed)
+        command.body_translation = _vector3(self.body_translation)
+        command.body_rotation = _vector3(self.body_rotation)
+        return command
+
+    def reset_motion_inputs(self):
+        """Clear all latched motion inputs and command state."""
+        self.held_keys.clear()
+        self.left_stick.reset()
+        self.right_stick.reset()
+        self.left_trigger = 0.0
+        self.right_trigger = 0.0
+        self.stride_direction = ZERO_VECTOR
+        self.rotation_speed = 0.0
+        self.body_translation = ZERO_VECTOR
+        self.body_rotation = ZERO_VECTOR
+        self._mode_stick_memory.clear()
+
+    # ----------------------------------------------------------------- helpers
+
+    def _update_active_mode_fields(self):
+        """Drive the active mode's command fields from the current axes."""
+        axes = self.axes()
+        if self._control_mode == ControlMode.Walk:
+            self.stride_direction = (axes.left_y, -axes.left_x, axes.left_trigger)
+            self.rotation_speed = -axes.right_x
+        elif self._control_mode == ControlMode.BodyPosition:
+            self.body_translation = (axes.left_y, -axes.left_x, axes.right_y)
+        elif self._control_mode == ControlMode.BodyRotation:
+            self.body_rotation = (-axes.left_x, axes.left_y, -axes.right_x)
+
+    def _pointer_set(self, stick: VirtualStick, x: float, y: float):
+        stick.dragging = True
+        stick.latched = False
+        stick.set_axes(*clamp_vector(x, y))
+
+    def _pointer_release(self, stick: VirtualStick, key_vectors: dict):
+        stick.dragging = False
+        if self._control_mode in LATCHING_MODES:
+            stick.latched = True
+        else:
+            self._apply_keyboard(stick, key_vectors)
+
+    def _sync_stick_with_keyboard(self, key: str):
+        if key in LEFT_STICK_KEYS:
+            stick, key_vectors = self.left_stick, LEFT_KEY_VECTORS
+        else:
+            stick, key_vectors = self.right_stick, RIGHT_KEY_VECTORS
+        if stick.dragging:
+            return
+        if self._any_keys_held(key_vectors):
+            self._apply_keyboard(stick, key_vectors)
+        elif self._control_mode in LATCHING_MODES:
+            # Last key released: hold position, same as a pointer release.
+            stick.latched = True
+        else:
+            stick.set_axes(0.0, 0.0)
+
+    def _apply_keyboard(self, stick: VirtualStick, key_vectors: dict):
+        """Drive a stick from held keys; keyboard input overrides a latch."""
+        x = 0.0
+        y = 0.0
+        for key, (key_x, key_y) in key_vectors.items():
+            if key in self.held_keys:
+                x += key_x
+                y += key_y
+        stick.set_axes(x * self.sensitivity, y * self.sensitivity)
+        stick.latched = False
+
+    def _any_keys_held(self, key_vectors: dict) -> bool:
+        return any(key in self.held_keys for key in key_vectors)
+
+
+def _vector3(value: tuple) -> Vector3:
+    x, y, z = value
+    return Vector3(x=float(x), y=float(y), z=float(z))

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/control_state.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/control_state.py
@@ -37,8 +37,9 @@ from dataclasses import dataclass
 
 from drqp_brain.joystick_input_handler import all_control_modes, ControlMode
 from drqp_interfaces.msg import MovementCommand, MovementCommandConstants
-from drqp_keyboard_control.layout import clamp, clamp_vector
 from geometry_msgs.msg import Vector3
+
+from drqp_keyboard_control.layout import clamp, clamp_vector
 
 LEFT_STICK_KEYS = frozenset({'w', 'a', 's', 'd'})
 RIGHT_STICK_KEYS = frozenset({'up', 'down', 'left', 'right'})

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/control_state.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/control_state.py
@@ -37,9 +37,8 @@ from dataclasses import dataclass
 
 from drqp_brain.joystick_input_handler import all_control_modes, ControlMode
 from drqp_interfaces.msg import MovementCommand, MovementCommandConstants
-from geometry_msgs.msg import Vector3
-
 from drqp_keyboard_control.layout import clamp, clamp_vector
+from geometry_msgs.msg import Vector3
 
 LEFT_STICK_KEYS = frozenset({'w', 'a', 's', 'd'})
 RIGHT_STICK_KEYS = frozenset({'up', 'down', 'left', 'right'})

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/gui_controls.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/gui_controls.py
@@ -18,133 +18,216 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from dataclasses import dataclass
+"""
+Pygame-free GUI widget models and pointer routing.
+
+Widgets expose a uniform pointer interface (``hit_test``/``press``/``drag``/
+``release``) plus value callables the renderer reads from, so behavior is
+fully unit testable. Rectangles are assigned from the layout engine through
+each widget's ``layout_key``.
+"""
+
+from dataclasses import dataclass, field
 import math
 from typing import Callable
 
+from drqp_keyboard_control.layout import clamp, RectSpec
 
-def clamp(value: float, minimum: float, maximum: float) -> float:
-    """Clamp value into inclusive range."""
-    return max(minimum, min(maximum, value))
+# Vertical room reserved inside a stick rect for its name (above) and its
+# axis readout (below); the interactive circle fills the rest.
+STICK_TEXT_MARGIN = 40.0
 
-
-def clamp_vector(x: float, y: float) -> tuple[float, float]:
-    """Clamp a 2D vector into the unit circle."""
-    magnitude = math.hypot(x, y)
-    if magnitude <= 1.0:
-        return (x, y)
-    return (x / magnitude, y / magnitude)
+# Trigger geometry: label strip above the track, track thickness across it.
+TRIGGER_LABEL_STRIP = 26.0
+TRIGGER_TRACK_THICKNESS = 34.0
 
 
-@dataclass
-class RectSpec:
-    """Small rectangle helper that keeps most GUI math Pygame-free."""
+def _zero_rect() -> RectSpec:
+    return RectSpec(0.0, 0.0, 0.0, 0.0)
 
-    x: float
-    y: float
-    width: float
-    height: float
 
-    def contains(self, pos: tuple[float, float]) -> bool:
-        px, py = pos
-        return self.x <= px <= self.x + self.width and self.y <= py <= self.y + self.height
+def _never_selected() -> bool:
+    return False
+
+
+@dataclass(kw_only=True)
+class Control:
+    """Base widget: a labeled rectangle with a uniform pointer interface."""
+
+    label: str
+    layout_key: str
+    rect: RectSpec = field(default_factory=_zero_rect)
+
+    def hit_test(self, pos: tuple[float, float]) -> bool:
+        """Return whether the point interacts with this widget."""
+        return self.rect.contains(pos)
+
+    def press(self, pos: tuple[float, float]):
+        """Handle a pointer press inside the widget."""
+
+    def drag(self, pos: tuple[float, float]):
+        """Handle pointer motion while this widget holds the capture."""
+
+    def release(self):
+        """Handle the pointer release ending the capture."""
+
+
+@dataclass(kw_only=True)
+class LabelControl(Control):
+    """Non-interactive text display."""
+
+    text: Callable[[], str]
+
+    def hit_test(self, pos: tuple[float, float]) -> bool:
+        """Labels never take pointer input."""
+        return False
+
+
+@dataclass(kw_only=True)
+class ButtonControl(Control):
+    """Clickable GUI button firing its action on press."""
+
+    action: Callable[[], None]
+    selected: Callable[[], bool] = _never_selected
+    pressed: bool = False
+
+    def press(self, pos: tuple[float, float]):
+        """Fire the action and show the pressed state until release."""
+        self.pressed = True
+        self.action()
+
+    def release(self):
+        """Clear the pressed visual state."""
+        self.pressed = False
+
+
+@dataclass(kw_only=True)
+class CheckboxControl(ButtonControl):
+    """Toggle rendered as a checkbox; behaves exactly like a button."""
+
+
+@dataclass(kw_only=True)
+class StickControl(Control):
+    """Draggable circular virtual thumb stick."""
+
+    on_move: Callable[[float, float], None]
+    on_release: Callable[[], None]
+    value: Callable[[], tuple[float, float]]
+    dragging: bool = False
 
     @property
     def center(self) -> tuple[float, float]:
-        return (self.x + self.width / 2.0, self.y + self.height / 2.0)
+        """Return the stick center in window coordinates."""
+        return self.rect.center
 
-
-@dataclass
-class StickControl:
-    """Draggable circular virtual thumb stick."""
-
-    name: str
-    center: tuple[float, float]
-    radius: float
-    setter: Callable[[float, float], None]
-    releaser: Callable[[], None]
-    dragging: bool = False
+    @property
+    def radius(self) -> float:
+        """Return the stick radius derived from the layout rect."""
+        return max(
+            10.0,
+            min(self.rect.width / 2.0, self.rect.height / 2.0 - STICK_TEXT_MARGIN),
+        )
 
     def hit_test(self, pos: tuple[float, float]) -> bool:
-        return math.hypot(pos[0] - self.center[0], pos[1] - self.center[1]) <= self.radius
+        """Sticks react only within their circle, not the whole rect."""
+        center_x, center_y = self.center
+        return math.hypot(pos[0] - center_x, pos[1] - center_y) <= self.radius
 
-    def begin_drag(self, pos: tuple[float, float]):
+    def press(self, pos: tuple[float, float]):
+        """Start dragging the stick knob."""
         self.dragging = True
-        self.update_drag(pos)
+        self.drag(pos)
 
-    def update_drag(self, pos: tuple[float, float]):
-        x = (pos[0] - self.center[0]) / self.radius
-        y = -(pos[1] - self.center[1]) / self.radius
-        self.setter(*clamp_vector(x, y))
+    def drag(self, pos: tuple[float, float]):
+        """Report the knob position as normalized axes (y up)."""
+        center_x, center_y = self.center
+        x = (pos[0] - center_x) / self.radius
+        y = -(pos[1] - center_y) / self.radius
+        self.on_move(x, y)
 
-    def end_drag(self):
+    def release(self):
+        """End the drag; latching policy is decided by the state model."""
         self.dragging = False
-        self.releaser()
+        self.on_release()
 
 
-@dataclass
-class TriggerControl:
-    """Horizontal or vertical trigger slider."""
+@dataclass(kw_only=True)
+class TriggerControl(Control):
+    """Horizontal or vertical trigger slider that keeps its value."""
 
-    name: str
-    rect: RectSpec
-    setter: Callable[[float], None]
+    on_change: Callable[[float], None]
+    value: Callable[[], float]
     dragging: bool = False
 
-    def begin_drag(self, pos: tuple[float, float]):
-        if not self.rect.contains(pos):
-            return
-        self.dragging = True
-        self.update_drag(pos)
+    @property
+    def vertical(self) -> bool:
+        """Return whether the slider runs bottom-to-top."""
+        return self.rect.height > self.rect.width
 
-    def update_drag(self, pos: tuple[float, float]):
-        if self.rect.height > self.rect.width:
-            value = 1.0 - ((pos[1] - self.rect.y) / self.rect.height)
+    @property
+    def track_rect(self) -> RectSpec:
+        """Return the slider track: below the label strip, centered across."""
+        track = RectSpec(
+            self.rect.x,
+            self.rect.y + TRIGGER_LABEL_STRIP,
+            self.rect.width,
+            max(1.0, self.rect.height - TRIGGER_LABEL_STRIP),
+        )
+        if self.vertical:
+            track.x += (track.width - TRIGGER_TRACK_THICKNESS) / 2.0
+            track.width = TRIGGER_TRACK_THICKNESS
         else:
-            value = (pos[0] - self.rect.x) / self.rect.width
-        self.setter(clamp(value, 0.0, 1.0))
+            track.y += (track.height - TRIGGER_TRACK_THICKNESS) / 2.0
+            track.height = TRIGGER_TRACK_THICKNESS
+        return track
 
-    def end_drag(self):
+    def press(self, pos: tuple[float, float]):
+        """Start dragging the slider knob."""
+        self.dragging = True
+        self.drag(pos)
+
+    def drag(self, pos: tuple[float, float]):
+        """Report the slider value for the pointer position."""
+        track = self.track_rect
+        if self.vertical:
+            value = 1.0 - ((pos[1] - track.y) / track.height)
+        else:
+            value = (pos[0] - track.x) / track.width
+        self.on_change(clamp(value, 0.0, 1.0))
+
+    def release(self):
+        """End the drag; sliders keep their last value."""
         self.dragging = False
 
 
-@dataclass
-class ButtonControl:
-    """Clickable GUI button."""
+class PointerRouter:
+    """Dispatch pointer events to widgets with single-capture semantics."""
 
-    label: str
-    rect: RectSpec
-    action: Callable[[], None]
-    selected: Callable[[], bool] = lambda: False
-    pressed: bool = False
+    def __init__(self, controls: list[Control]):
+        self.controls = controls
+        self._active: Control | None = None
 
-    def click(self, pos: tuple[float, float]) -> bool:
-        if not self.rect.contains(pos):
-            return False
-        self.pressed = True
-        self.action()
-        return True
+    @property
+    def active(self) -> Control | None:
+        """Return the widget currently holding the pointer capture."""
+        return self._active
 
-    def release(self):
-        self.pressed = False
+    def press(self, pos: tuple[float, float]) -> bool:
+        """Send the press to the first hit widget and capture it."""
+        for control in self.controls:
+            if control.hit_test(pos):
+                self._active = control
+                control.press(pos)
+                return True
+        return False
 
-
-@dataclass
-class CheckboxControl:
-    """Clickable checkbox GUI control."""
-
-    label: str
-    rect: RectSpec
-    action: Callable[[], None]
-    selected: Callable[[], bool]
-    pressed: bool = False
-
-    def click(self, pos: tuple[float, float]) -> bool:
-        if not self.rect.contains(pos):
-            return False
-        self.pressed = True
-        self.action()
-        return True
+    def move(self, pos: tuple[float, float]):
+        """Forward pointer motion to the captured widget only."""
+        if self._active is not None:
+            self._active.drag(pos)
 
     def release(self):
-        self.pressed = False
+        """Release the capture, notifying the captured widget."""
+        if self._active is not None:
+            self._active.release()
+            self._active = None

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -48,7 +48,8 @@ class PygameKeyboardControlApp:
         self.show_help = False
         self.stay_on_top = False
 
-        pygame.init()
+        pygame.display.init()
+        pygame.font.init()
         pygame.display.set_caption('Dr.QP Keyboard Control')
         self.screen = pygame.display.set_mode((width, height), pygame.RESIZABLE)
         self.window_id = self._display_window_id()

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -20,13 +20,12 @@
 
 """Composition root wiring the Pygame window, widgets, router, and renderer."""
 
-import rclpy
-
 from drqp_keyboard_control.gui_controls import PointerRouter
 from drqp_keyboard_control.keymap import build_key_map
 from drqp_keyboard_control.renderer import PygameRenderer
 from drqp_keyboard_control.sdl_window import set_sdl_window_always_on_top
 from drqp_keyboard_control.ui import apply_layout, build_controls, KEYBOARD_HELP_LINES
+import rclpy
 
 
 class PygameKeyboardControlApp:

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -20,12 +20,13 @@
 
 """Composition root wiring the Pygame window, widgets, router, and renderer."""
 
+import rclpy
+
 from drqp_keyboard_control.gui_controls import PointerRouter
 from drqp_keyboard_control.keymap import build_key_map
 from drqp_keyboard_control.renderer import PygameRenderer
 from drqp_keyboard_control.sdl_window import set_sdl_window_always_on_top
 from drqp_keyboard_control.ui import apply_layout, build_controls, KEYBOARD_HELP_LINES
-import rclpy
 
 
 class PygameKeyboardControlApp:

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -100,6 +100,10 @@ class PygameKeyboardControlApp:
             elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
                 self.router.release()
             elif event.type == pygame.VIDEORESIZE:
+                self.screen = pygame.display.set_mode(
+                    (event.w, event.h), pygame.RESIZABLE
+                )
+                self.renderer.screen = self.screen
                 apply_layout(self.controls, event.w, event.h)
 
     def _render(self):

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -18,30 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from drqp_brain.joystick_input_handler import all_control_modes
-import rclpy
+"""Composition root wiring the Pygame window, widgets, router, and renderer."""
 
-from drqp_keyboard_control.gui_controls import (
-    ButtonControl,
-    CheckboxControl,
-    RectSpec,
-    StickControl,
-    TriggerControl,
-)
+from drqp_keyboard_control.gui_controls import PointerRouter
+from drqp_keyboard_control.keymap import build_key_map
+from drqp_keyboard_control.renderer import PygameRenderer
 from drqp_keyboard_control.sdl_window import set_sdl_window_always_on_top
-
-KEYBOARD_HELP_LINES = [
-    'W/A/S/D: left stick',
-    'Arrow keys: right stick',
-    'Hold multiple movement keys together',
-    'Tab: cycle mode',
-    '1/2/3: select Tripod/Ripple/Wave',
-    'B: toggle balance mode',
-    '+/-: adjust keyboard sensitivity',
-    'Space or Esc: kill switch',
-    'Delete: reboot servos',
-    'Backspace: finalize',
-]
+from drqp_keyboard_control.ui import apply_layout, build_controls, KEYBOARD_HELP_LINES
+import rclpy
 
 
 class PygameKeyboardControlApp:
@@ -59,50 +43,28 @@ class PygameKeyboardControlApp:
 
         self.pygame = pygame
         self.node = node
-        self.width = width
-        self.height = height
         self.frame_rate_hz = frame_rate_hz
         self.running = True
-        self.active_stick: StickControl | None = None
-        self.active_trigger: TriggerControl | None = None
-        self.buttons: list[ButtonControl] = []
-        self.checkboxes: list[CheckboxControl] = []
         self.show_help = False
         self.stay_on_top = False
 
         pygame.init()
         pygame.display.set_caption('Dr.QP Keyboard Control')
-        self.screen = pygame.display.set_mode((self.width, self.height))
+        self.screen = pygame.display.set_mode((width, height), pygame.RESIZABLE)
         self.window_id = self._display_window_id()
         self.clock = pygame.time.Clock()
-        self.font = pygame.font.Font(None, 28)
-        self.small_font = pygame.font.Font(None, 22)
+        self.key_map = build_key_map(pygame)
+        self.renderer = PygameRenderer(pygame, self.screen)
 
-        self.left_stick = StickControl(
-            'Left Stick',
-            (220.0, 385.0),
-            105.0,
-            self.node.state.set_left_stick,
-            self.node.state.release_left_stick,
+        self.controls = build_controls(
+            node,
+            toggle_help=self._toggle_help,
+            help_visible=lambda: self.show_help,
+            toggle_stay_on_top=self._toggle_stay_on_top,
+            stay_on_top_enabled=lambda: self.stay_on_top,
         )
-        self.right_stick = StickControl(
-            'Right Stick',
-            (520.0, 385.0),
-            105.0,
-            self.node.state.set_right_stick,
-            self.node.state.release_right_stick,
-        )
-        self.left_trigger = TriggerControl(
-            'Left Trigger',
-            RectSpec(55.0, 280.0, 34.0, 210.0),
-            self.node.state.set_left_trigger,
-        )
-        self.right_trigger = TriggerControl(
-            'Right Trigger',
-            RectSpec(655.0, 280.0, 34.0, 210.0),
-            self.node.state.set_right_trigger,
-        )
-        self._build_buttons()
+        self.router = PointerRouter(self.controls)
+        apply_layout(self.controls, width, height)
 
     def run(self):
         """Run the GUI and ROS event loops."""
@@ -112,66 +74,35 @@ class PygameKeyboardControlApp:
             self._render()
             self.clock.tick(self.frame_rate_hz)
 
-    def _build_buttons(self):
-        mode_x = 150.0
-        for index, mode in enumerate(all_control_modes):
-            self.buttons.append(
-                ButtonControl(
-                    mode.name,
-                    RectSpec(mode_x + index * 150.0, 35.0, 136.0, 38.0),
-                    lambda selected_mode=mode: self.node.state.set_control_mode(selected_mode),
-                    lambda selected_mode=mode: self.node.state.control_mode == selected_mode,
-                )
-            )
+    def close(self):
+        """Shut Pygame down; safe to call after run() returns."""
+        self.pygame.quit()
 
-        gait_labels = ['Tripod', 'Ripple', 'Wave']
-        for index, label in enumerate(gait_labels):
-            self.buttons.append(
-                ButtonControl(
-                    label,
-                    RectSpec(mode_x + index * 150.0, 88.0, 136.0, 38.0),
-                    lambda selected_index=index: self.node.state.set_gait_index(selected_index),
-                    lambda selected_index=index: self.node.state.gait_index == selected_index,
-                )
-            )
+    def _handle_events(self):
+        pygame = self.pygame
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self._request_shutdown()
+            elif event.type == pygame.KEYDOWN:
+                key = self.key_map.get(event.key)
+                if key is not None:
+                    self.node.handle_key_down(key)
+            elif event.type == pygame.KEYUP:
+                key = self.key_map.get(event.key)
+                if key is not None:
+                    self.node.handle_key_up(key)
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                self.router.press(event.pos)
+            elif event.type == pygame.MOUSEMOTION:
+                self.router.move(event.pos)
+            elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+                self.router.release()
+            elif event.type == pygame.VIDEORESIZE:
+                apply_layout(self.controls, event.w, event.h)
 
-        actions = [
-            ('Kill Switch', lambda: self.node._publish_event('kill_switch_pressed')),
-            ('Finalize', lambda: self.node._publish_event('finalize')),
-            ('Reboot', lambda: self.node._publish_event('reboot_servos')),
-        ]
-        for index, (label, action) in enumerate(actions):
-            self.buttons.append(
-                ButtonControl(
-                    label,
-                    RectSpec(185.0 + index * 130.0, 560.0, 118.0, 42.0),
-                    action,
-                )
-            )
-        self.buttons.append(
-            ButtonControl(
-                'Help',
-                RectSpec(150.0, 141.0, 136.0, 38.0),
-                self._toggle_help,
-                lambda: self.show_help,
-            )
-        )
-        self.checkboxes.append(
-            CheckboxControl(
-                'Stay on top',
-                RectSpec(300.0, 146.0, 120.0, 28.0),
-                self._toggle_stay_on_top,
-                lambda: self.stay_on_top,
-            )
-        )
-        self.checkboxes.append(
-            CheckboxControl(
-                'Balance Mode',
-                RectSpec(440.0, 146.0, 130.0, 28.0),
-                self.node._toggle_balance_mode,
-                lambda: self.node.balance_mode_enabled,
-            )
-        )
+    def _render(self):
+        help_lines = KEYBOARD_HELP_LINES if self.show_help else None
+        self.renderer.render(self.controls, help_lines=help_lines)
 
     def _toggle_help(self):
         self.show_help = not self.show_help
@@ -180,12 +111,12 @@ class PygameKeyboardControlApp:
         self.stay_on_top = not self.stay_on_top
         self._apply_stay_on_top(self.stay_on_top)
 
+    def _apply_stay_on_top(self, enabled: bool) -> bool:
+        return set_sdl_window_always_on_top(self.window_id, enabled)
+
     def _request_shutdown(self):
         self.node.publish_stop_command()
         self.running = False
-
-    def _apply_stay_on_top(self, enabled: bool) -> bool:
-        return set_sdl_window_always_on_top(self.window_id, enabled)
 
     def _display_window_id(self) -> int | None:
         try:
@@ -194,254 +125,3 @@ class PygameKeyboardControlApp:
             return int(Window.from_display_module().id)
         except (AttributeError, ImportError, TypeError, ValueError):
             return None
-
-    def _handle_events(self):
-        for event in self.pygame.event.get():
-            if event.type == self.pygame.QUIT:
-                self._request_shutdown()
-            elif event.type == self.pygame.KEYDOWN:
-                key = self._normalize_key(event.key)
-                if key is not None:
-                    self.node.handle_key_down(key)
-            elif event.type == self.pygame.KEYUP:
-                key = self._normalize_key(event.key)
-                if key is not None:
-                    self.node.handle_key_up(key)
-            elif event.type == self.pygame.MOUSEBUTTONDOWN and event.button == 1:
-                self._begin_pointer(event.pos)
-            elif event.type == self.pygame.MOUSEMOTION:
-                self._move_pointer(event.pos)
-            elif event.type == self.pygame.MOUSEBUTTONUP and event.button == 1:
-                self._end_pointer()
-
-    def _begin_pointer(self, pos: tuple[float, float]):
-        for button in self.buttons:
-            if button.click(pos):
-                return
-        for checkbox in self.checkboxes:
-            if checkbox.click(pos):
-                return
-
-        if self.left_stick.hit_test(pos):
-            self.active_stick = self.left_stick
-            self.active_stick.begin_drag(pos)
-            return
-        if self.right_stick.hit_test(pos):
-            self.active_stick = self.right_stick
-            self.active_stick.begin_drag(pos)
-            return
-
-        for trigger in (self.left_trigger, self.right_trigger):
-            if trigger.rect.contains(pos):
-                self.active_trigger = trigger
-                self.active_trigger.begin_drag(pos)
-                return
-
-    def _move_pointer(self, pos: tuple[float, float]):
-        if self.active_stick is not None:
-            self.active_stick.update_drag(pos)
-        if self.active_trigger is not None:
-            self.active_trigger.update_drag(pos)
-
-    def _end_pointer(self):
-        for button in self.buttons:
-            button.release()
-        for checkbox in self.checkboxes:
-            checkbox.release()
-        if self.active_stick is not None:
-            self.active_stick.end_drag()
-            self.active_stick = None
-        if self.active_trigger is not None:
-            self.active_trigger.end_drag()
-            self.active_trigger = None
-
-    def _normalize_key(self, key_code: int) -> str | None:
-        pygame = self.pygame
-        key_map = {
-            pygame.K_w: 'w',
-            pygame.K_a: 'a',
-            pygame.K_s: 's',
-            pygame.K_d: 'd',
-            pygame.K_b: 'b',
-            pygame.K_UP: 'up',
-            pygame.K_DOWN: 'down',
-            pygame.K_LEFT: 'left',
-            pygame.K_RIGHT: 'right',
-            pygame.K_TAB: 'tab',
-            pygame.K_1: '1',
-            pygame.K_2: '2',
-            pygame.K_3: '3',
-            pygame.K_PLUS: '+',
-            pygame.K_EQUALS: '=',
-            pygame.K_MINUS: '-',
-            pygame.K_UNDERSCORE: '_',
-            pygame.K_SPACE: 'space',
-            pygame.K_ESCAPE: 'esc',
-            pygame.K_DELETE: 'delete',
-            pygame.K_BACKSPACE: 'backspace',
-        }
-        return key_map.get(key_code)
-
-    def _render(self):
-        self.screen.fill((21, 24, 28))
-        self._draw_text(
-            f'Sensitivity {self.node.state.sensitivity:.2f}',
-            (185, 612),
-            (178, 187, 197),
-            self.small_font,
-        )
-
-        for button in self.buttons:
-            self._draw_button(button)
-        for checkbox in self.checkboxes:
-            self._draw_checkbox(checkbox)
-
-        axes = self.node.state.axes()
-        self._draw_trigger(self.left_trigger, axes.left_trigger)
-        self._draw_trigger(self.right_trigger, axes.right_trigger)
-        self._draw_stick(self.left_stick, axes.left_x, axes.left_y)
-        self._draw_stick(self.right_stick, axes.right_x, axes.right_y)
-        if self.show_help:
-            self._draw_help()
-        self.pygame.display.flip()
-
-    def _draw_button(self, button: ButtonControl):
-        selected = button.selected()
-        color = (63, 132, 103) if selected else (47, 54, 61)
-        if button.pressed:
-            color = (150, 80, 68)
-        self._draw_rect(button.rect, color, border_radius=6)
-        self._draw_rect_outline(button.rect, (111, 126, 140), border_radius=6)
-        text_color = (245, 247, 250) if selected or button.pressed else (203, 211, 219)
-        self._draw_centered_text(button.label, button.rect, text_color, self.small_font)
-
-    def _draw_checkbox(self, checkbox: CheckboxControl):
-        box = RectSpec(checkbox.rect.x, checkbox.rect.y + 4.0, 20.0, 20.0)
-        text_pos = (checkbox.rect.x + 28.0, checkbox.rect.y + 5.0)
-        border_color = (150, 163, 177) if not checkbox.pressed else (210, 218, 226)
-        self._draw_rect(box, (47, 54, 61), border_radius=4)
-        self._draw_rect_outline(box, border_color, border_radius=4)
-        if checkbox.selected():
-            inner = RectSpec(box.x + 5.0, box.y + 5.0, 10.0, 10.0)
-            self._draw_rect(inner, (86, 160, 133), border_radius=2)
-        self._draw_text(checkbox.label, text_pos, (203, 211, 219), self.small_font)
-
-    def _draw_trigger(self, trigger: TriggerControl, value: float):
-        self._draw_text(trigger.name, (trigger.rect.x - 26, trigger.rect.y - 28), (203, 211, 219))
-        self._draw_rect(trigger.rect, (45, 51, 58), border_radius=6)
-        if trigger.rect.height > trigger.rect.width:
-            fill_height = trigger.rect.height * value
-            fill = RectSpec(
-                trigger.rect.x,
-                trigger.rect.y + trigger.rect.height - fill_height,
-                trigger.rect.width,
-                fill_height,
-            )
-            knob = (
-                round(trigger.rect.x + trigger.rect.width / 2.0),
-                round(trigger.rect.y + trigger.rect.height * (1.0 - value)),
-            )
-        else:
-            fill = RectSpec(
-                trigger.rect.x,
-                trigger.rect.y,
-                trigger.rect.width * value,
-                trigger.rect.height,
-            )
-            knob = (
-                round(trigger.rect.x + trigger.rect.width * value),
-                round(trigger.rect.y + trigger.rect.height / 2.0),
-            )
-        self._draw_rect(fill, (80, 130, 184), border_radius=6)
-        self.pygame.draw.circle(
-            self.screen,
-            (235, 239, 244),
-            knob,
-            14,
-        )
-
-    def _draw_stick(self, stick: StickControl, x: float, y: float):
-        pygame = self.pygame
-        pygame.draw.circle(self.screen, (38, 44, 51), stick.center, stick.radius)
-        pygame.draw.circle(self.screen, (91, 104, 118), stick.center, stick.radius, 2)
-        pygame.draw.line(
-            self.screen,
-            (62, 70, 80),
-            (stick.center[0] - stick.radius, stick.center[1]),
-            (stick.center[0] + stick.radius, stick.center[1]),
-            1,
-        )
-        pygame.draw.line(
-            self.screen,
-            (62, 70, 80),
-            (stick.center[0], stick.center[1] - stick.radius),
-            (stick.center[0], stick.center[1] + stick.radius),
-            1,
-        )
-        knob = (stick.center[0] + x * stick.radius, stick.center[1] - y * stick.radius)
-        pygame.draw.circle(self.screen, (86, 160, 133), knob, 34)
-        pygame.draw.circle(self.screen, (235, 239, 244), knob, 34, 2)
-        self._draw_text(stick.name, (stick.center[0] - 52, stick.center[1] - stick.radius - 35))
-        self._draw_text(
-            f'x={x:+.2f} y={y:+.2f}',
-            (stick.center[0] - 58, stick.center[1] + stick.radius + 18),
-            (178, 187, 197),
-            self.small_font,
-        )
-
-    def _draw_help(self):
-        panel = RectSpec(180.0, 150.0, 390.0, 285.0)
-        self._draw_rect(panel, (34, 39, 45), border_radius=6)
-        self._draw_rect_outline(panel, (118, 132, 146), border_radius=6)
-        self._draw_text('Keyboard Controls', (panel.x + 18, panel.y + 16), (235, 239, 244))
-        for index, line in enumerate(KEYBOARD_HELP_LINES):
-            self._draw_text(
-                line,
-                (panel.x + 18, panel.y + 50 + index * 24),
-                (203, 211, 219),
-                self.small_font,
-            )
-
-    def _draw_text(
-        self,
-        text: str,
-        pos: tuple[float, float],
-        color: tuple[int, int, int] = (203, 211, 219),
-        font=None,
-    ):
-        surface = (font or self.small_font).render(text, True, color)
-        self.screen.blit(surface, pos)
-
-    def _draw_centered_text(self, text: str, rect: RectSpec, color: tuple[int, int, int], font):
-        surface = font.render(text, True, color)
-        surface_rect = surface.get_rect(center=rect.center)
-        self.screen.blit(surface, surface_rect)
-
-    def _draw_rect(
-        self,
-        rect: RectSpec,
-        color: tuple[int, int, int],
-        *,
-        border_radius: int = 0,
-    ):
-        self.pygame.draw.rect(
-            self.screen,
-            color,
-            self.pygame.Rect(rect.x, rect.y, rect.width, rect.height),
-            border_radius=border_radius,
-        )
-
-    def _draw_rect_outline(
-        self,
-        rect: RectSpec,
-        color: tuple[int, int, int],
-        *,
-        border_radius: int = 0,
-    ):
-        self.pygame.draw.rect(
-            self.screen,
-            color,
-            self.pygame.Rect(rect.x, rect.y, rect.width, rect.height),
-            width=1,
-            border_radius=border_radius,
-        )

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -48,7 +48,6 @@ class PygameKeyboardControlApp:
         self.running = True
         self.show_help = False
         self.stay_on_top = False
-        self._pending_stay_on_top: bool | None = None
 
         pygame.display.init()
         pygame.font.init()
@@ -73,7 +72,6 @@ class PygameKeyboardControlApp:
         """Run the GUI and ROS event loops."""
         while self.running and rclpy.ok():
             self._handle_events()
-            self._flush_stay_on_top()
             rclpy.spin_once(self.node, timeout_sec=0.0)
             self._render()
             self.clock.tick(self.frame_rate_hz)
@@ -113,15 +111,7 @@ class PygameKeyboardControlApp:
 
     def _toggle_stay_on_top(self):
         self.stay_on_top = not self.stay_on_top
-        self._pending_stay_on_top = self.stay_on_top
-
-    def _flush_stay_on_top(self):
-        if self._pending_stay_on_top is None:
-            return
-
-        enabled = self._pending_stay_on_top
-        self._pending_stay_on_top = None
-        self._apply_stay_on_top(enabled)
+        self._apply_stay_on_top(self.stay_on_top)
 
     def _apply_stay_on_top(self, enabled: bool) -> bool:
         if self.window_id is None:

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -120,8 +120,9 @@ class PygameKeyboardControlApp:
 
     def _display_window_id(self) -> int | None:
         try:
-            from pygame._sdl2.video import Window
-
-            return int(Window.from_display_module().id)
-        except (AttributeError, ImportError, TypeError, ValueError):
+            window_id = self.pygame.display.get_wm_info().get('window')
+            if window_id is None:
+                return None
+            return int(window_id)
+        except (AttributeError, TypeError, ValueError):
             return None

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -52,7 +52,7 @@ class PygameKeyboardControlApp:
         pygame.font.init()
         pygame.display.set_caption('Dr.QP Keyboard Control')
         self.screen = pygame.display.set_mode((width, height), pygame.RESIZABLE)
-        self.window_id = self._display_window_id()
+        self.window_id = None
         self.clock = pygame.time.Clock()
         self.key_map = build_key_map(pygame)
         self.renderer = PygameRenderer(pygame, self.screen)
@@ -113,6 +113,8 @@ class PygameKeyboardControlApp:
         self._apply_stay_on_top(self.stay_on_top)
 
     def _apply_stay_on_top(self, enabled: bool) -> bool:
+        if self.window_id is None:
+            self.window_id = self._display_window_id()
         return set_sdl_window_always_on_top(self.window_id, enabled)
 
     def _request_shutdown(self):

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -100,9 +100,7 @@ class PygameKeyboardControlApp:
             elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
                 self.router.release()
             elif event.type == pygame.VIDEORESIZE:
-                self.screen = pygame.display.set_mode(
-                    (event.w, event.h), pygame.RESIZABLE
-                )
+                self.screen = pygame.display.set_mode((event.w, event.h), pygame.RESIZABLE)
                 self.renderer.screen = self.screen
                 apply_layout(self.controls, event.w, event.h)
 

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -121,9 +121,8 @@ class PygameKeyboardControlApp:
 
     def _display_window_id(self) -> int | None:
         try:
-            window_id = self.pygame.display.get_wm_info().get('window')
-            if window_id is None:
-                return None
-            return int(window_id)
-        except (AttributeError, TypeError, ValueError):
+            from pygame._sdl2.video import Window
+
+            return int(Window.from_display_module().id)
+        except (AttributeError, ImportError, TypeError, ValueError):
             return None

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_app.py
@@ -47,6 +47,7 @@ class PygameKeyboardControlApp:
         self.running = True
         self.show_help = False
         self.stay_on_top = False
+        self._pending_stay_on_top: bool | None = None
 
         pygame.display.init()
         pygame.font.init()
@@ -71,6 +72,7 @@ class PygameKeyboardControlApp:
         """Run the GUI and ROS event loops."""
         while self.running and rclpy.ok():
             self._handle_events()
+            self._flush_stay_on_top()
             rclpy.spin_once(self.node, timeout_sec=0.0)
             self._render()
             self.clock.tick(self.frame_rate_hz)
@@ -110,7 +112,15 @@ class PygameKeyboardControlApp:
 
     def _toggle_stay_on_top(self):
         self.stay_on_top = not self.stay_on_top
-        self._apply_stay_on_top(self.stay_on_top)
+        self._pending_stay_on_top = self.stay_on_top
+
+    def _flush_stay_on_top(self):
+        if self._pending_stay_on_top is None:
+            return
+
+        enabled = self._pending_stay_on_top
+        self._pending_stay_on_top = None
+        self._apply_stay_on_top(enabled)
 
     def _apply_stay_on_top(self, enabled: bool) -> bool:
         if self.window_id is None:

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_node.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_node.py
@@ -25,13 +25,14 @@
 import argparse
 
 from drqp_interfaces.msg import MovementCommand
-from drqp_keyboard_control.control_state import GuiControlState
 import rclpy
 from rclpy.executors import ExternalShutdownException
 import rclpy.node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile
 import rclpy.utilities
 import std_msgs.msg
+
+from drqp_keyboard_control.control_state import GuiControlState
 
 EVENT_KEYS = {
     'space': 'kill_switch_pressed',

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_node.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_node.py
@@ -20,12 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import argparse
-from dataclasses import dataclass, field
+"""ROS node publishing MovementCommand messages built from GUI input."""
 
-from drqp_brain.joystick_input_handler import all_control_modes, ControlMode
-from drqp_interfaces.msg import MovementCommand, MovementCommandConstants
-from geometry_msgs.msg import Vector3
+import argparse
+
+from drqp_interfaces.msg import MovementCommand
+from drqp_keyboard_control.control_state import GuiControlState
 import rclpy
 from rclpy.executors import ExternalShutdownException
 import rclpy.node
@@ -33,204 +33,12 @@ from rclpy.qos import QoSDurabilityPolicy, QoSProfile
 import rclpy.utilities
 import std_msgs.msg
 
-from drqp_keyboard_control.gui_controls import clamp, clamp_vector
-from drqp_keyboard_control.keyboard_control_app import PygameKeyboardControlApp
-
-LEFT_STICK_KEYS = frozenset({'w', 'a', 's', 'd'})
-RIGHT_STICK_KEYS = frozenset({'up', 'down', 'left', 'right'})
-MOTION_KEYS = LEFT_STICK_KEYS | RIGHT_STICK_KEYS
 EVENT_KEYS = {
     'space': 'kill_switch_pressed',
     'esc': 'kill_switch_pressed',
     'delete': 'reboot_servos',
     'backspace': 'finalize',
 }
-
-
-@dataclass(frozen=True)
-class VirtualAxes:
-    """Virtual controller axes used to build movement commands."""
-
-    left_x: float = 0.0
-    left_y: float = 0.0
-    right_x: float = 0.0
-    right_y: float = 0.0
-    left_trigger: float = 0.0
-    right_trigger: float = 0.0
-
-
-@dataclass
-class GuiControlState:
-    """Track GUI and keyboard input as joystick-like movement state."""
-
-    sensitivity: float = 0.5
-    sensitivity_step: float = 0.1
-    minimum_sensitivity: float = 0.1
-    maximum_sensitivity: float = 1.0
-    held_keys: set[str] = field(default_factory=set)
-    control_mode: ControlMode = ControlMode.Walk
-    gait_index: int = 0
-    left_stick: tuple[float, float] = (0.0, 0.0)
-    right_stick: tuple[float, float] = (0.0, 0.0)
-    left_stick_active: bool = False
-    right_stick_active: bool = False
-    left_trigger: float = 0.0
-    right_trigger: float = 0.0
-
-    gaits = [
-        MovementCommandConstants.GAIT_TRIPOD,
-        MovementCommandConstants.GAIT_RIPPLE,
-        MovementCommandConstants.GAIT_WAVE,
-    ]
-
-    def key_down(self, key: str) -> bool:
-        """Apply a normalized key press and return whether state changed."""
-        key = key.lower()
-        if key in MOTION_KEYS:
-            before = set(self.held_keys)
-            self.held_keys.add(key)
-            return before != self.held_keys
-        if key == 'tab':
-            self.next_control_mode()
-            return True
-        if key in {'+', '='}:
-            self.adjust_sensitivity(self.sensitivity_step)
-            return True
-        if key in {'-', '_'}:
-            self.adjust_sensitivity(-self.sensitivity_step)
-            return True
-        if key in {'1', '2', '3'}:
-            self.set_gait_index(int(key) - 1)
-            return True
-        return False
-
-    def key_up(self, key: str) -> bool:
-        """Apply a normalized key release and return whether state changed."""
-        key = key.lower()
-        if key not in MOTION_KEYS or key not in self.held_keys:
-            return False
-        self.held_keys.remove(key)
-        return True
-
-    @property
-    def gait(self) -> str:
-        """Return the currently selected gait name."""
-        return self.gaits[self.gait_index]
-
-    def set_gait_index(self, gait_index: int):
-        """Set selected gait by index."""
-        self.gait_index = max(0, min(len(self.gaits) - 1, gait_index))
-
-    def set_control_mode(self, control_mode: ControlMode):
-        """Set the current semantic control mode."""
-        self.control_mode = control_mode
-
-    def next_control_mode(self):
-        """Cycle through the same control modes as the joystick translator."""
-        current_index = all_control_modes.index(self.control_mode)
-        self.control_mode = all_control_modes[(current_index + 1) % len(all_control_modes)]
-
-    def adjust_sensitivity(self, delta: float):
-        """Adjust keyboard emulation magnitude."""
-        self.sensitivity = clamp(
-            self.sensitivity + delta,
-            self.minimum_sensitivity,
-            self.maximum_sensitivity,
-        )
-        self.sensitivity = round(self.sensitivity, 2)
-
-    def set_left_stick(self, x: float, y: float, *, active: bool = True):
-        """Set left virtual stick axes."""
-        self.left_stick = clamp_vector(x, y)
-        self.left_stick_active = active
-
-    def release_left_stick(self):
-        """Return left virtual stick to center."""
-        self.left_stick = (0.0, 0.0)
-        self.left_stick_active = False
-
-    def set_right_stick(self, x: float, y: float, *, active: bool = True):
-        """Set right virtual stick axes."""
-        self.right_stick = clamp_vector(x, y)
-        self.right_stick_active = active
-
-    def release_right_stick(self):
-        """Return right virtual stick to center."""
-        self.right_stick = (0.0, 0.0)
-        self.right_stick_active = False
-
-    def reset_motion_inputs(self):
-        """Clear all latched motion inputs."""
-        self.held_keys.clear()
-        self.release_left_stick()
-        self.release_right_stick()
-        self.left_trigger = 0.0
-        self.right_trigger = 0.0
-
-    def set_left_trigger(self, value: float):
-        """Set left trigger slider value."""
-        self.left_trigger = clamp(value, 0.0, 1.0)
-
-    def set_right_trigger(self, value: float):
-        """Set right trigger slider value."""
-        self.right_trigger = clamp(value, 0.0, 1.0)
-
-    def axes(self) -> VirtualAxes:
-        """Return merged keyboard and pointer controller axes."""
-        keyboard_left = (
-            self._axis('d', 'a') * self.sensitivity,
-            self._axis('w', 's') * self.sensitivity,
-        )
-        keyboard_right = (
-            self._axis('right', 'left') * self.sensitivity,
-            self._axis('up', 'down') * self.sensitivity,
-        )
-        left_x, left_y = self.left_stick if self.left_stick_active else keyboard_left
-        right_x, right_y = self.right_stick if self.right_stick_active else keyboard_right
-        return VirtualAxes(
-            left_x=left_x,
-            left_y=left_y,
-            right_x=right_x,
-            right_y=right_y,
-            left_trigger=self.left_trigger,
-            right_trigger=self.right_trigger,
-        )
-
-    def movement_command(self) -> MovementCommand:
-        """Build the MovementCommand represented by the current GUI state."""
-        axes = self.axes()
-        command = MovementCommand()
-        command.gait_type = self.gait
-
-        if self.control_mode == ControlMode.Walk:
-            command.stride_direction = Vector3(
-                x=axes.left_y,
-                y=-axes.left_x,
-                z=axes.left_trigger,
-            )
-            command.rotation_speed = float(-axes.right_x)
-        elif self.control_mode == ControlMode.BodyPosition:
-            command.body_translation = Vector3(
-                x=axes.left_y,
-                y=-axes.left_x,
-                z=axes.right_y,
-            )
-        elif self.control_mode == ControlMode.BodyRotation:
-            command.body_rotation = Vector3(
-                x=-axes.left_x,
-                y=axes.left_y,
-                z=-axes.right_x,
-            )
-
-        return command
-
-    def _axis(self, positive_key: str, negative_key: str) -> float:
-        value = 0.0
-        if positive_key in self.held_keys:
-            value += 1.0
-        if negative_key in self.held_keys:
-            value -= 1.0
-        return value
 
 
 class KeyboardControlNode(rclpy.node.Node):
@@ -273,39 +81,43 @@ class KeyboardControlNode(rclpy.node.Node):
         """Handle a normalized key press from the GUI."""
         normalized_key = key.lower()
         if normalized_key in EVENT_KEYS:
-            self._publish_event(EVENT_KEYS[normalized_key])
+            self.publish_event(EVENT_KEYS[normalized_key])
             return True
         if normalized_key == 'b':
-            self._toggle_balance_mode()
+            self.toggle_balance_mode()
             return True
         return self.state.key_down(normalized_key)
-
-    def _toggle_balance_mode(self):
-        """Toggle dedicated balance mode without affecting walking input."""
-        self.balance_mode_enabled = not self.balance_mode_enabled
-        self.balance_mode_pub.publish(std_msgs.msg.Bool(data=self.balance_mode_enabled))
 
     def handle_key_up(self, key: str) -> bool:
         """Handle a normalized key release from the GUI."""
         return self.state.key_up(key)
 
-    def _publish_command(self):
-        self.movement_command_pub.publish(self.state.movement_command())
+    def toggle_balance_mode(self):
+        """Toggle dedicated balance mode without affecting walking input."""
+        self.balance_mode_enabled = not self.balance_mode_enabled
+        self.balance_mode_pub.publish(std_msgs.msg.Bool(data=self.balance_mode_enabled))
 
     def publish_stop_command(self):
         """Publish a zero movement command before the GUI exits."""
         self.state.reset_motion_inputs()
         self._publish_command()
 
-    def _publish_event(self, event: str):
+    def publish_event(self, event: str):
+        """Publish a named robot event (kill switch, reboot, finalize)."""
         msg = std_msgs.msg.String()
         msg.data = event
         self.robot_event_pub.publish(msg)
         self.get_logger().info(f'Published event: {event}')
 
+    def _publish_command(self):
+        self.movement_command_pub.publish(self.state.movement_command())
+
 
 def main():
     """Entry point for GUI keyboard control node."""
+    # Imported lazily so the node stays importable on headless systems.
+    from drqp_keyboard_control.keyboard_control_app import PygameKeyboardControlApp
+
     node = None
     app = None
     try:
@@ -313,7 +125,7 @@ def main():
         parser.add_argument('--sensitivity', type=float, default=0.5)
         parser.add_argument('--sensitivity-step', type=float, default=0.1)
         parser.add_argument('--publish-rate-hz', type=float, default=20.0)
-        parser.add_argument('--width', type=int, default=760)
+        parser.add_argument('--width', type=int, default=980)
         parser.add_argument('--height', type=int, default=640)
         parser.add_argument('--frame-rate-hz', type=float, default=60.0)
         filtered_args = rclpy.utilities.remove_ros_args()
@@ -340,7 +152,7 @@ def main():
         if rclpy.ok():
             rclpy.shutdown()
         if app is not None:
-            app.pygame.quit()
+            app.close()
 
 
 if __name__ == '__main__':

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_node.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keyboard_control_node.py
@@ -25,14 +25,13 @@
 import argparse
 
 from drqp_interfaces.msg import MovementCommand
+from drqp_keyboard_control.control_state import GuiControlState
 import rclpy
 from rclpy.executors import ExternalShutdownException
 import rclpy.node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile
 import rclpy.utilities
 import std_msgs.msg
-
-from drqp_keyboard_control.control_state import GuiControlState
 
 EVENT_KEYS = {
     'space': 'kill_switch_pressed',

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keymap.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/keymap.py
@@ -17,3 +17,32 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+
+"""Translation of Pygame key codes into the normalized key names of the model."""
+
+
+def build_key_map(pygame) -> dict[int, str]:
+    """Map Pygame key codes to the normalized key names GuiControlState expects."""
+    return {
+        pygame.K_w: 'w',
+        pygame.K_a: 'a',
+        pygame.K_s: 's',
+        pygame.K_d: 'd',
+        pygame.K_b: 'b',
+        pygame.K_UP: 'up',
+        pygame.K_DOWN: 'down',
+        pygame.K_LEFT: 'left',
+        pygame.K_RIGHT: 'right',
+        pygame.K_TAB: 'tab',
+        pygame.K_1: '1',
+        pygame.K_2: '2',
+        pygame.K_3: '3',
+        pygame.K_PLUS: '+',
+        pygame.K_EQUALS: '=',
+        pygame.K_MINUS: '-',
+        pygame.K_UNDERSCORE: '_',
+        pygame.K_SPACE: 'space',
+        pygame.K_ESCAPE: 'esc',
+        pygame.K_DELETE: 'delete',
+        pygame.K_BACKSPACE: 'backspace',
+    }

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/layout.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/layout.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Minimal flexbox-style layout engine.
+
+Pure Python and Pygame-free so layouts can be unit tested. A layout is a tree
+of ``Row``/``Column`` containers and ``Box`` leaves. Leaves (and containers)
+may carry a ``key``; ``solve()`` computes the final rectangles for the given
+viewport and returns them indexed by key.
+
+Sizing model per node:
+- ``width``/``height``: fixed size on that dimension when set.
+- ``flex``: share of the leftover main-axis space in the parent container
+  (after fixed-size children and spacing are subtracted).
+- Otherwise a node falls back to its measured (intrinsic) size.
+
+Container extras: ``spacing`` between children, uniform ``padding``,
+``justify`` for main-axis placement of leftover space, and ``align`` for
+cross-axis placement (``stretch`` fills the cross axis).
+"""
+
+from dataclasses import dataclass, field
+import enum
+import math
+
+
+def clamp(value: float, minimum: float, maximum: float) -> float:
+    """Clamp value into inclusive range."""
+    return max(minimum, min(maximum, value))
+
+
+def clamp_vector(x: float, y: float) -> tuple[float, float]:
+    """Clamp a 2D vector into the unit circle."""
+    magnitude = math.hypot(x, y)
+    if magnitude <= 1.0:
+        return (x, y)
+    return (x / magnitude, y / magnitude)
+
+
+@dataclass
+class RectSpec:
+    """Small rectangle helper that keeps most GUI math Pygame-free."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+
+    def contains(self, pos: tuple[float, float]) -> bool:
+        """Return whether the point lies inside the rectangle."""
+        px, py = pos
+        return self.x <= px <= self.x + self.width and self.y <= py <= self.y + self.height
+
+    @property
+    def center(self) -> tuple[float, float]:
+        """Return the rectangle center point."""
+        return (self.x + self.width / 2.0, self.y + self.height / 2.0)
+
+
+class Justify(enum.Enum):
+    """Main-axis placement of children when leftover space remains."""
+
+    start = enum.auto()
+    center = enum.auto()
+    end = enum.auto()
+
+
+class Align(enum.Enum):
+    """
+    Cross-axis placement of a child inside a container.
+
+    ``stretch`` (the default, as in CSS flexbox) fills the cross axis unless
+    the child declares an explicit cross-axis size, which is then kept.
+    """
+
+    start = enum.auto()
+    center = enum.auto()
+    end = enum.auto()
+    stretch = enum.auto()
+
+
+@dataclass
+class Box:
+    """Leaf layout node, typically bound to a widget through its key."""
+
+    key: str | None = None
+    width: float | None = None
+    height: float | None = None
+    flex: float = 0.0
+
+    def measure(self) -> tuple[float, float]:
+        """Return the intrinsic (width, height) of this node."""
+        return (self.width or 0.0, self.height or 0.0)
+
+    def arrange(self, rect: RectSpec, rects: dict[str, RectSpec]):
+        """Assign the final rectangle, recording it under this node's key."""
+        if self.key is not None:
+            rects[self.key] = rect
+
+
+@dataclass
+class _Container(Box):
+    """Shared row/column behavior; subclasses select the main axis."""
+
+    children: list[Box] = field(default_factory=list)
+    spacing: float = 0.0
+    padding: float = 0.0
+    justify: Justify = Justify.start
+    align: Align = Align.stretch
+
+    # Index into a (width, height) tuple: 0 lays children out horizontally.
+    main_axis: int = 0
+
+    def measure(self) -> tuple[float, float]:
+        """Measure content plus spacing and padding, fixed sizes override."""
+        sizes = [child.measure() for child in self.children]
+        main = sum(size[self.main_axis] for size in sizes)
+        if self.children:
+            main += self.spacing * (len(self.children) - 1)
+        cross = max((size[1 - self.main_axis] for size in sizes), default=0.0)
+
+        measured = [0.0, 0.0]
+        measured[self.main_axis] = main + 2.0 * self.padding
+        measured[1 - self.main_axis] = cross + 2.0 * self.padding
+        return (
+            self.width if self.width is not None else measured[0],
+            self.height if self.height is not None else measured[1],
+        )
+
+    def arrange(self, rect: RectSpec, rects: dict[str, RectSpec]):
+        """Distribute the content rect between children along the main axis."""
+        super().arrange(rect, rects)
+
+        content = RectSpec(
+            rect.x + self.padding,
+            rect.y + self.padding,
+            max(0.0, rect.width - 2.0 * self.padding),
+            max(0.0, rect.height - 2.0 * self.padding),
+        )
+        content_size = (content.width, content.height)
+        main_extent = content_size[self.main_axis]
+        cross_extent = content_size[1 - self.main_axis]
+
+        main_sizes = self._resolve_main_sizes(main_extent)
+
+        used = sum(main_sizes) + self.spacing * max(0, len(self.children) - 1)
+        offset = self._justify_offset(main_extent - used)
+
+        cursor = (content.x, content.y)[self.main_axis]
+        cursor += offset
+        for child, main_size in zip(self.children, main_sizes):
+            cross_size, cross_offset = self._align_cross(child, cross_extent)
+
+            origin = [0.0, 0.0]
+            origin[self.main_axis] = cursor
+            origin[1 - self.main_axis] = (content.x, content.y)[1 - self.main_axis] + cross_offset
+            size = [0.0, 0.0]
+            size[self.main_axis] = main_size
+            size[1 - self.main_axis] = cross_size
+
+            child.arrange(RectSpec(origin[0], origin[1], size[0], size[1]), rects)
+            cursor += main_size + self.spacing
+
+    def _resolve_main_sizes(self, main_extent: float) -> list[float]:
+        fixed_sizes = [child.measure()[self.main_axis] for child in self.children]
+        total_spacing = self.spacing * max(0, len(self.children) - 1)
+        total_flex = sum(child.flex for child in self.children)
+        leftover = main_extent - total_spacing
+        leftover -= sum(size for child, size in zip(self.children, fixed_sizes) if not child.flex)
+        leftover = max(0.0, leftover)
+
+        sizes = []
+        for child, fixed_size in zip(self.children, fixed_sizes):
+            if child.flex and total_flex:
+                sizes.append(leftover * child.flex / total_flex)
+            else:
+                sizes.append(fixed_size)
+        return sizes
+
+    def _justify_offset(self, leftover: float) -> float:
+        leftover = max(0.0, leftover)
+        if self.justify == Justify.center:
+            return leftover / 2.0
+        if self.justify == Justify.end:
+            return leftover
+        return 0.0
+
+    def _align_cross(self, child: Box, cross_extent: float) -> tuple[float, float]:
+        if self.align == Align.stretch:
+            explicit = child.height if self.main_axis == 0 else child.width
+            if explicit is None:
+                return cross_extent, 0.0
+            return min(explicit, cross_extent), 0.0
+        cross_size = min(child.measure()[1 - self.main_axis], cross_extent)
+        if self.align == Align.center:
+            return cross_size, (cross_extent - cross_size) / 2.0
+        if self.align == Align.end:
+            return cross_size, cross_extent - cross_size
+        return cross_size, 0.0
+
+
+@dataclass
+class Row(_Container):
+    """Container that lays children out left to right."""
+
+    main_axis: int = 0
+
+
+@dataclass
+class Column(_Container):
+    """Container that lays children out top to bottom."""
+
+    main_axis: int = 1
+
+
+def solve(root: Box, width: float, height: float) -> dict[str, RectSpec]:
+    """Lay out the tree in the given viewport and return rects by node key."""
+    rects: dict[str, RectSpec] = {}
+    root.arrange(RectSpec(0.0, 0.0, width, height), rects)
+    return rects

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/layout.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/layout.py
@@ -182,18 +182,32 @@ class _Container(Box):
     def _resolve_main_sizes(self, main_extent: float) -> list[float]:
         fixed_sizes = [child.measure()[self.main_axis] for child in self.children]
         total_spacing = self.spacing * max(0, len(self.children) - 1)
-        total_flex = sum(child.flex for child in self.children)
+        flex_children = [
+            child
+            for child in self.children
+            if child.flex and self._explicit_main_axis_size(child) is None
+        ]
+        total_flex = sum(child.flex for child in flex_children)
         leftover = main_extent - total_spacing
-        leftover -= sum(size for child, size in zip(self.children, fixed_sizes) if not child.flex)
+        leftover -= sum(
+            size
+            for child, size in zip(self.children, fixed_sizes)
+            if not child.flex or self._explicit_main_axis_size(child) is not None
+        )
         leftover = max(0.0, leftover)
 
         sizes = []
         for child, fixed_size in zip(self.children, fixed_sizes):
-            if child.flex and total_flex:
+            if self._explicit_main_axis_size(child) is not None:
+                sizes.append(fixed_size)
+            elif child.flex and total_flex:
                 sizes.append(leftover * child.flex / total_flex)
             else:
                 sizes.append(fixed_size)
         return sizes
+
+    def _explicit_main_axis_size(self, child: Box) -> float | None:
+        return child.width if self.main_axis == 0 else child.height
 
     def _justify_offset(self, leftover: float) -> float:
         leftover = max(0.0, leftover)

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/renderer.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/renderer.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Pygame drawing of the widget models; the only module that paints pixels."""
+
+from drqp_keyboard_control.gui_controls import (
+    ButtonControl,
+    CheckboxControl,
+    Control,
+    LabelControl,
+    StickControl,
+    TriggerControl,
+)
+from drqp_keyboard_control.layout import RectSpec
+from drqp_keyboard_control.theme import DEFAULT_THEME, Theme
+
+CHECKBOX_BOX_SIZE = 20.0
+TEXT_GAP = 8.0
+
+HELP_PANEL_WIDTH = 390.0
+HELP_PANEL_PADDING = 18.0
+HELP_TITLE_HEIGHT = 34.0
+HELP_LINE_HEIGHT = 24.0
+
+
+class PygameRenderer:
+    """Draw widgets and overlays onto a Pygame surface using a theme."""
+
+    def __init__(self, pygame_module, screen, theme: Theme = DEFAULT_THEME):
+        self.pygame = pygame_module
+        self.screen = screen
+        self.theme = theme
+        self.font = pygame_module.font.Font(None, theme.font_size)
+        self.small_font = pygame_module.font.Font(None, theme.small_font_size)
+
+    def render(self, controls: list[Control], *, help_lines: list[str] | None = None):
+        """Draw a full frame: background, widgets, and optional help overlay."""
+        self.screen.fill(self.theme.background)
+        for control in controls:
+            self._draw_control(control)
+        if help_lines:
+            self._draw_help(help_lines)
+        self.pygame.display.flip()
+
+    def _draw_control(self, control: Control):
+        if isinstance(control, CheckboxControl):
+            self._draw_checkbox(control)
+        elif isinstance(control, ButtonControl):
+            self._draw_button(control)
+        elif isinstance(control, StickControl):
+            self._draw_stick(control)
+        elif isinstance(control, TriggerControl):
+            self._draw_trigger(control)
+        elif isinstance(control, LabelControl):
+            self._draw_label(control)
+
+    def _draw_button(self, button: ButtonControl):
+        theme = self.theme
+        selected = button.selected()
+        color = theme.button_selected if selected else theme.button_fill
+        if button.pressed:
+            color = theme.button_pressed
+        self._fill_rect(button.rect, color, radius=theme.button_radius)
+        self._outline_rect(button.rect, theme.button_border, radius=theme.button_radius)
+        text_color = theme.text_primary if selected or button.pressed else theme.text_normal
+        self._text_centered(button.label, button.rect.center, self.small_font, text_color)
+
+    def _draw_checkbox(self, checkbox: CheckboxControl):
+        theme = self.theme
+        center_x, center_y = checkbox.rect.center
+        box = RectSpec(
+            checkbox.rect.x,
+            center_y - CHECKBOX_BOX_SIZE / 2.0,
+            CHECKBOX_BOX_SIZE,
+            CHECKBOX_BOX_SIZE,
+        )
+        border = theme.checkbox_border_pressed if checkbox.pressed else theme.checkbox_border
+        self._fill_rect(box, theme.button_fill, radius=theme.checkbox_radius)
+        self._outline_rect(box, border, radius=theme.checkbox_radius)
+        if checkbox.selected():
+            mark = RectSpec(box.x + 5.0, box.y + 5.0, box.width - 10.0, box.height - 10.0)
+            self._fill_rect(mark, theme.checkbox_mark, radius=2)
+        label_pos = (box.x + box.width + TEXT_GAP, center_y)
+        self._text(checkbox.label, label_pos, self.small_font, theme.text_normal, anchor='midleft')
+
+    def _draw_stick(self, stick: StickControl):
+        pygame = self.pygame
+        theme = self.theme
+        center = stick.center
+        radius = stick.radius
+
+        pygame.draw.circle(self.screen, theme.stick_fill, center, radius)
+        pygame.draw.circle(self.screen, theme.stick_border, center, radius, 2)
+        for start, end in (
+            ((center[0] - radius, center[1]), (center[0] + radius, center[1])),
+            ((center[0], center[1] - radius), (center[0], center[1] + radius)),
+        ):
+            pygame.draw.line(self.screen, theme.stick_axis, start, end, 1)
+
+        x, y = stick.value()
+        knob = (center[0] + x * radius, center[1] - y * radius)
+        pygame.draw.circle(self.screen, theme.stick_knob, knob, theme.stick_knob_radius)
+        pygame.draw.circle(self.screen, theme.stick_knob_border, knob, theme.stick_knob_radius, 2)
+
+        name_pos = (center[0], center[1] - radius - TEXT_GAP)
+        self._text(stick.label, name_pos, self.font, theme.text_normal, anchor='midbottom')
+        value_pos = (center[0], center[1] + radius + TEXT_GAP)
+        readout = f'x={x:+.2f} y={y:+.2f}'
+        self._text(readout, value_pos, self.small_font, theme.text_muted, anchor='midtop')
+
+    def _draw_trigger(self, trigger: TriggerControl):
+        pygame = self.pygame
+        theme = self.theme
+        track = trigger.track_rect
+        value = trigger.value()
+
+        label_pos = (trigger.rect.center[0], trigger.rect.y)
+        self._text(trigger.label, label_pos, self.small_font, theme.text_normal, anchor='midtop')
+        self._fill_rect(track, theme.trigger_track, radius=theme.button_radius)
+
+        if trigger.vertical:
+            fill_height = track.height * value
+            fill_top = track.y + track.height - fill_height
+            fill = RectSpec(track.x, fill_top, track.width, fill_height)
+            knob = (track.center[0], track.y + track.height * (1.0 - value))
+        else:
+            fill = RectSpec(track.x, track.y, track.width * value, track.height)
+            knob = (track.x + track.width * value, track.center[1])
+        self._fill_rect(fill, theme.trigger_fill, radius=theme.button_radius)
+        pygame.draw.circle(self.screen, theme.trigger_knob, knob, theme.trigger_knob_radius)
+
+    def _draw_label(self, label: LabelControl):
+        pos = (label.rect.x, label.rect.center[1])
+        self._text(label.text(), pos, self.small_font, self.theme.text_muted, anchor='midleft')
+
+    def _draw_help(self, lines: list[str]):
+        theme = self.theme
+        screen_width, screen_height = self.screen.get_size()
+        panel_height = HELP_TITLE_HEIGHT + len(lines) * HELP_LINE_HEIGHT
+        panel_height += 2.0 * HELP_PANEL_PADDING
+        panel = RectSpec(
+            (screen_width - HELP_PANEL_WIDTH) / 2.0,
+            (screen_height - panel_height) / 2.0,
+            HELP_PANEL_WIDTH,
+            panel_height,
+        )
+        self._fill_rect(panel, theme.panel_fill, radius=theme.button_radius)
+        self._outline_rect(panel, theme.panel_border, radius=theme.button_radius)
+
+        text_x = panel.x + HELP_PANEL_PADDING
+        title_pos = (text_x, panel.y + HELP_PANEL_PADDING)
+        self._text('Keyboard Controls', title_pos, self.font, theme.text_primary)
+        for index, line in enumerate(lines):
+            line_y = panel.y + HELP_PANEL_PADDING + HELP_TITLE_HEIGHT
+            line_y += index * HELP_LINE_HEIGHT
+            self._text(line, (text_x, line_y), self.small_font, theme.text_normal)
+
+    def _text(self, text, pos, font, color, *, anchor: str = 'topleft'):
+        surface = font.render(text, True, color)
+        self.screen.blit(surface, surface.get_rect(**{anchor: pos}))
+
+    def _text_centered(self, text, center, font, color):
+        self._text(text, center, font, color, anchor='center')
+
+    def _fill_rect(self, rect: RectSpec, color, *, radius: int = 0):
+        self.pygame.draw.rect(self.screen, color, self._to_pygame(rect), border_radius=radius)
+
+    def _outline_rect(self, rect: RectSpec, color, *, radius: int = 0):
+        self.pygame.draw.rect(
+            self.screen, color, self._to_pygame(rect), width=1, border_radius=radius
+        )
+
+    def _to_pygame(self, rect: RectSpec):
+        return self.pygame.Rect(rect.x, rect.y, rect.width, rect.height)

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/sdl_window.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/sdl_window.py
@@ -108,6 +108,10 @@ def sdl_library_candidates() -> list[str]:
 
     unique_candidates = []
     for candidate in candidates:
-        if candidate and _is_core_sdl_library_name(candidate) and candidate not in unique_candidates:
+        if (
+            candidate
+            and _is_core_sdl_library_name(candidate)
+            and candidate not in unique_candidates
+        ):
             unique_candidates.append(candidate)
     return unique_candidates

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/sdl_window.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/sdl_window.py
@@ -26,6 +26,14 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+def _is_core_sdl_library_name(name: str) -> bool:
+    """Return whether a library filename points to the core SDL binary."""
+    stem = Path(name).name.lower()
+    if 'sdl2_ttf' in stem or 'sdl2_image' in stem or 'sdl2_mixer' in stem:
+        return False
+    return 'sdl2' in stem
+
+
 def set_sdl_window_always_on_top(window_id: int | None, enabled: bool) -> bool:
     """Set the Pygame SDL window topmost flag when SDL exposes the API."""
     if window_id is None:
@@ -90,12 +98,16 @@ def sdl_library_candidates() -> list[str]:
             if not search_dir.is_dir():
                 continue
             for pattern in patterns:
-                candidates.extend(str(path) for path in search_dir.glob(pattern))
+                candidates.extend(
+                    str(path)
+                    for path in search_dir.glob(pattern)
+                    if _is_core_sdl_library_name(str(path))
+                )
     except (ImportError, OSError):
         logger.debug('Unable to inspect pygame-bundled SDL libraries', exc_info=True)
 
     unique_candidates = []
     for candidate in candidates:
-        if candidate and candidate not in unique_candidates:
+        if candidate and _is_core_sdl_library_name(candidate) and candidate not in unique_candidates:
             unique_candidates.append(candidate)
     return unique_candidates

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/theme.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/theme.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Color palette, font sizes, and shape constants for the GUI."""
+
+from dataclasses import dataclass
+
+Color = tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class Theme:
+    """Visual style shared by every widget renderer."""
+
+    background: Color = (21, 24, 28)
+
+    text_primary: Color = (235, 239, 244)
+    text_normal: Color = (203, 211, 219)
+    text_muted: Color = (178, 187, 197)
+
+    button_fill: Color = (47, 54, 61)
+    button_selected: Color = (63, 132, 103)
+    button_pressed: Color = (150, 80, 68)
+    button_border: Color = (111, 126, 140)
+    button_radius: int = 6
+
+    checkbox_border: Color = (150, 163, 177)
+    checkbox_border_pressed: Color = (210, 218, 226)
+    checkbox_mark: Color = (86, 160, 133)
+    checkbox_radius: int = 4
+
+    stick_fill: Color = (38, 44, 51)
+    stick_border: Color = (91, 104, 118)
+    stick_axis: Color = (62, 70, 80)
+    stick_knob: Color = (86, 160, 133)
+    stick_knob_border: Color = (235, 239, 244)
+    stick_knob_radius: int = 34
+
+    trigger_track: Color = (45, 51, 58)
+    trigger_fill: Color = (80, 130, 184)
+    trigger_knob: Color = (235, 239, 244)
+    trigger_knob_radius: int = 14
+
+    panel_fill: Color = (34, 39, 45)
+    panel_border: Color = (118, 132, 146)
+
+    font_size: int = 28
+    small_font_size: int = 22
+
+
+DEFAULT_THEME = Theme()

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/ui.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/ui.py
@@ -30,7 +30,6 @@ position on screen comes from the layout engine — no hardcoded coordinates.
 from typing import Callable
 
 from drqp_brain.joystick_input_handler import all_control_modes
-
 from drqp_keyboard_control.gui_controls import (
     ButtonControl,
     CheckboxControl,

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/ui.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/ui.py
@@ -184,16 +184,18 @@ def build_layout() -> Column:
     checkbox_width, checkbox_height = CHECKBOX_SIZE
     action_width, action_height = ACTION_BUTTON_SIZE
 
+    spacing = 14.0
+
     def button_row(keys: list[str]) -> Row:
         return Row(
             children=[Box(key=key, width=button_width, height=button_height) for key in keys],
-            spacing=14.0,
+            spacing=spacing,
             justify=Justify.center,
         )
 
     return Column(
         padding=16.0,
-        spacing=12.0,
+        spacing=spacing,
         children=[
             button_row([f'mode.{mode.name}' for mode in all_control_modes]),
             button_row([f'gait.{index}' for index in range(len(GAIT_LABELS))]),
@@ -203,13 +205,13 @@ def build_layout() -> Column:
                     Box(key='stay_on_top', width=checkbox_width, height=checkbox_height),
                     Box(key='balance', width=checkbox_width, height=checkbox_height),
                 ],
-                spacing=20.0,
+                spacing=spacing,
                 justify=Justify.center,
                 align=Align.center,
             ),
             Row(
                 flex=1.0,
-                spacing=24.0,
+                spacing=spacing,
                 children=[
                     Box(key='left_trigger', width=TRIGGER_COLUMN_WIDTH),
                     Box(key='left_stick', flex=1.0),
@@ -226,7 +228,7 @@ def build_layout() -> Column:
                     )
                     for event in ('kill_switch_pressed', 'finalize', 'reboot_servos')
                 ],
-                spacing=12.0,
+                spacing=spacing,
                 justify=Justify.center,
             ),
             Row(

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/ui.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/ui.py
@@ -58,7 +58,6 @@ GAIT_LABELS = ['Tripod', 'Ripple', 'Wave']
 
 BUTTON_SIZE = (136.0, 38.0)
 ACTION_BUTTON_SIZE = (118.0, 42.0)
-CHECKBOX_SIZE = (150.0, 28.0)
 TRIGGER_COLUMN_WIDTH = 90.0
 STATUS_BAR_SIZE = (260.0, 20.0)
 
@@ -181,7 +180,7 @@ def build_controls(
 def build_layout() -> Column:
     """Describe the whole window as a layout tree keyed by widget."""
     button_width, button_height = BUTTON_SIZE
-    checkbox_width, checkbox_height = CHECKBOX_SIZE
+    checkbox_width, checkbox_height = BUTTON_SIZE
     action_width, action_height = ACTION_BUTTON_SIZE
 
     spacing = 14.0

--- a/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/ui.py
+++ b/packages/simulation/drqp_keyboard_control/drqp_keyboard_control/ui.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Declarative UI definition: which widgets exist and how they are laid out.
+
+Pygame-free. ``build_controls`` wires widgets to the node/state callbacks,
+``build_layout`` describes the screen as a layout tree, and ``apply_layout``
+assigns solved rectangles to the widgets by their ``layout_key``. Every
+position on screen comes from the layout engine — no hardcoded coordinates.
+"""
+
+from typing import Callable
+
+from drqp_brain.joystick_input_handler import all_control_modes
+
+from drqp_keyboard_control.gui_controls import (
+    ButtonControl,
+    CheckboxControl,
+    Control,
+    LabelControl,
+    StickControl,
+    TriggerControl,
+)
+from drqp_keyboard_control.layout import Align, Box, Column, Justify, Row, solve
+
+KEYBOARD_HELP_LINES = [
+    'W/A/S/D: left stick',
+    'Arrow keys: right stick',
+    'Hold multiple movement keys together',
+    'Tab: cycle mode',
+    '1/2/3: select Tripod/Ripple/Wave',
+    'B: toggle balance mode',
+    '+/-: adjust keyboard sensitivity',
+    'Space or Esc: kill switch',
+    'Delete: reboot servos',
+    'Backspace: finalize',
+]
+
+GAIT_LABELS = ['Tripod', 'Ripple', 'Wave']
+
+BUTTON_SIZE = (136.0, 38.0)
+ACTION_BUTTON_SIZE = (118.0, 42.0)
+CHECKBOX_SIZE = (150.0, 28.0)
+TRIGGER_COLUMN_WIDTH = 90.0
+STATUS_BAR_SIZE = (260.0, 20.0)
+
+
+def build_controls(
+    node,
+    *,
+    toggle_help: Callable[[], None],
+    help_visible: Callable[[], bool],
+    toggle_stay_on_top: Callable[[], None],
+    stay_on_top_enabled: Callable[[], bool],
+) -> list[Control]:
+    """Create every widget, bound to the node's state and the app toggles."""
+    state = node.state
+    controls: list[Control] = []
+
+    for mode in all_control_modes:
+        controls.append(
+            ButtonControl(
+                label=mode.name,
+                layout_key=f'mode.{mode.name}',
+                action=lambda selected_mode=mode: state.set_control_mode(selected_mode),
+                selected=lambda selected_mode=mode: state.control_mode == selected_mode,
+            )
+        )
+
+    for index, label in enumerate(GAIT_LABELS):
+        controls.append(
+            ButtonControl(
+                label=label,
+                layout_key=f'gait.{index}',
+                action=lambda selected_index=index: state.set_gait_index(selected_index),
+                selected=lambda selected_index=index: state.gait_index == selected_index,
+            )
+        )
+
+    controls.append(
+        ButtonControl(
+            label='Help',
+            layout_key='help',
+            action=toggle_help,
+            selected=help_visible,
+        )
+    )
+    controls.append(
+        CheckboxControl(
+            label='Stay on top',
+            layout_key='stay_on_top',
+            action=toggle_stay_on_top,
+            selected=stay_on_top_enabled,
+        )
+    )
+    controls.append(
+        CheckboxControl(
+            label='Balance Mode',
+            layout_key='balance',
+            action=node.toggle_balance_mode,
+            selected=lambda: node.balance_mode_enabled,
+        )
+    )
+
+    controls.append(
+        TriggerControl(
+            label='Left Trigger',
+            layout_key='left_trigger',
+            on_change=state.set_left_trigger,
+            value=lambda: state.left_trigger,
+        )
+    )
+    controls.append(
+        StickControl(
+            label='Left Stick',
+            layout_key='left_stick',
+            on_move=state.set_left_stick,
+            on_release=state.release_left_stick,
+            value=lambda: (state.axes().left_x, state.axes().left_y),
+        )
+    )
+    controls.append(
+        StickControl(
+            label='Right Stick',
+            layout_key='right_stick',
+            on_move=state.set_right_stick,
+            on_release=state.release_right_stick,
+            value=lambda: (state.axes().right_x, state.axes().right_y),
+        )
+    )
+    controls.append(
+        TriggerControl(
+            label='Right Trigger',
+            layout_key='right_trigger',
+            on_change=state.set_right_trigger,
+            value=lambda: state.right_trigger,
+        )
+    )
+
+    for event, label in (
+        ('kill_switch_pressed', 'Kill Switch'),
+        ('finalize', 'Finalize'),
+        ('reboot_servos', 'Reboot'),
+    ):
+        controls.append(
+            ButtonControl(
+                label=label,
+                layout_key=f'action.{event}',
+                action=lambda event_name=event: node.publish_event(event_name),
+            )
+        )
+
+    controls.append(
+        LabelControl(
+            label='Sensitivity',
+            layout_key='sensitivity',
+            text=lambda: f'Sensitivity {state.sensitivity:.2f}',
+        )
+    )
+    return controls
+
+
+def build_layout() -> Column:
+    """Describe the whole window as a layout tree keyed by widget."""
+    button_width, button_height = BUTTON_SIZE
+    checkbox_width, checkbox_height = CHECKBOX_SIZE
+    action_width, action_height = ACTION_BUTTON_SIZE
+
+    def button_row(keys: list[str]) -> Row:
+        return Row(
+            children=[Box(key=key, width=button_width, height=button_height) for key in keys],
+            spacing=14.0,
+            justify=Justify.center,
+        )
+
+    return Column(
+        padding=16.0,
+        spacing=12.0,
+        children=[
+            button_row([f'mode.{mode.name}' for mode in all_control_modes]),
+            button_row([f'gait.{index}' for index in range(len(GAIT_LABELS))]),
+            Row(
+                children=[
+                    Box(key='help', width=button_width, height=button_height),
+                    Box(key='stay_on_top', width=checkbox_width, height=checkbox_height),
+                    Box(key='balance', width=checkbox_width, height=checkbox_height),
+                ],
+                spacing=20.0,
+                justify=Justify.center,
+                align=Align.center,
+            ),
+            Row(
+                flex=1.0,
+                spacing=24.0,
+                children=[
+                    Box(key='left_trigger', width=TRIGGER_COLUMN_WIDTH),
+                    Box(key='left_stick', flex=1.0),
+                    Box(key='right_stick', flex=1.0),
+                    Box(key='right_trigger', width=TRIGGER_COLUMN_WIDTH),
+                ],
+            ),
+            Row(
+                children=[
+                    Box(
+                        key=f'action.{event}',
+                        width=action_width,
+                        height=action_height,
+                    )
+                    for event in ('kill_switch_pressed', 'finalize', 'reboot_servos')
+                ],
+                spacing=12.0,
+                justify=Justify.center,
+            ),
+            Row(
+                children=[
+                    Box(key='sensitivity', width=STATUS_BAR_SIZE[0], height=STATUS_BAR_SIZE[1]),
+                ],
+            ),
+        ],
+    )
+
+
+def apply_layout(controls: list[Control], width: float, height: float):
+    """Solve the layout for the viewport and position every widget."""
+    rects = solve(build_layout(), width, height)
+    for control in controls:
+        control.rect = rects[control.layout_key]

--- a/packages/simulation/drqp_keyboard_control/package.xml
+++ b/packages/simulation/drqp_keyboard_control/package.xml
@@ -19,6 +19,8 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>drqp_launch_testing</test_depend>
+  <test_depend>launch_pytest</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/packages/simulation/drqp_keyboard_control/test/__init__.py
+++ b/packages/simulation/drqp_keyboard_control/test/__init__.py
@@ -1,43 +1,19 @@
-"""Tests for drqp_keyboard_control."""
-
-from __future__ import annotations
-
-import os
-from pathlib import Path
-import unittest
-from unittest import mock
-import warnings
-
-import pytest
-from pytest import PytestDeprecationWarning
-
-
-def _run_pytest_suite() -> None:
-    test_dir = Path(__file__).parent
-    with (
-        warnings.catch_warnings(),
-        mock.patch.dict(
-            os.environ,
-            {'PYTEST_DISABLE_PLUGIN_AUTOLOAD': '1'},
-        ),
-    ):
-        warnings.filterwarnings(
-            'ignore',
-            message=r'The \(path: py\.path\.local\) argument is deprecated.*',
-            category=PytestDeprecationWarning,
-        )
-        exit_code = pytest.main([test_dir, '-q'])
-    if exit_code != 0:
-        raise AssertionError(f'pytest exited with code {exit_code}')
-
-
-def load_tests(
-    loader: unittest.TestLoader,
-    tests: unittest.TestSuite,
-    pattern: str | None,
-) -> unittest.TestSuite:
-    del loader, tests, pattern
-
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.FunctionTestCase(_run_pytest_suite))
-    return suite
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -134,3 +134,10 @@ def test_stay_on_top_toggle_updates_state_and_applies_best_effort(app):
     checkbox.action()
     assert app.stay_on_top is False
     assert requested_states == [True, False]
+
+
+def test_display_window_id_uses_wm_info_window_handle(app):
+    """Window-id discovery should use the stable WM info handle when present."""
+    app.pygame.display.get_wm_info = lambda: {'window': 42}
+
+    assert app._display_window_id() == 42

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -21,7 +21,9 @@
 """App-level tests running Pygame headless through the SDL dummy driver."""
 
 import os
-from unittest.mock import Mock
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from drqp_keyboard_control.control_state import GuiControlState
 import pytest
@@ -137,7 +139,13 @@ def test_stay_on_top_toggle_updates_state_and_applies_best_effort(app):
 
 
 def test_display_window_id_uses_wm_info_window_handle(app):
-    """Window-id discovery should use the stable WM info handle when present."""
-    app.pygame.display.get_wm_info = lambda: {'window': 42}
+    """Window-id discovery should prefer SDL's display window identifier."""
+    app.pygame.display.get_wm_info = lambda: {'window': 99}
+    fake_window_type = type(
+        'FakeWindowType',
+        (),
+        {'from_display_module': staticmethod(lambda: type('FakeWindow', (), {'id': 42})())},
+    )
 
-    assert app._display_window_id() == 42
+    with patch.dict(sys.modules, {'pygame._sdl2.video': SimpleNamespace(Window=fake_window_type)}):
+        assert app._display_window_id() == 42

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -144,8 +144,8 @@ def test_stay_on_top_looks_up_window_id_lazily(app):
     app.window_id = None
     app._display_window_id = lambda: 42
     requested = []
-    app._apply_stay_on_top = (
-        lambda enabled: requested.append(enabled) or setattr(app, 'window_id', 42) or True
+    app._apply_stay_on_top = lambda enabled: (
+        requested.append(enabled) or setattr(app, 'window_id', 42) or True
     )
 
     find_control(app, 'stay_on_top').action()

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -74,7 +74,7 @@ def test_mouse_drag_on_stick_drives_state(app):
     pygame.event.post(pygame.event.Event(pygame.MOUSEBUTTONDOWN, button=1, pos=grab))
     pygame.event.post(pygame.event.Event(pygame.MOUSEMOTION, pos=target))
     app._handle_events()
-    assert app.node.state.axes().left_x == pytest.approx(1.0)
+    assert app.node.state.axes().left_x == pytest.approx(1.0, abs=0.01)
 
     pygame.event.post(pygame.event.Event(pygame.MOUSEBUTTONUP, button=1, pos=target))
     app._handle_events()
@@ -144,8 +144,8 @@ def test_stay_on_top_looks_up_window_id_lazily(app):
     app.window_id = None
     app._display_window_id = lambda: 42
     requested = []
-    app._apply_stay_on_top = (
-        lambda enabled: requested.append(enabled) or setattr(app, 'window_id', 42) or True
+    app._apply_stay_on_top = lambda enabled: (
+        requested.append(enabled) or setattr(app, 'window_id', 42) or True
     )
 
     find_control(app, 'stay_on_top').action()

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""App-level tests running Pygame headless through the SDL dummy driver."""
+
+import os
+from unittest.mock import Mock
+
+from drqp_keyboard_control.control_state import GuiControlState
+import pytest
+
+
+@pytest.fixture
+def app():
+    """Construct the app against a node double using the dummy SDL driver."""
+    os.environ['SDL_VIDEODRIVER'] = 'dummy'
+    os.environ['SDL_AUDIODRIVER'] = 'dummy'
+
+    from drqp_keyboard_control.keyboard_control_app import PygameKeyboardControlApp
+
+    node = Mock()
+    node.state = GuiControlState()
+    node.balance_mode_enabled = False
+    app = PygameKeyboardControlApp(node, width=980, height=640)
+    yield app
+    app.close()
+
+
+def find_control(app, layout_key):
+    """Return the widget bound to the given layout key."""
+    return next(c for c in app.controls if c.layout_key == layout_key)
+
+
+def test_key_events_are_normalized_and_forwarded(app):
+    """Known keys should reach the node; unknown keys must be ignored."""
+    pygame = app.pygame
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_w))
+    pygame.event.post(pygame.event.Event(pygame.KEYUP, key=pygame.K_w))
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_F1))
+
+    app._handle_events()
+
+    app.node.handle_key_down.assert_called_once_with('w')
+    app.node.handle_key_up.assert_called_once_with('w')
+
+
+def test_mouse_drag_on_stick_drives_state(app):
+    """A press-drag-release on the stick should drive the control state."""
+    pygame = app.pygame
+    stick = find_control(app, 'left_stick')
+    center_x, center_y = stick.center
+    grab = (int(center_x), int(center_y))
+    target = (int(center_x + stick.radius), int(center_y))
+
+    pygame.event.post(pygame.event.Event(pygame.MOUSEBUTTONDOWN, button=1, pos=grab))
+    pygame.event.post(pygame.event.Event(pygame.MOUSEMOTION, pos=target))
+    app._handle_events()
+    assert app.node.state.axes().left_x == pytest.approx(1.0)
+
+    pygame.event.post(pygame.event.Event(pygame.MOUSEBUTTONUP, button=1, pos=target))
+    app._handle_events()
+    assert app.node.state.axes().left_x == pytest.approx(0.0)
+
+
+def test_button_click_fires_action(app):
+    """Clicking inside a button rect should trigger its action."""
+    pygame = app.pygame
+    kill = find_control(app, 'action.kill_switch_pressed')
+    pos = (int(kill.rect.center[0]), int(kill.rect.center[1]))
+
+    pygame.event.post(pygame.event.Event(pygame.MOUSEBUTTONDOWN, button=1, pos=pos))
+    pygame.event.post(pygame.event.Event(pygame.MOUSEBUTTONUP, button=1, pos=pos))
+    app._handle_events()
+
+    app.node.publish_event.assert_called_once_with('kill_switch_pressed')
+
+
+def test_window_resize_relayouts_widgets(app):
+    """A resize event should re-solve the layout for the new size."""
+    pygame = app.pygame
+    stick = find_control(app, 'right_stick')
+    old_rect = stick.rect
+
+    pygame.event.post(pygame.event.Event(pygame.VIDEORESIZE, w=1600, h=1000))
+    app._handle_events()
+
+    assert stick.rect != old_rect
+
+
+def test_quit_event_stops_the_robot_and_the_loop(app):
+    """Closing the window should publish a stop command and end the loop."""
+    pygame = app.pygame
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+
+    app._handle_events()
+
+    app.node.publish_stop_command.assert_called_once_with()
+    assert app.running is False
+
+
+def test_render_smoke_headless(app):
+    """A full frame render must succeed, including the help overlay."""
+    app._render()
+    app.show_help = True
+    app._render()
+
+
+def test_stay_on_top_toggle_updates_state_and_applies_best_effort(app):
+    """Stay-on-top checkbox should reflect clicks even if the platform call fails."""
+    requested_states = []
+    app._apply_stay_on_top = lambda enabled: requested_states.append(enabled) and False
+
+    checkbox = find_control(app, 'stay_on_top')
+    checkbox.action()
+    assert app.stay_on_top is True
+
+    checkbox.action()
+    assert app.stay_on_top is False
+    assert requested_states == [True, False]

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -125,45 +125,31 @@ def test_render_smoke_headless(app):
 
 
 def test_stay_on_top_toggle_updates_state_and_applies_best_effort(app):
-    """Stay-on-top checkbox should queue and then apply the platform change."""
+    """Stay-on-top checkbox should reflect clicks even if the platform call fails."""
     requested_states = []
     app._apply_stay_on_top = lambda enabled: requested_states.append(enabled) and False
 
     checkbox = find_control(app, 'stay_on_top')
     checkbox.action()
     assert app.stay_on_top is True
-    assert requested_states == []
-
-    app._flush_stay_on_top()
     assert requested_states == [True]
 
     checkbox.action()
     assert app.stay_on_top is False
-    assert requested_states == [True]
-
-    app._flush_stay_on_top()
     assert requested_states == [True, False]
 
 
 def test_stay_on_top_looks_up_window_id_lazily(app):
-    """Window-id discovery should be deferred until the queued toggle is flushed."""
+    """Window-id discovery should be deferred until topmost support is used."""
     app.window_id = None
     app._display_window_id = lambda: 42
     requested = []
-
-    def apply(enabled):
-        requested.append(enabled)
-        app.window_id = 42
-        return True
-
-    app._apply_stay_on_top = apply
+    app._apply_stay_on_top = (
+        lambda enabled: requested.append(enabled) or setattr(app, 'window_id', 42) or True
+    )
 
     find_control(app, 'stay_on_top').action()
 
-    assert app.window_id is None
-    assert requested == []
-
-    app._flush_stay_on_top()
     assert app.window_id == 42
     assert requested == [True]
 

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -95,14 +95,18 @@ def test_button_click_fires_action(app):
 
 
 def test_window_resize_relayouts_widgets(app):
-    """A resize event should re-solve the layout for the new size."""
+    """A resize event should resize the display and re-solve the layout."""
     pygame = app.pygame
     stick = find_control(app, 'right_stick')
     old_rect = stick.rect
+    old_screen = app.screen
 
     pygame.event.post(pygame.event.Event(pygame.VIDEORESIZE, w=1600, h=1000))
     app._handle_events()
 
+    assert app.screen.get_size() == (1600, 1000)
+    assert app.renderer.screen is app.screen
+    assert old_screen.get_size() == (1600, 1000)
     assert stick.rect != old_rect
 
 

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -125,30 +125,45 @@ def test_render_smoke_headless(app):
 
 
 def test_stay_on_top_toggle_updates_state_and_applies_best_effort(app):
-    """Stay-on-top checkbox should reflect clicks even if the platform call fails."""
+    """Stay-on-top checkbox should queue and then apply the platform change."""
     requested_states = []
     app._apply_stay_on_top = lambda enabled: requested_states.append(enabled) and False
 
     checkbox = find_control(app, 'stay_on_top')
     checkbox.action()
     assert app.stay_on_top is True
+    assert requested_states == []
+
+    app._flush_stay_on_top()
+    assert requested_states == [True]
 
     checkbox.action()
     assert app.stay_on_top is False
+    assert requested_states == [True]
+
+    app._flush_stay_on_top()
     assert requested_states == [True, False]
 
 
 def test_stay_on_top_looks_up_window_id_lazily(app):
-    """Window-id discovery should be deferred until topmost support is used."""
+    """Window-id discovery should be deferred until the queued toggle is flushed."""
     app.window_id = None
     app._display_window_id = lambda: 42
     requested = []
-    app._apply_stay_on_top = (
-        lambda enabled: requested.append(enabled) or setattr(app, 'window_id', 42) or True
-    )
+
+    def apply(enabled):
+        requested.append(enabled)
+        app.window_id = 42
+        return True
+
+    app._apply_stay_on_top = apply
 
     find_control(app, 'stay_on_top').action()
 
+    assert app.window_id is None
+    assert requested == []
+
+    app._flush_stay_on_top()
     assert app.window_id == 42
     assert requested == [True]
 

--- a/packages/simulation/drqp_keyboard_control/test/test_app.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_app.py
@@ -138,6 +138,21 @@ def test_stay_on_top_toggle_updates_state_and_applies_best_effort(app):
     assert requested_states == [True, False]
 
 
+def test_stay_on_top_looks_up_window_id_lazily(app):
+    """Window-id discovery should be deferred until topmost support is used."""
+    app.window_id = None
+    app._display_window_id = lambda: 42
+    requested = []
+    app._apply_stay_on_top = (
+        lambda enabled: requested.append(enabled) or setattr(app, 'window_id', 42) or True
+    )
+
+    find_control(app, 'stay_on_top').action()
+
+    assert app.window_id == 42
+    assert requested == [True]
+
+
 def test_display_window_id_uses_wm_info_window_handle(app):
     """Window-id discovery should prefer SDL's display window identifier."""
     app.pygame.display.get_wm_info = lambda: {'window': 99}

--- a/packages/simulation/drqp_keyboard_control/test/test_control_state.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_control_state.py
@@ -1,0 +1,377 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from drqp_brain.joystick_input_handler import ControlMode
+from drqp_interfaces.msg import MovementCommandConstants
+from drqp_keyboard_control.control_state import GuiControlState, VirtualAxes
+import pytest
+
+
+def test_wasd_key_down_up_holds_until_release():
+    """Keyboard axes should use key state instead of repeat timeouts."""
+    state = GuiControlState(sensitivity=0.5)
+
+    assert state.key_down('w') is True
+    assert state.axes().left_y == pytest.approx(0.5)
+    assert state.axes().left_y == pytest.approx(0.5)
+
+    assert state.key_up('w') is True
+    assert state.axes().left_y == pytest.approx(0.0)
+
+
+def test_repeated_key_down_reports_no_change():
+    """OS key-repeat events should not report state changes."""
+    state = GuiControlState()
+
+    assert state.key_down('w') is True
+    assert state.key_down('w') is False
+    assert state.key_up('w') is True
+    assert state.key_up('w') is False
+
+
+def test_multiple_keyboard_keys_combine_across_sticks():
+    """WASD and arrow keys should work while held together."""
+    state = GuiControlState(sensitivity=0.75)
+
+    for key in ('w', 'd', 'left', 'up'):
+        state.key_down(key)
+
+    axes = state.axes()
+    assert axes.left_x == pytest.approx(0.75)
+    assert axes.left_y == pytest.approx(0.75)
+    assert axes.right_x == pytest.approx(-0.75)
+    assert axes.right_y == pytest.approx(0.75)
+
+
+def test_opposite_keyboard_keys_cancel_on_axis():
+    """Opposite held keys should cancel each other."""
+    state = GuiControlState(sensitivity=0.6)
+
+    state.key_down('w')
+    state.key_down('s')
+    state.key_down('left')
+    state.key_down('right')
+
+    axes = state.axes()
+    assert axes.left_y == pytest.approx(0.0)
+    assert axes.right_x == pytest.approx(0.0)
+
+
+def test_pointer_stick_takes_precedence_over_keyboard_until_released():
+    """Dragged virtual sticks should override keyboard axes for that stick."""
+    state = GuiControlState(sensitivity=0.5)
+    state.key_down('w')
+
+    state.set_left_stick(-0.25, -0.5)
+    assert state.axes().left_x == pytest.approx(-0.25)
+    assert state.axes().left_y == pytest.approx(-0.5)
+
+    state.key_down('d')
+    assert state.axes().left_x == pytest.approx(-0.25)
+
+    state.release_left_stick()
+    assert state.axes().left_x == pytest.approx(0.5)
+    assert state.axes().left_y == pytest.approx(0.5)
+
+
+def test_pointer_stick_clamps_to_unit_circle():
+    """Pointer input should be limited to the unit circle."""
+    state = GuiControlState()
+
+    state.set_left_stick(3.0, 4.0)
+
+    assert state.axes().left_x == pytest.approx(0.6)
+    assert state.axes().left_y == pytest.approx(0.8)
+
+
+def test_walk_mode_stick_release_springs_to_center():
+    """In Walk mode releasing the stick must stop the robot."""
+    state = GuiControlState()
+
+    state.set_right_stick(0.7, -0.2)
+    state.release_right_stick()
+
+    assert state.axes().right_x == pytest.approx(0.0)
+    assert state.axes().right_y == pytest.approx(0.0)
+
+
+def test_body_mode_stick_release_latches_in_place():
+    """In body modes releasing the stick must keep its value."""
+    state = GuiControlState()
+    state.set_control_mode(ControlMode.BodyPosition)
+
+    state.set_left_stick(0.3, 0.6)
+    state.release_left_stick()
+
+    assert state.axes().left_x == pytest.approx(0.3)
+    assert state.axes().left_y == pytest.approx(0.6)
+    assert state.left_stick.latched is True
+
+    command = state.movement_command()
+    assert command.body_translation.x == pytest.approx(0.6)
+    assert command.body_translation.y == pytest.approx(-0.3)
+
+
+def test_body_rotation_stick_release_latches_in_place():
+    """Body rotation mode should latch exactly like body position mode."""
+    state = GuiControlState()
+    state.set_control_mode(ControlMode.BodyRotation)
+
+    state.set_right_stick(-0.4, 0.0)
+    state.release_right_stick()
+
+    command = state.movement_command()
+    assert command.body_rotation.z == pytest.approx(0.4)
+
+
+def test_body_pose_survives_switch_to_walk_mode():
+    """Switching to Walk must keep the latched body pose in commands."""
+    state = GuiControlState()
+    state.set_control_mode(ControlMode.BodyPosition)
+    state.set_left_stick(0.2, 0.5)
+    state.release_left_stick()
+
+    state.set_control_mode(ControlMode.Walk)
+    command = state.movement_command()
+
+    assert command.body_translation.x == pytest.approx(0.5)
+    assert command.body_translation.y == pytest.approx(-0.2)
+    assert command.stride_direction.x == pytest.approx(0.0)
+    assert command.stride_direction.y == pytest.approx(0.0)
+
+
+def test_mode_switch_restores_latched_stick_positions():
+    """Re-entering a body mode should restore its latched stick values."""
+    state = GuiControlState()
+    state.set_control_mode(ControlMode.BodyPosition)
+    state.set_left_stick(0.25, -0.75)
+    state.release_left_stick()
+
+    state.set_control_mode(ControlMode.BodyRotation)
+    assert state.axes().left_x == pytest.approx(0.0)
+
+    state.set_control_mode(ControlMode.BodyPosition)
+    assert state.axes().left_x == pytest.approx(0.25)
+    assert state.axes().left_y == pytest.approx(-0.75)
+
+
+def test_leaving_walk_mode_stops_walking():
+    """Stride and rotation must be zeroed when leaving Walk mode."""
+    state = GuiControlState(sensitivity=1.0)
+    state.key_down('w')
+    state.movement_command()
+
+    state.set_control_mode(ControlMode.BodyPosition)
+    command = state.movement_command()
+
+    assert command.stride_direction.x == pytest.approx(0.0)
+    assert command.stride_direction.y == pytest.approx(0.0)
+    assert command.rotation_speed == pytest.approx(0.0)
+
+
+def test_entering_walk_mode_resumes_keyboard_and_springs_pointer_input():
+    """Walk mode entry should reflect held keys, not stale latched values."""
+    state = GuiControlState(sensitivity=0.5)
+    state.set_control_mode(ControlMode.BodyPosition)
+    state.set_left_stick(0.9, 0.0)
+    state.release_left_stick()
+    state.key_down('w')
+
+    state.set_control_mode(ControlMode.Walk)
+
+    assert state.axes().left_x == pytest.approx(0.0)
+    assert state.axes().left_y == pytest.approx(0.5)
+
+
+def test_keyboard_press_in_body_mode_overrides_latch():
+    """Fresh keyboard input should take over a latched stick."""
+    state = GuiControlState(sensitivity=0.5)
+    state.set_control_mode(ControlMode.BodyPosition)
+    state.set_left_stick(0.9, 0.9)
+    state.release_left_stick()
+
+    state.key_down('s')
+
+    assert state.axes().left_x == pytest.approx(0.0)
+    assert state.axes().left_y == pytest.approx(-0.5)
+
+
+def test_keyboard_release_in_body_mode_latches_value():
+    """Releasing the last motion key in a body mode should hold the value."""
+    state = GuiControlState(sensitivity=0.4)
+    state.set_control_mode(ControlMode.BodyRotation)
+
+    state.key_down('a')
+    state.key_up('a')
+
+    assert state.axes().left_x == pytest.approx(-0.4)
+    assert state.left_stick.latched is True
+
+
+def test_sensitivity_adjustment_applies_to_held_keys():
+    """Changing sensitivity while keys are held should rescale the stick."""
+    state = GuiControlState(sensitivity=0.5, sensitivity_step=0.1)
+    state.key_down('w')
+
+    state.key_down('+')
+
+    assert state.sensitivity == pytest.approx(0.6)
+    assert state.axes().left_y == pytest.approx(0.6)
+
+
+def test_sensitivity_adjustment_is_clamped():
+    """Plus and minus keys should adjust the emulated stick magnitude."""
+    state = GuiControlState(sensitivity=0.95, sensitivity_step=0.1)
+
+    state.key_down('+')
+    assert state.sensitivity == pytest.approx(1.0)
+
+    for _ in range(20):
+        state.key_down('-')
+
+    assert state.sensitivity == pytest.approx(0.1)
+
+
+def test_sensitivity_adjustment_keeps_latched_sticks():
+    """Sensitivity changes must not clobber a latched pointer value."""
+    state = GuiControlState()
+    state.set_control_mode(ControlMode.BodyPosition)
+    state.set_left_stick(0.3, 0.3)
+    state.release_left_stick()
+
+    state.adjust_sensitivity(0.1)
+
+    assert state.axes().left_x == pytest.approx(0.3)
+    assert state.axes().left_y == pytest.approx(0.3)
+
+
+def test_tab_cycles_control_modes():
+    """TAB should cycle through the same control modes as the joystick node."""
+    state = GuiControlState()
+
+    state.key_down('tab')
+    assert state.control_mode == ControlMode.BodyPosition
+
+    state.key_down('tab')
+    assert state.control_mode == ControlMode.BodyRotation
+
+    state.key_down('tab')
+    assert state.control_mode == ControlMode.Walk
+
+
+def test_control_mode_is_read_only_attribute():
+    """Direct assignment must be rejected; set_control_mode owns transitions."""
+    state = GuiControlState()
+
+    with pytest.raises(AttributeError):
+        state.control_mode = ControlMode.BodyPosition
+
+
+def test_number_keys_select_gaits():
+    """Number keys should directly select tripod, ripple, and wave gaits."""
+    state = GuiControlState()
+
+    state.key_down('2')
+    assert state.gait == MovementCommandConstants.GAIT_RIPPLE
+
+    state.key_down('3')
+    assert state.gait == MovementCommandConstants.GAIT_WAVE
+
+    state.key_down('1')
+    assert state.gait == MovementCommandConstants.GAIT_TRIPOD
+
+
+def test_trigger_values_clamp():
+    """Trigger setters should clamp into the 0..1 range."""
+    state = GuiControlState()
+
+    state.set_left_trigger(1.4)
+    state.set_right_trigger(-0.2)
+
+    assert state.left_trigger == pytest.approx(1.0)
+    assert state.right_trigger == pytest.approx(0.0)
+
+
+def test_walk_command_maps_sticks_and_left_trigger():
+    """Walk mode should map left stick, right stick X, and left trigger."""
+    state = GuiControlState()
+    state.set_left_stick(0.25, 0.5)
+    state.set_right_stick(-0.75, 0.1)
+    state.set_left_trigger(0.4)
+
+    command = state.movement_command()
+
+    assert command.stride_direction.x == pytest.approx(0.5)
+    assert command.stride_direction.y == pytest.approx(-0.25)
+    assert command.stride_direction.z == pytest.approx(0.4)
+    assert command.rotation_speed == pytest.approx(0.75)
+    assert command.gait_type == MovementCommandConstants.GAIT_TRIPOD
+
+
+def test_body_position_mode_uses_sticks():
+    """Body position mode should match existing joystick-style mapping."""
+    state = GuiControlState()
+    state.set_control_mode(ControlMode.BodyPosition)
+    state.set_left_stick(-0.4, 0.3)
+    state.set_right_stick(0.0, 0.8)
+
+    command = state.movement_command()
+
+    assert command.body_translation.x == pytest.approx(0.3)
+    assert command.body_translation.y == pytest.approx(0.4)
+    assert command.body_translation.z == pytest.approx(0.8)
+    assert command.stride_direction.x == pytest.approx(0.0)
+
+
+def test_body_rotation_mode_uses_sticks():
+    """Body rotation mode should match existing joystick-style mapping."""
+    state = GuiControlState()
+    state.set_control_mode(ControlMode.BodyRotation)
+    state.set_left_stick(0.6, -0.5)
+    state.set_right_stick(0.7, 0.0)
+
+    command = state.movement_command()
+
+    assert command.body_rotation.x == pytest.approx(-0.6)
+    assert command.body_rotation.y == pytest.approx(-0.5)
+    assert command.body_rotation.z == pytest.approx(-0.7)
+    assert command.rotation_speed == pytest.approx(0.0)
+
+
+def test_reset_motion_inputs_clears_everything():
+    """Reset should zero sticks, triggers, body pose, and mode memory."""
+    state = GuiControlState()
+    state.key_down('w')
+    state.set_left_trigger(0.7)
+    state.set_control_mode(ControlMode.BodyPosition)
+    state.set_left_stick(0.5, 0.5)
+    state.release_left_stick()
+    state.movement_command()
+
+    state.reset_motion_inputs()
+    command = state.movement_command()
+
+    assert state.axes() == VirtualAxes()
+    assert command.body_translation.x == pytest.approx(0.0)
+    assert command.stride_direction.x == pytest.approx(0.0)
+
+    state.set_control_mode(ControlMode.BodyRotation)
+    state.set_control_mode(ControlMode.BodyPosition)
+    assert state.axes().left_x == pytest.approx(0.0)

--- a/packages/simulation/drqp_keyboard_control/test/test_copyright.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_copyright.py
@@ -1,0 +1,26 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    package_root = os.path.dirname(os.path.dirname(__file__))
+    rc = main(argv=[package_root])
+    assert rc == 0, 'Found errors'

--- a/packages/simulation/drqp_keyboard_control/test/test_flake8.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_flake8.py
@@ -1,0 +1,29 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import multiprocessing
+import os
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    # Use spawn method to avoid fork-related warnings
+    multiprocessing.set_start_method('spawn', force=True)
+    package_root = os.path.dirname(os.path.dirname(__file__))
+    rc, errors = main_with_errors(argv=[package_root])
+    assert rc == 0, 'Found %d code style errors / warnings:\n' % len(errors) + '\n'.join(errors)

--- a/packages/simulation/drqp_keyboard_control/test/test_gui_controls.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_gui_controls.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from drqp_keyboard_control.gui_controls import (
+    ButtonControl,
+    CheckboxControl,
+    LabelControl,
+    PointerRouter,
+    StickControl,
+    TriggerControl,
+)
+from drqp_keyboard_control.layout import RectSpec
+import pytest
+
+
+def make_stick(moves, releases):
+    """Create a stick with a 50px circle radius, recording its callbacks."""
+    return StickControl(
+        label='Left Stick',
+        layout_key='left_stick',
+        rect=RectSpec(50.0, 50.0, 100.0, 180.0),
+        on_move=lambda x, y: moves.append((x, y)),
+        on_release=lambda: releases.append(True),
+        value=lambda: moves[-1] if moves else (0.0, 0.0),
+    )
+
+
+def test_button_fires_action_on_press_and_clears_on_release():
+    """Buttons should act on press and track the pressed visual state."""
+    presses = []
+    button = ButtonControl(
+        label='Kill',
+        layout_key='kill',
+        rect=RectSpec(0.0, 0.0, 100.0, 40.0),
+        action=lambda: presses.append(True),
+    )
+
+    assert button.hit_test((50.0, 20.0)) is True
+    button.press((50.0, 20.0))
+    assert presses == [True]
+    assert button.pressed is True
+
+    button.release()
+    assert button.pressed is False
+    assert button.selected() is False
+
+
+def test_checkbox_reports_selected_state():
+    """Checkboxes should reflect their bound state getter."""
+    enabled = []
+    checkbox = CheckboxControl(
+        label='Balance Mode',
+        layout_key='balance',
+        rect=RectSpec(0.0, 0.0, 120.0, 28.0),
+        action=lambda: enabled.append(True),
+        selected=lambda: bool(enabled),
+    )
+
+    assert checkbox.selected() is False
+    checkbox.press((5.0, 5.0))
+    assert checkbox.selected() is True
+
+
+def test_label_ignores_pointer():
+    """Labels must never take pointer input."""
+    label = LabelControl(
+        label='Sensitivity',
+        layout_key='sensitivity',
+        rect=RectSpec(0.0, 0.0, 200.0, 20.0),
+        text=lambda: 'Sensitivity 0.50',
+    )
+
+    assert label.hit_test((10.0, 10.0)) is False
+    assert label.text() == 'Sensitivity 0.50'
+
+
+def test_stick_geometry_derives_from_rect():
+    """Stick center/radius should come from the layout rect minus text margin."""
+    stick = make_stick([], [])
+
+    assert stick.center == (100.0, 140.0)
+    assert stick.radius == pytest.approx(50.0)
+    assert stick.hit_test((100.0, 140.0)) is True
+    assert stick.hit_test((100.0, 191.0)) is False
+
+
+def test_stick_drag_reports_normalized_axes_y_up():
+    """Dragging should report normalized axes with y pointing up."""
+    moves = []
+    releases = []
+    stick = make_stick(moves, releases)
+
+    stick.press((125.0, 115.0))
+    assert stick.dragging is True
+    assert moves[-1] == (pytest.approx(0.5), pytest.approx(0.5))
+
+    stick.drag((100.0, 190.0))
+    assert moves[-1] == (pytest.approx(0.0), pytest.approx(-1.0))
+
+    stick.release()
+    assert stick.dragging is False
+    assert releases == [True]
+
+
+def test_horizontal_trigger_maps_left_to_zero_right_to_one():
+    """Horizontal trigger sliders should map along the x axis, clamped."""
+    values = []
+    trigger = TriggerControl(
+        label='Left Trigger',
+        layout_key='left_trigger',
+        rect=RectSpec(10.0, 20.0, 100.0, 30.0),
+        on_change=values.append,
+        value=lambda: values[-1] if values else 0.0,
+    )
+
+    trigger.press((110.0, 25.0))
+    assert values[-1] == pytest.approx(1.0)
+
+    trigger.drag((-10.0, 25.0))
+    assert values[-1] == pytest.approx(0.0)
+
+
+def test_vertical_trigger_maps_top_to_pressed():
+    """Vertical trigger sliders should put full trigger at the top."""
+    values = []
+    trigger = TriggerControl(
+        label='Right Trigger',
+        layout_key='right_trigger',
+        rect=RectSpec(20.0, 10.0, 30.0, 100.0),
+        on_change=values.append,
+        value=lambda: values[-1] if values else 0.0,
+    )
+
+    assert trigger.vertical is True
+    trigger.press((35.0, 10.0))
+    assert values[-1] == pytest.approx(1.0)
+
+    trigger.drag((35.0, 110.0))
+    assert values[-1] == pytest.approx(0.0)
+
+
+def test_router_routes_press_to_first_hit_and_captures_drag():
+    """The router should capture the pressed widget for the whole drag."""
+    moves = []
+    releases = []
+    stick = make_stick(moves, releases)
+    presses = []
+    button = ButtonControl(
+        label='Help',
+        layout_key='help',
+        rect=RectSpec(200.0, 0.0, 80.0, 30.0),
+        action=lambda: presses.append(True),
+    )
+    router = PointerRouter([button, stick])
+
+    assert router.press((100.0, 100.0)) is True
+    assert router.active is stick
+
+    # Motion over the button must keep driving the captured stick.
+    router.move((240.0, 15.0))
+    assert len(moves) == 2
+    assert presses == []
+
+    router.release()
+    assert releases == [True]
+    assert router.active is None
+
+
+def test_router_ignores_misses_and_motion_without_capture():
+    """Presses outside all widgets should not create a capture."""
+    presses = []
+    button = ButtonControl(
+        label='Help',
+        layout_key='help',
+        rect=RectSpec(0.0, 0.0, 50.0, 20.0),
+        action=lambda: presses.append(True),
+    )
+    router = PointerRouter([button])
+
+    assert router.press((300.0, 300.0)) is False
+    router.move((10.0, 10.0))
+    router.release()
+
+    assert presses == []
+    assert button.pressed is False
+
+
+def test_router_press_release_cycle_on_button():
+    """A captured button should clear its pressed state on release."""
+    button = ButtonControl(
+        label='Reboot',
+        layout_key='reboot',
+        rect=RectSpec(0.0, 0.0, 50.0, 20.0),
+        action=lambda: None,
+    )
+    router = PointerRouter([button])
+
+    router.press((10.0, 10.0))
+    assert button.pressed is True
+
+    router.release()
+    assert button.pressed is False

--- a/packages/simulation/drqp_keyboard_control/test/test_keyboard_control_node.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_keyboard_control_node.py
@@ -21,27 +21,7 @@
 from unittest.mock import Mock
 
 from drqp_brain.joystick_input_handler import ControlMode
-from drqp_interfaces.msg import MovementCommandConstants
-from drqp_keyboard_control.gui_controls import (
-    ButtonControl,
-    CheckboxControl,
-    clamp_vector,
-    RectSpec,
-    StickControl,
-    TriggerControl,
-)
-from drqp_keyboard_control.keyboard_control_app import (
-    KEYBOARD_HELP_LINES,
-    PygameKeyboardControlApp,
-)
-from drqp_keyboard_control.keyboard_control_node import (
-    GuiControlState,
-    KeyboardControlNode,
-)
-from drqp_keyboard_control.sdl_window import (
-    sdl_library_candidates,
-    set_sdl_window_always_on_top,
-)
+from drqp_keyboard_control.keyboard_control_node import KeyboardControlNode
 import pytest
 import rclpy
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile
@@ -62,317 +42,58 @@ def ros_context():
         rclpy.shutdown()
 
 
-def test_wasd_key_down_up_holds_until_release():
-    """Keyboard axes should use key state instead of repeat timeouts."""
-    state = GuiControlState(sensitivity=0.5)
-
-    assert state.key_down('w') is True
-    assert state.axes().left_y == pytest.approx(0.5)
-    assert state.axes().left_y == pytest.approx(0.5)
-
-    assert state.key_up('w') is True
-    assert state.axes().left_y == pytest.approx(0.0)
-
-
-def test_multiple_keyboard_keys_combine_across_sticks():
-    """WASD and arrow keys should work while held together."""
-    state = GuiControlState(sensitivity=0.75)
-
-    for key in ('w', 'd', 'left', 'up'):
-        state.key_down(key)
-
-    axes = state.axes()
-    assert axes.left_x == pytest.approx(0.75)
-    assert axes.left_y == pytest.approx(0.75)
-    assert axes.right_x == pytest.approx(-0.75)
-    assert axes.right_y == pytest.approx(0.75)
-
-
-def test_opposite_keyboard_keys_cancel_on_axis():
-    """Opposite held keys should cancel each other."""
-    state = GuiControlState(sensitivity=0.6)
-
-    state.key_down('w')
-    state.key_down('s')
-    state.key_down('left')
-    state.key_down('right')
-
-    axes = state.axes()
-    assert axes.left_y == pytest.approx(0.0)
-    assert axes.right_x == pytest.approx(0.0)
-
-
-def test_pointer_stick_takes_precedence_over_keyboard_until_released():
-    """Dragged virtual sticks should override keyboard axes for that stick."""
-    state = GuiControlState(sensitivity=0.5)
-    state.key_down('w')
-
-    state.set_left_stick(-0.25, -0.5)
-    assert state.axes().left_x == pytest.approx(-0.25)
-    assert state.axes().left_y == pytest.approx(-0.5)
-
-    state.release_left_stick()
-    assert state.axes().left_x == pytest.approx(0.0)
-    assert state.axes().left_y == pytest.approx(0.5)
-
-
-def test_stick_drag_clamps_and_release_springs_to_center():
-    """Mobile-style stick drag should clamp to the unit circle and spring back."""
-    state = GuiControlState()
-    stick = StickControl(
-        'Left',
-        (100.0, 100.0),
-        50.0,
-        state.set_left_stick,
-        state.release_left_stick,
-    )
-
-    stick.begin_drag((200.0, 0.0))
-    axes = state.axes()
-    assert axes.left_x == pytest.approx(0.707106, abs=1e-5)
-    assert axes.left_y == pytest.approx(0.707106, abs=1e-5)
-
-    stick.end_drag()
-    assert state.axes().left_x == pytest.approx(0.0)
-    assert state.axes().left_y == pytest.approx(0.0)
-
-
-def test_trigger_slider_clamps():
-    """Trigger sliders should produce stable 0..1 values."""
-    state = GuiControlState()
-    trigger = TriggerControl(
-        'Left Trigger',
-        RectSpec(10.0, 20.0, 100.0, 30.0),
-        state.set_left_trigger,
-    )
-
-    trigger.begin_drag((110.0, 25.0))
-    assert state.left_trigger == pytest.approx(1.0)
-
-    trigger.update_drag((-10.0, 25.0))
-    assert state.left_trigger == pytest.approx(0.0)
-
-
-def test_vertical_trigger_slider_maps_top_to_pressed():
-    """Vertical trigger sliders should put full trigger at the top."""
-    state = GuiControlState()
-    trigger = TriggerControl(
-        'Right Trigger',
-        RectSpec(20.0, 10.0, 30.0, 100.0),
-        state.set_right_trigger,
-    )
-
-    trigger.begin_drag((35.0, 10.0))
-    assert state.right_trigger == pytest.approx(1.0)
-
-    trigger.update_drag((35.0, 110.0))
-    assert state.right_trigger == pytest.approx(0.0)
-
-
-def test_mode_and_gait_toggle_selection():
-    """Visual toggle actions should update mode and gait state directly."""
-    state = GuiControlState()
-
-    mode_button = ButtonControl(
-        'BodyRotation',
-        RectSpec(0.0, 0.0, 100.0, 30.0),
-        lambda: state.set_control_mode(ControlMode.BodyRotation),
-        lambda: state.control_mode == ControlMode.BodyRotation,
-    )
-    gait_button = ButtonControl(
-        'Wave',
-        RectSpec(110.0, 0.0, 100.0, 30.0),
-        lambda: state.set_gait_index(2),
-        lambda: state.gait_index == 2,
-    )
-
-    assert mode_button.click((5.0, 5.0)) is True
-    assert gait_button.click((115.0, 5.0)) is True
-
-    assert state.control_mode == ControlMode.BodyRotation
-    assert state.gait == MovementCommandConstants.GAIT_WAVE
-    assert mode_button.selected() is True
-    assert gait_button.selected() is True
-
-
-def test_checkbox_click_invokes_action_and_tracks_pressed_state():
-    """Checkbox controls should behave like click targets."""
-    calls = []
-    checkbox = CheckboxControl(
-        'Stay on top',
-        RectSpec(0.0, 0.0, 120.0, 28.0),
-        lambda: calls.append('toggle'),
-        lambda: bool(calls),
-    )
-
-    assert checkbox.click((10.0, 10.0)) is True
-    assert calls == ['toggle']
-    assert checkbox.selected() is True
-    assert checkbox.pressed is True
-
-    checkbox.release()
-    assert checkbox.pressed is False
-
-
-def test_stay_on_top_toggle_updates_state_and_applies_best_effort():
-    """Stay-on-top checkbox should reflect clicks even if the platform call fails."""
-    app = PygameKeyboardControlApp.__new__(PygameKeyboardControlApp)
-    app.stay_on_top = False
-    requested_states = []
-    app._apply_stay_on_top = lambda enabled: requested_states.append(enabled) and False
-
-    app._toggle_stay_on_top()
-    assert app.stay_on_top is True
-    assert requested_states == [True]
-
-    app._toggle_stay_on_top()
-    assert app.stay_on_top is False
-    assert requested_states == [True, False]
-
-
-def test_set_sdl_window_always_on_top_fails_without_window_id():
-    """The platform topmost helper should safely no-op when unavailable."""
-    assert set_sdl_window_always_on_top(None, True) is False
-
-
-def test_sdl_library_candidates_are_unique():
-    """SDL lookup should return a deduplicated best-effort candidate list."""
-    candidates = sdl_library_candidates()
-
-    assert candidates == list(dict.fromkeys(candidates))
-    assert all(candidates)
-
-
-def test_tab_cycles_control_modes():
-    """TAB should cycle through the same control modes as the joystick node."""
-    state = GuiControlState()
-
-    state.key_down('tab')
-    assert state.control_mode == ControlMode.BodyPosition
-
-    state.key_down('tab')
-    assert state.control_mode == ControlMode.BodyRotation
-
-    state.key_down('tab')
-    assert state.control_mode == ControlMode.Walk
-
-
-def test_number_keys_select_gaits():
-    """Number keys should directly select tripod, ripple, and wave gaits."""
-    state = GuiControlState()
-
-    state.key_down('2')
-    assert state.gait == MovementCommandConstants.GAIT_RIPPLE
-
-    state.key_down('3')
-    assert state.gait == MovementCommandConstants.GAIT_WAVE
-
-    state.key_down('1')
-    assert state.gait == MovementCommandConstants.GAIT_TRIPOD
-
-
-def test_sensitivity_adjustment_is_clamped():
-    """Plus and minus keys should adjust the emulated stick magnitude."""
-    state = GuiControlState(sensitivity=0.95, sensitivity_step=0.1)
-
-    state.key_down('+')
-    assert state.sensitivity == pytest.approx(1.0)
-
-    for _ in range(20):
-        state.key_down('-')
-
-    assert state.sensitivity == pytest.approx(0.1)
-
-
-def test_walk_command_maps_sticks_and_left_trigger():
-    """Walk mode should map left stick, right stick X, and left trigger."""
-    state = GuiControlState()
-    state.set_left_stick(0.25, 0.5)
-    state.set_right_stick(-0.75, 0.1)
-    state.set_left_trigger(0.4)
-
-    command = state.movement_command()
-
-    assert command.stride_direction.x == pytest.approx(0.5)
-    assert command.stride_direction.y == pytest.approx(-0.25)
-    assert command.stride_direction.z == pytest.approx(0.4)
-    assert command.rotation_speed == pytest.approx(0.75)
-
-
-def test_body_position_mode_uses_sticks():
-    """Body position mode should match existing joystick-style mapping."""
-    state = GuiControlState()
-    state.control_mode = ControlMode.BodyPosition
-    state.set_left_stick(-0.4, 0.3)
-    state.set_right_stick(0.0, 0.8)
-
-    command = state.movement_command()
-
-    assert command.body_translation.x == pytest.approx(0.3)
-    assert command.body_translation.y == pytest.approx(0.4)
-    assert command.body_translation.z == pytest.approx(0.8)
-    assert command.stride_direction.x == pytest.approx(0.0)
-
-
-def test_body_rotation_mode_uses_sticks():
-    """Body rotation mode should match existing joystick-style mapping."""
-    state = GuiControlState()
-    state.control_mode = ControlMode.BodyRotation
-    state.set_left_stick(0.6, -0.5)
-    state.set_right_stick(0.7, 0.0)
-
-    command = state.movement_command()
-
-    assert command.body_rotation.x == pytest.approx(-0.6)
-    assert command.body_rotation.y == pytest.approx(-0.5)
-    assert command.body_rotation.z == pytest.approx(-0.7)
-    assert command.rotation_speed == pytest.approx(0.0)
-
-
-def test_space_and_escape_publish_kill_switch_once_per_keydown(ros_context):
-    """Space and Esc should publish kill switch events as actions."""
+@pytest.fixture
+def node(ros_context):
+    """Provide a KeyboardControlNode and destroy it after the test."""
     node = KeyboardControlNode()
+    yield node
+    node.destroy_node()
+
+
+def test_space_and_escape_publish_kill_switch_once_per_keydown(node):
+    """Space and Esc should publish kill switch events as actions."""
     node.robot_event_pub.publish = Mock()
-    try:
-        assert node.handle_key_down('space') is True
-        assert node.handle_key_down('esc') is True
-        assert node.handle_key_up('space') is False
-        assert node.handle_key_up('esc') is False
-    finally:
-        node.destroy_node()
+
+    assert node.handle_key_down('space') is True
+    assert node.handle_key_down('esc') is True
+    assert node.handle_key_up('space') is False
+    assert node.handle_key_up('esc') is False
 
     event_names = [call.args[0].data for call in node.robot_event_pub.publish.call_args_list]
     assert event_names == ['kill_switch_pressed', 'kill_switch_pressed']
 
 
-def test_delete_and_backspace_publish_robot_events(ros_context):
+def test_delete_and_backspace_publish_robot_events(node):
     """Delete and Backspace should publish matching robot events."""
-    node = KeyboardControlNode()
     node.robot_event_pub.publish = Mock()
-    try:
-        assert node.handle_key_down('delete') is True
-        assert node.handle_key_down('backspace') is True
-    finally:
-        node.destroy_node()
+
+    assert node.handle_key_down('delete') is True
+    assert node.handle_key_down('backspace') is True
 
     event_names = [call.args[0].data for call in node.robot_event_pub.publish.call_args_list]
     assert event_names == ['reboot_servos', 'finalize']
 
 
-def test_b_key_toggles_balance_mode_and_publishes(ros_context):
+def test_b_key_toggles_balance_mode_and_publishes(node):
     """B should toggle balance mode and publish the latched state each time."""
-    node = KeyboardControlNode()
     node.balance_mode_pub.publish = Mock()
-    try:
-        assert node.handle_key_down('b') is True
-        assert node.balance_mode_enabled is True
-        assert node.handle_key_down('b') is True
-        assert node.balance_mode_enabled is False
-    finally:
-        node.destroy_node()
+
+    assert node.handle_key_down('b') is True
+    assert node.balance_mode_enabled is True
+    assert node.handle_key_down('b') is True
+    assert node.balance_mode_enabled is False
 
     published = [call.args[0].data for call in node.balance_mode_pub.publish.call_args_list]
     assert published == [True, False]
+
+
+def test_motion_keys_are_delegated_to_state(node):
+    """Plain motion keys should flow into the shared control state."""
+    assert node.handle_key_down('w') is True
+    assert node.state.axes().left_y == pytest.approx(0.5)
+
+    assert node.handle_key_up('w') is True
+    assert node.state.axes().left_y == pytest.approx(0.0)
 
 
 def test_balance_mode_publishes_initial_false_for_late_joiners(ros_context):
@@ -400,81 +121,35 @@ def test_balance_mode_publishes_initial_false_for_late_joiners(ros_context):
     assert received == [False]
 
 
-def test_balance_mode_checkbox_toggles_node_directly():
-    """Balance Mode checkbox should call into the node's toggle method directly."""
-    app = PygameKeyboardControlApp.__new__(PygameKeyboardControlApp)
-    app.node = Mock()
-    app.node.balance_mode_enabled = False
-    app.buttons = []
-    app.checkboxes = []
-    app.show_help = False
-    app.stay_on_top = False
-
-    app._build_buttons()
-
-    balance_checkbox = next(c for c in app.checkboxes if c.label == 'Balance Mode')
-    assert balance_checkbox.selected() is False
-
-    pos = (balance_checkbox.rect.x + 1.0, balance_checkbox.rect.y + 1.0)
-    assert balance_checkbox.click(pos) is True
-    app.node._toggle_balance_mode.assert_called_once_with()
-
-
-def test_publish_stop_command_clears_motion_inputs_before_publishing(ros_context):
+def test_publish_stop_command_clears_motion_inputs_before_publishing(node):
     """GUI shutdown should send one final zero movement command."""
-    node = KeyboardControlNode()
     node.movement_command_pub.publish = Mock()
-    try:
-        node.state.key_down('w')
-        node.state.set_left_stick(0.5, 0.5)
-        node.state.set_right_stick(-0.25, 0.0)
-        node.state.set_left_trigger(0.75)
-        node.state.set_right_trigger(0.5)
+    node.state.key_down('w')
+    node.state.set_left_stick(0.5, 0.5)
+    node.state.set_left_trigger(0.75)
+    node.state.set_control_mode(ControlMode.BodyPosition)
+    node.state.set_right_stick(-0.25, 0.6)
+    node.state.release_right_stick()
 
-        node.publish_stop_command()
-    finally:
-        node.destroy_node()
+    node.publish_stop_command()
 
     command = node.movement_command_pub.publish.call_args.args[0]
     assert command.stride_direction.x == pytest.approx(0.0)
     assert command.stride_direction.y == pytest.approx(0.0)
     assert command.stride_direction.z == pytest.approx(0.0)
     assert command.rotation_speed == pytest.approx(0.0)
+    assert command.body_translation.x == pytest.approx(0.0)
+    assert command.body_translation.z == pytest.approx(0.0)
 
 
-def test_app_shutdown_requests_stop_command():
-    """Closing the pygame window should ask the node to stop the robot."""
-    app = PygameKeyboardControlApp.__new__(PygameKeyboardControlApp)
-    app.running = True
-    app.node = Mock()
+def test_latched_body_pose_is_published_across_modes(node):
+    """The published command must carry latched body pose in Walk mode."""
+    node.state.set_control_mode(ControlMode.BodyPosition)
+    node.state.set_left_stick(0.2, 0.4)
+    node.state.release_left_stick()
+    node.state.set_control_mode(ControlMode.Walk)
 
-    app._request_shutdown()
+    command = node.state.movement_command()
 
-    app.node.publish_stop_command.assert_called_once_with()
-    assert app.running is False
-
-
-def test_keyboard_help_lines_cover_all_bindings():
-    """Help content should list all keyboard controls."""
-    help_text = '\n'.join(KEYBOARD_HELP_LINES)
-
-    for expected in (
-        'W/A/S/D',
-        'Arrow keys',
-        'Tab',
-        '1/2/3',
-        'B: toggle balance mode',
-        '+/-',
-        'Space or Esc',
-        'Delete',
-        'Backspace',
-    ):
-        assert expected in help_text
-
-
-def test_clamp_vector_limits_to_unit_circle():
-    """The vector helper should preserve direction while limiting magnitude."""
-    x, y = clamp_vector(3.0, 4.0)
-
-    assert x == pytest.approx(0.6)
-    assert y == pytest.approx(0.8)
+    assert command.body_translation.x == pytest.approx(0.4)
+    assert command.body_translation.y == pytest.approx(-0.2)

--- a/packages/simulation/drqp_keyboard_control/test/test_layout.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_layout.py
@@ -127,6 +127,7 @@ def test_align_center_and_end_position_cross_axis():
 
 def test_justify_center_and_end_distribute_leftover_main_axis():
     """Justify should place fixed-size children within leftover space."""
+
     def children():
         return [Box(key='a', width=60.0, height=10.0)]
 

--- a/packages/simulation/drqp_keyboard_control/test/test_layout.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_layout.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from drqp_keyboard_control.layout import (
+    Align,
+    Box,
+    clamp_vector,
+    Column,
+    Justify,
+    RectSpec,
+    Row,
+    solve,
+)
+import pytest
+
+
+def test_row_places_fixed_children_with_spacing():
+    """Fixed-size children should stack left to right with spacing."""
+    root = Row(
+        children=[
+            Box(key='a', width=100.0, height=30.0),
+            Box(key='b', width=50.0, height=30.0),
+        ],
+        spacing=10.0,
+    )
+
+    rects = solve(root, 400.0, 100.0)
+
+    assert rects['a'] == RectSpec(0.0, 0.0, 100.0, 30.0)
+    assert rects['b'] == RectSpec(110.0, 0.0, 50.0, 30.0)
+
+
+def test_column_places_fixed_children_with_spacing_and_padding():
+    """Padding should inset children on both axes."""
+    root = Column(
+        children=[
+            Box(key='a', width=100.0, height=30.0),
+            Box(key='b', width=100.0, height=40.0),
+        ],
+        spacing=8.0,
+        padding=16.0,
+    )
+
+    rects = solve(root, 400.0, 400.0)
+
+    assert rects['a'] == RectSpec(16.0, 16.0, 100.0, 30.0)
+    assert rects['b'] == RectSpec(16.0, 54.0, 100.0, 40.0)
+
+
+def test_flex_children_share_leftover_space_by_weight():
+    """Flex children should split leftover space proportionally."""
+    root = Row(
+        children=[
+            Box(key='fixed', width=100.0, height=10.0),
+            Box(key='one', flex=1.0),
+            Box(key='three', flex=3.0),
+        ],
+        spacing=10.0,
+    )
+
+    rects = solve(root, 520.0, 50.0)
+
+    assert rects['fixed'].width == pytest.approx(100.0)
+    assert rects['one'].width == pytest.approx(100.0)
+    assert rects['three'].width == pytest.approx(300.0)
+    assert rects['one'].x == pytest.approx(110.0)
+    assert rects['three'].x == pytest.approx(220.0)
+
+
+def test_flex_column_fills_viewport_height():
+    """A flex child in a column should absorb all remaining height."""
+    root = Column(
+        children=[
+            Box(key='header', height=40.0),
+            Box(key='body', flex=1.0),
+            Box(key='footer', height=60.0),
+        ],
+    )
+
+    rects = solve(root, 300.0, 640.0)
+
+    assert rects['body'].y == pytest.approx(40.0)
+    assert rects['body'].height == pytest.approx(540.0)
+    assert rects['footer'].y == pytest.approx(580.0)
+
+
+def test_align_stretch_fills_cross_axis():
+    """Stretch alignment should expand children across the container."""
+    root = Row(
+        children=[Box(key='a', width=50.0)],
+        align=Align.stretch,
+    )
+
+    rects = solve(root, 200.0, 120.0)
+
+    assert rects['a'].height == pytest.approx(120.0)
+
+
+def test_align_center_and_end_position_cross_axis():
+    """Center/end alignment should offset children on the cross axis."""
+    centered = Row(children=[Box(key='c', width=50.0, height=40.0)], align=Align.center)
+    ended = Row(children=[Box(key='e', width=50.0, height=40.0)], align=Align.end)
+
+    center_rects = solve(centered, 200.0, 100.0)
+    end_rects = solve(ended, 200.0, 100.0)
+
+    assert center_rects['c'].y == pytest.approx(30.0)
+    assert end_rects['e'].y == pytest.approx(60.0)
+
+
+def test_justify_center_and_end_distribute_leftover_main_axis():
+    """Justify should place fixed-size children within leftover space."""
+    def children():
+        return [Box(key='a', width=60.0, height=10.0)]
+
+    center = solve(Row(children=children(), justify=Justify.center), 200.0, 50.0)
+    end = solve(Row(children=children(), justify=Justify.end), 200.0, 50.0)
+
+    assert center['a'].x == pytest.approx(70.0)
+    assert end['a'].x == pytest.approx(140.0)
+
+
+def test_nested_containers_compose():
+    """Nested rows inside columns should inherit their parent slots."""
+    root = Column(
+        children=[
+            Row(
+                key='toolbar',
+                children=[
+                    Box(key='left', width=40.0, height=20.0),
+                    Box(key='right', width=40.0, height=20.0),
+                ],
+                spacing=4.0,
+                height=28.0,
+            ),
+            Box(key='content', flex=1.0),
+        ],
+        padding=10.0,
+    )
+
+    rects = solve(root, 300.0, 200.0)
+
+    assert rects['toolbar'] == RectSpec(10.0, 10.0, 280.0, 28.0)
+    assert rects['left'] == RectSpec(10.0, 10.0, 40.0, 20.0)
+    assert rects['right'] == RectSpec(54.0, 10.0, 40.0, 20.0)
+    assert rects['content'].y == pytest.approx(38.0)
+    assert rects['content'].height == pytest.approx(152.0)
+
+
+def test_container_measures_intrinsic_size_from_children():
+    """Containers without explicit size should measure their content."""
+    row = Row(
+        children=[
+            Box(width=40.0, height=20.0),
+            Box(width=60.0, height=30.0),
+        ],
+        spacing=10.0,
+        padding=5.0,
+    )
+
+    assert row.measure() == (120.0, 40.0)
+
+
+def test_rect_contains_and_center():
+    """RectSpec should expose hit testing and center math."""
+    rect = RectSpec(10.0, 20.0, 100.0, 50.0)
+
+    assert rect.contains((10.0, 20.0)) is True
+    assert rect.contains((110.0, 70.0)) is True
+    assert rect.contains((111.0, 70.0)) is False
+    assert rect.center == (60.0, 45.0)
+
+
+def test_clamp_vector_limits_to_unit_circle():
+    """The vector helper should preserve direction while limiting magnitude."""
+    x, y = clamp_vector(3.0, 4.0)
+
+    assert x == pytest.approx(0.6)
+    assert y == pytest.approx(0.8)
+    assert clamp_vector(0.3, -0.4) == (0.3, -0.4)

--- a/packages/simulation/drqp_keyboard_control/test/test_layout.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_layout.py
@@ -84,6 +84,23 @@ def test_flex_children_share_leftover_space_by_weight():
     assert rects['three'].x == pytest.approx(220.0)
 
 
+def test_explicit_main_axis_size_beats_flex():
+    """Explicit size on the main axis should override flex sizing."""
+    root = Row(
+        children=[
+            Box(key='fixed_flex', width=120.0, height=10.0, flex=1.0),
+            Box(key='flex_only', flex=1.0),
+        ],
+        spacing=10.0,
+    )
+
+    rects = solve(root, 410.0, 50.0)
+
+    assert rects['fixed_flex'].width == pytest.approx(120.0)
+    assert rects['flex_only'].width == pytest.approx(280.0)
+    assert rects['flex_only'].x == pytest.approx(130.0)
+
+
 def test_flex_column_fills_viewport_height():
     """A flex child in a column should absorb all remaining height."""
     root = Column(

--- a/packages/simulation/drqp_keyboard_control/test/test_layout.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_layout.py
@@ -179,7 +179,7 @@ def test_container_measures_intrinsic_size_from_children():
 
 
 def test_rect_contains_and_center():
-    """RectSpec should expose hit testing and center math."""
+    """The rect helper should expose hit testing and center math."""
     rect = RectSpec(10.0, 20.0, 100.0, 50.0)
 
     assert rect.contains((10.0, 20.0)) is True

--- a/packages/simulation/drqp_keyboard_control/test/test_pep257.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_pep257.py
@@ -1,0 +1,26 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    package_root = os.path.dirname(os.path.dirname(__file__))
+    rc = main(argv=[package_root, os.path.join(package_root, 'test')])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/packages/simulation/drqp_keyboard_control/test/test_sdl_window.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_sdl_window.py
@@ -17,3 +17,21 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+
+from drqp_keyboard_control.sdl_window import (
+    sdl_library_candidates,
+    set_sdl_window_always_on_top,
+)
+
+
+def test_set_sdl_window_always_on_top_fails_without_window_id():
+    """The platform topmost helper should safely no-op when unavailable."""
+    assert set_sdl_window_always_on_top(None, True) is False
+
+
+def test_sdl_library_candidates_are_unique():
+    """SDL lookup should return a deduplicated best-effort candidate list."""
+    candidates = sdl_library_candidates()
+
+    assert candidates == list(dict.fromkeys(candidates))
+    assert all(candidates)

--- a/packages/simulation/drqp_keyboard_control/test/test_sdl_window.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_sdl_window.py
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 from drqp_keyboard_control.sdl_window import (
+    _is_core_sdl_library_name,
     sdl_library_candidates,
     set_sdl_window_always_on_top,
 )
@@ -35,3 +36,11 @@ def test_sdl_library_candidates_are_unique():
 
     assert candidates == list(dict.fromkeys(candidates))
     assert all(candidates)
+
+
+def test_core_sdl_library_filter_rejects_satellite_libraries():
+    """Stay-on-top must bind the core SDL binary, not SDL satellite libs."""
+    assert _is_core_sdl_library_name('libSDL2-2-abcdef.so.0') is True
+    assert _is_core_sdl_library_name('libSDL2_ttf-2-abcdef.so.0') is False
+    assert _is_core_sdl_library_name('libSDL2_image-2-abcdef.so.0') is False
+    assert _is_core_sdl_library_name('libSDL2_mixer-2-abcdef.so.0') is False

--- a/packages/simulation/drqp_keyboard_control/test/test_ui.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_ui.py
@@ -77,7 +77,7 @@ def test_layout_produces_no_overlapping_widgets(node, size):
 
     interactive = [c for c in controls if not isinstance(c, LabelControl)]
     for index, first in enumerate(interactive):
-        for second in interactive[index + 1:]:
+        for second in interactive[index + 1 :]:
             assert not rects_intersect(first.rect, second.rect), (
                 f'{first.layout_key} overlaps {second.layout_key} at {size}'
             )

--- a/packages/simulation/drqp_keyboard_control/test/test_ui.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_ui.py
@@ -77,7 +77,7 @@ def test_layout_produces_no_overlapping_widgets(node, size):
 
     interactive = [c for c in controls if not isinstance(c, LabelControl)]
     for index, first in enumerate(interactive):
-        for second in interactive[index + 1 :]:
+        for second in interactive[index + 1 :]:  # noqa: E203
             assert not rects_intersect(first.rect, second.rect), (
                 f'{first.layout_key} overlaps {second.layout_key} at {size}'
             )

--- a/packages/simulation/drqp_keyboard_control/test/test_ui.py
+++ b/packages/simulation/drqp_keyboard_control/test/test_ui.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2017-2025 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from unittest.mock import Mock
+
+from drqp_brain.joystick_input_handler import ControlMode
+from drqp_keyboard_control.control_state import GuiControlState
+from drqp_keyboard_control.gui_controls import LabelControl, StickControl
+from drqp_keyboard_control.ui import apply_layout, build_controls, KEYBOARD_HELP_LINES
+import pytest
+
+
+@pytest.fixture
+def node():
+    """Node double exposing the interfaces build_controls binds to."""
+    node = Mock()
+    node.state = GuiControlState()
+    node.balance_mode_enabled = False
+    return node
+
+
+def make_controls(node, **overrides):
+    """Build the full widget list with no-op app callbacks by default."""
+    callbacks = {
+        'toggle_help': lambda: None,
+        'help_visible': lambda: False,
+        'toggle_stay_on_top': lambda: None,
+        'stay_on_top_enabled': lambda: False,
+    }
+    callbacks.update(overrides)
+    return build_controls(node, **callbacks)
+
+
+def rects_intersect(a, b) -> bool:
+    """Return whether two RectSpec areas overlap."""
+    return (
+        a.x < b.x + b.width
+        and b.x < a.x + a.width
+        and a.y < b.y + b.height
+        and b.y < a.y + a.height
+    )
+
+
+def test_every_control_gets_a_layout_slot(node):
+    """The layout tree must provide a rect for every widget key."""
+    controls = make_controls(node)
+
+    apply_layout(controls, 980.0, 640.0)
+
+    for control in controls:
+        assert control.rect.width > 0.0, control.layout_key
+        assert control.rect.height > 0.0, control.layout_key
+
+
+@pytest.mark.parametrize('size', [(980.0, 640.0), (760.0, 520.0), (1400.0, 900.0)])
+def test_layout_produces_no_overlapping_widgets(node, size):
+    """Widgets must never overlap, regardless of the window size."""
+    controls = make_controls(node)
+    apply_layout(controls, *size)
+
+    interactive = [c for c in controls if not isinstance(c, LabelControl)]
+    for index, first in enumerate(interactive):
+        for second in interactive[index + 1:]:
+            assert not rects_intersect(first.rect, second.rect), (
+                f'{first.layout_key} overlaps {second.layout_key} at {size}'
+            )
+
+
+def test_layout_stays_inside_viewport(node):
+    """All widgets must stay within the window bounds."""
+    controls = make_controls(node)
+    apply_layout(controls, 980.0, 640.0)
+
+    for control in controls:
+        assert control.rect.x >= 0.0, control.layout_key
+        assert control.rect.y >= 0.0, control.layout_key
+        assert control.rect.x + control.rect.width <= 980.0, control.layout_key
+        assert control.rect.y + control.rect.height <= 640.0, control.layout_key
+
+
+def test_relayout_moves_widgets_for_new_window_size(node):
+    """Re-solving for a resized window should reposition widgets."""
+    controls = make_controls(node)
+    apply_layout(controls, 980.0, 640.0)
+    left_stick = next(c for c in controls if c.layout_key == 'left_stick')
+    small_rect = left_stick.rect
+
+    apply_layout(controls, 1600.0, 1000.0)
+
+    assert left_stick.rect != small_rect
+    assert left_stick.rect.width > small_rect.width
+
+
+def test_mode_and_gait_buttons_drive_state(node):
+    """Mode and gait buttons should update state and reflect selection."""
+    controls = make_controls(node)
+    by_key = {c.layout_key: c for c in controls}
+
+    by_key['mode.BodyRotation'].action()
+    assert node.state.control_mode == ControlMode.BodyRotation
+    assert by_key['mode.BodyRotation'].selected() is True
+    assert by_key['mode.Walk'].selected() is False
+
+    by_key['gait.2'].action()
+    assert node.state.gait_index == 2
+    assert by_key['gait.2'].selected() is True
+
+
+def test_sticks_and_triggers_bind_to_state(node):
+    """Stick and trigger widgets should read and write the shared state."""
+    controls = make_controls(node)
+    by_key = {c.layout_key: c for c in controls}
+
+    by_key['left_stick'].on_move(0.25, -0.5)
+    assert by_key['left_stick'].value() == (pytest.approx(0.25), pytest.approx(-0.5))
+
+    by_key['right_trigger'].on_change(0.7)
+    assert by_key['right_trigger'].value() == pytest.approx(0.7)
+
+
+def test_stick_release_latches_in_body_mode_through_widget(node):
+    """The full widget-to-state path must latch sticks in body modes."""
+    controls = make_controls(node)
+    apply_layout(controls, 980.0, 640.0)
+    by_key = {c.layout_key: c for c in controls}
+    node.state.set_control_mode(ControlMode.BodyPosition)
+
+    stick: StickControl = by_key['left_stick']
+    center_x, center_y = stick.center
+    stick.press((center_x + stick.radius / 2.0, center_y))
+    stick.release()
+
+    assert stick.value() == (pytest.approx(0.5), pytest.approx(0.0))
+
+
+def test_action_buttons_publish_robot_events(node):
+    """Kill switch, finalize, and reboot buttons should publish events."""
+    controls = make_controls(node)
+    by_key = {c.layout_key: c for c in controls}
+
+    by_key['action.kill_switch_pressed'].action()
+    by_key['action.finalize'].action()
+    by_key['action.reboot_servos'].action()
+
+    published = [call.args[0] for call in node.publish_event.call_args_list]
+    assert published == ['kill_switch_pressed', 'finalize', 'reboot_servos']
+
+
+def test_balance_checkbox_binds_to_node(node):
+    """The Balance Mode checkbox should call into the node toggle."""
+    controls = make_controls(node)
+    balance = next(c for c in controls if c.layout_key == 'balance')
+
+    assert balance.selected() is False
+    balance.action()
+    node.toggle_balance_mode.assert_called_once_with()
+
+    node.balance_mode_enabled = True
+    assert balance.selected() is True
+
+
+def test_help_and_stay_on_top_bind_to_app_callbacks(node):
+    """Help button and stay-on-top checkbox use the app-provided hooks."""
+    calls = []
+    controls = make_controls(
+        node,
+        toggle_help=lambda: calls.append('help'),
+        toggle_stay_on_top=lambda: calls.append('top'),
+        help_visible=lambda: True,
+    )
+    by_key = {c.layout_key: c for c in controls}
+
+    by_key['help'].action()
+    by_key['stay_on_top'].action()
+
+    assert calls == ['help', 'top']
+    assert by_key['help'].selected() is True
+
+
+def test_sensitivity_label_tracks_state(node):
+    """The status label should render the live sensitivity value."""
+    controls = make_controls(node)
+    label = next(c for c in controls if c.layout_key == 'sensitivity')
+
+    assert label.text() == 'Sensitivity 0.50'
+    node.state.adjust_sensitivity(0.1)
+    assert label.text() == 'Sensitivity 0.60'
+
+
+def test_keyboard_help_lines_cover_all_bindings():
+    """Help content should list all keyboard controls."""
+    help_text = '\n'.join(KEYBOARD_HELP_LINES)
+
+    for expected in (
+        'W/A/S/D',
+        'Arrow keys',
+        'Tab',
+        '1/2/3',
+        'B: toggle balance mode',
+        '+/-',
+        'Space or Esc',
+        'Delete',
+        'Backspace',
+    ):
+        assert expected in help_text

--- a/ruff.toml
+++ b/ruff.toml
@@ -55,7 +55,7 @@ force-single-line = false
 force-sort-within-sections = true # sort all imports within section no matter the style
 combine-as-imports = true
 known-first-party = ["validate_agent_files"]
-known-third-party = ["rclpy", "sensor_msgs", "tf2_ros", "pytest", "drqp_brain", "drqp_kinematics"]
+known-third-party = ["rclpy", "sensor_msgs", "tf2_ros", "pytest", "drqp_brain", "drqp_keyboard_control", "drqp_kinematics"]
 case-sensitive = false
 order-by-type = false # ignore type, use alphabetical order
 


### PR DESCRIPTION
# Summary

Rework the `drqp_keyboard_control` GUI around a small flexbox-style layout engine, splitting the monolithic Pygame app into layered, individually tested modules. Fix the body position/rotation virtual joysticks so they latch in place on mouse release instead of springing back to zero, allowing the robot body pose to survive switching back to movement mode.

## What Changed

- **Layout engine** (`layout.py`): `Row`/`Column` containers and `Box` leaves with flex weights, spacing, padding, `justify`, and CSS-like `align: stretch`; `solve()` returns rectangles keyed by widget. The whole screen is declared as one layout tree in `ui.py` — no hardcoded coordinates remain, and the window is now resizable (layout re-solves on resize).
- **Component architecture**: the 450-line app class is split into layers where everything below the composition root is Pygame-free and unit testable:
  - `control_state.py` — pure input model (`VirtualStick`, `GuiControlState`); no Pygame, no rclpy
  - `gui_controls.py` — widget view-models with a uniform `hit_test/press/drag/release` interface plus a `PointerRouter` with single-capture drag semantics
  - `ui.py` — declarative widget construction, state/node bindings, and the layout tree
  - `theme.py` / `renderer.py` — palette and the only module that paints pixels
  - `keymap.py` — Pygame key-code normalization
  - `keyboard_control_app.py` — thin composition root; `keyboard_control_node.py` is ROS I/O only and imports the app lazily so it stays importable headless
- **Body-pose latching fix**: `GuiControlState` keeps persistent `stride_direction`/`rotation_speed`/`body_translation`/`body_rotation` and publishes all `MovementCommand` fields every cycle, mirroring the physical joystick translator. In BodyPosition/BodyRotation modes sticks latch on release and each mode remembers its stick positions; keyboard input follows the same rules and fresh key presses override a latch. Walk mode still springs to center, and leaving Walk zeroes stride so the robot never keeps walking uncommanded.
- **Tests**: split into per-module suites — layout math, control-state behavior (including all latching rules), widgets/router, UI wiring with no-overlap layout checks at multiple window sizes, ROS node behavior, and app-level tests driving real Pygame events through the SDL dummy driver. Added the repo-standard `test_flake8`/`test_pep257`/`test_copyright` files this package was missing: 80 tests total.

## Why

The GUI was laid out with magic coordinates that made every visual change error-prone, the app class mixed input handling, state, layout, and drawing, and most of it was untestable. Operationally, a mouse cannot hold a stick while clicking a mode button (unlike a thumb on a gamepad), so body pose was impossible to carry into movement mode — the sticks reset to zero on every release.

## How to Test

1. `./scripts/with-ros-env.sh colcon build --symlink-install --packages-select drqp_keyboard_control`
2. `./scripts/with-ros-env.sh colcon test --packages-select drqp_keyboard_control` — 80 tests, 0 failures (includes flake8/pep257/copyright linters).
3. Manual headless run: `SDL_VIDEODRIVER=dummy ros2 run drqp_keyboard_control drqp_keyboard_control` publishes complete `MovementCommand` messages (body pose fields included) on `/robot/movement_command` and shuts down cleanly.
4. Interactive check: in Body Position/Rotation mode drag a stick and release — the knob stays; switch to Walk mode — the published command keeps the latched body pose; resize the window — widgets reflow.

## Breaking Changes

- None. The executable name and all ROS topics/messages are unchanged; module moves are internal to the package (no external importers).

## Migration

- None.