### PR TITLE
Isolate Gazebo test launches by ROS domain

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,9 @@
 
     "UV_CACHE_DIR": "/uv/cache",
     "UV_PYTHON_INSTALL_DIR": "/uv/python",
-    "UV_PROJECT_ENVIRONMENT": "/uv/venvs/${localWorkspaceFolderBasename}/"
+    "UV_PROJECT_ENVIRONMENT": "/uv/venvs/${localWorkspaceFolderBasename}/",
+
+    "CTEST_PARALLEL_LEVEL": " " // equivalent to `ctest --parallel` / `ctest -j`
   },
 
   "forwardPorts": ["14500-14599"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ env:
   ROS_DISTRO: jazzy
   REGISTRY: ghcr.io
   REGISTRY_USERNAME: ${{ github.actor }} # for nektos/act, use your own username via --actor option
+  CTEST_PARALLEL_LEVEL: '  ' # whitespace only == empty, auto mode parallel, aka -j to all ctest calls
 
 jobs:
   paths-filter:
@@ -359,7 +360,7 @@ jobs:
             test_status=0
             # -rA makes pytest report captured output for passing tests too (launch_pytest output is otherwise hidden on success).
             # PYTEST_ADDOPTS is used instead of --pytest-args because colcon can't forward pytest args to ctest-driven (ament_cmake) tests.
-            PYTEST_ADDOPTS="-rA --durations=0" python3 -m colcon test --event-handlers console_cohesion+ console_direct+ --return-code-on-test-failure --ctest-args=" ${CTEST_EXTRA_ARGS}" || test_status=$?
+            PYTEST_ADDOPTS="-rA --durations=0" python3 -m colcon test --event-handlers console_cohesion+ console_direct+ --return-code-on-test-failure || test_status=$?
 
             mkdir -p ./.tmp/devcontainer-ci
             rm -rf ./.tmp/devcontainer-ci/build ./.tmp/devcontainer-ci/log
@@ -373,7 +374,6 @@ jobs:
             # Without the block scalar, YAML folds these into one value.
             |
             DRQP_TEST_MODE=${{ matrix.sim_test_mode }}
-            CTEST_EXTRA_ARGS=${{ matrix.sim_test_mode == 'slow' && '-j2' || '' }}
 
       - name: Publish devcontainer test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
           source "scripts/setup.bash"
 
           # symlink-install is a must to collect proper coverage for python nodes
-          python3 -m colcon build --mixin coverage-pytest ninja rel-with-deb-info --event-handlers console_cohesion+ console_direct+ --symlink-install --cmake-args -D DRQP_ENABLE_COVERAGE=ON
+          python3 -m colcon build --mixin coverage-pytest ninja rel-with-deb-info --symlink-install --cmake-args -D DRQP_ENABLE_COVERAGE=ON
 
       - name: Test ROS workspace
         run: |
@@ -251,7 +251,7 @@ jobs:
 
           # -rA makes pytest report captured output for passing tests too (launch_pytest output is otherwise hidden on success).
           # PYTEST_ADDOPTS is used instead of --pytest-args because colcon can't forward pytest args to ctest-driven (ament_cmake) tests.
-          PYTEST_ADDOPTS="-rA --durations=0" python3 -m colcon test --mixin coverage-pytest --event-handlers console_cohesion+ console_direct+ --return-code-on-test-failure
+          PYTEST_ADDOPTS="-rA --durations=0" python3 -m colcon test --mixin coverage-pytest --return-code-on-test-failure
 
       - name: Process llvm coverage
         run: ./packages/cmake/llvm-cov-export-all.py ./build
@@ -352,7 +352,7 @@ jobs:
             rosdep update
             ./scripts/ros-dep.sh
             source "scripts/setup.bash"
-            python3 -m colcon build --mixin ninja rel-with-deb-info --event-handlers console_cohesion+ console_direct+
+            python3 -m colcon build --mixin ninja rel-with-deb-info
 
             ./scripts/ros-dep.sh
             source "scripts/setup.bash"
@@ -360,7 +360,7 @@ jobs:
             test_status=0
             # -rA makes pytest report captured output for passing tests too (launch_pytest output is otherwise hidden on success).
             # PYTEST_ADDOPTS is used instead of --pytest-args because colcon can't forward pytest args to ctest-driven (ament_cmake) tests.
-            PYTEST_ADDOPTS="-rA --durations=0" python3 -m colcon test --event-handlers console_cohesion+ console_direct+ --return-code-on-test-failure || test_status=$?
+            PYTEST_ADDOPTS="-rA --durations=0" python3 -m colcon test --return-code-on-test-failure || test_status=$?
 
             mkdir -p ./.tmp/devcontainer-ci
             rm -rf ./.tmp/devcontainer-ci/build ./.tmp/devcontainer-ci/log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,9 @@ jobs:
             exit "$test_status"
           env:
             # Pass the build args to devcontainer build
+            # devcontainers/ci expects newline-delimited KEY=VALUE entries.
+            # Without the block scalar, YAML folds these into one value.
+            |
             DRQP_TEST_MODE=${{ matrix.sim_test_mode }}
             CTEST_EXTRA_ARGS=${{ matrix.sim_test_mode == 'slow' && '-j2' || '' }}
 

--- a/packages/runtime/drqp_brain/drqp_brain/brain_node.py
+++ b/packages/runtime/drqp_brain/drqp_brain/brain_node.py
@@ -33,7 +33,7 @@ from drqp_brain.balance_controller import (
     body_tilt_from_imu,
     imu_balance_stride_scale,
 )
-from drqp_brain.instance_guard import InstanceAlreadyRunningError, InstanceGuard
+from drqp_brain.instance_guard import domain_instance_guard, InstanceAlreadyRunningError
 from drqp_brain.joint_trajectory_builder import JointTrajectoryBuilder
 from drqp_brain.locomotion_kinematics import (
     AnalyticLocomotionKinematics,
@@ -843,7 +843,7 @@ def main():
         parser = argparse.ArgumentParser('Dr.QP Robot controller ROS node')
         filtered_args = rclpy.utilities.remove_ros_args()
         args = parser.parse_args(args=filtered_args[1:])
-        with InstanceGuard('drqp_brain'):
+        with domain_instance_guard('drqp_brain'):
             rclpy.init()
             guard_node = rclpy.create_node('drqp_brain_startup_guard')
             _assert_no_existing_brain_node(guard_node)

--- a/packages/runtime/drqp_brain/drqp_brain/instance_guard.py
+++ b/packages/runtime/drqp_brain/drqp_brain/instance_guard.py
@@ -46,21 +46,30 @@ class InstanceGuard:
 
     def acquire(self) -> None:
         """Acquire the instance lock or raise when another process owns it."""
+        if not self.try_acquire():
+            raise InstanceAlreadyRunningError(
+                f'Another {self.name} process already holds the startup lock.'
+            )
+
+    def try_acquire(self) -> bool:
+        """Try to acquire the instance lock without raising on contention."""
+        if self._lock_file is not None:
+            return True
+
         self._lock_path.parent.mkdir(parents=True, exist_ok=True)
         self._lock_file = self._lock_path.open('w', encoding='utf-8')
         try:
             fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
+        except BlockingIOError:
             self._lock_file.close()
             self._lock_file = None
-            raise InstanceAlreadyRunningError(
-                f'Another {self.name} process already holds the startup lock.'
-            ) from exc
+            return False
 
         self._lock_file.seek(0)
         self._lock_file.truncate()
         self._lock_file.write(f'{os.getpid()}\n')
         self._lock_file.flush()
+        return True
 
     def release(self) -> None:
         """Release the lock if it is currently held."""
@@ -100,18 +109,28 @@ def default_lock_dir() -> Path:
 
 
 def make_launch_instance_guard(name: str):
-    """Create a launch action that holds an instance lock for launch lifetime."""
+    """Create a launch action that holds a domain-scoped lock for its lifetime."""
     from launch.actions import OpaqueFunction
 
     return OpaqueFunction(function=_acquire_launch_instance_guard, args=(name,))
 
 
-def _acquire_launch_instance_guard(_context, name: str):
-    from launch.actions import RegisterEventHandler
-    from launch.event_handlers import OnShutdown
+def _domain_scoped_guard_name(name: str, ros_domain_id: str) -> str:
+    """Return the instance guard name for a ROS domain."""
+    return f'{name}-domain-{ros_domain_id}'
 
-    guard = InstanceGuard(name)
-    guard.acquire()
+
+def _acquire_launch_instance_guard(context, name: str):
+    from launch.actions import EmitEvent, LogError, RegisterEventHandler
+    from launch.event_handlers import OnShutdown
+    from launch.events import Shutdown
+
+    guard = InstanceGuard(
+        _domain_scoped_guard_name(name, context.environment.get('ROS_DOMAIN_ID', '0'))
+    )
+    if not guard.try_acquire():
+        reason = f'{guard.name} is already running; refusing duplicate launch.'
+        return [LogError(msg=reason), EmitEvent(event=Shutdown(reason=reason))]
 
     def release_guard(_event, _context):
         guard.release()

--- a/packages/runtime/drqp_brain/drqp_brain/instance_guard.py
+++ b/packages/runtime/drqp_brain/drqp_brain/instance_guard.py
@@ -108,6 +108,24 @@ def default_lock_dir() -> Path:
     return get_runtime_directory() / 'tmp'
 
 
+def domain_scoped_guard_name(name: str, ros_domain_id: str) -> str:
+    """Return the instance guard name for a ROS domain."""
+    return f'{name}-domain-{ros_domain_id}'
+
+
+def domain_instance_guard(
+    name: str,
+    lock_dir: Path | str | None = None,
+    ros_domain_id: str | None = None,
+) -> InstanceGuard:
+    """Create an instance guard isolated to a ROS domain."""
+    domain_id = ros_domain_id or os.environ.get('ROS_DOMAIN_ID', '0')
+    guard_name = domain_scoped_guard_name(name, domain_id)
+    if lock_dir is None:
+        return InstanceGuard(guard_name)
+    return InstanceGuard(guard_name, lock_dir=lock_dir)
+
+
 def make_launch_instance_guard(name: str):
     """Create a launch action that holds a domain-scoped lock for its lifetime."""
     from launch.actions import OpaqueFunction
@@ -115,18 +133,14 @@ def make_launch_instance_guard(name: str):
     return OpaqueFunction(function=_acquire_launch_instance_guard, args=(name,))
 
 
-def _domain_scoped_guard_name(name: str, ros_domain_id: str) -> str:
-    """Return the instance guard name for a ROS domain."""
-    return f'{name}-domain-{ros_domain_id}'
-
-
 def _acquire_launch_instance_guard(context, name: str):
     from launch.actions import EmitEvent, LogError, RegisterEventHandler
     from launch.event_handlers import OnShutdown
     from launch.events import Shutdown
 
-    guard = InstanceGuard(
-        _domain_scoped_guard_name(name, context.environment.get('ROS_DOMAIN_ID', '0'))
+    guard = domain_instance_guard(
+        name,
+        ros_domain_id=context.environment.get('ROS_DOMAIN_ID', '0'),
     )
     if not guard.try_acquire():
         reason = f'{guard.name} is already running; refusing duplicate launch.'

--- a/packages/runtime/drqp_brain/drqp_brain/robot_state/robot_state_node.py
+++ b/packages/runtime/drqp_brain/drqp_brain/robot_state/robot_state_node.py
@@ -20,7 +20,7 @@
 
 import sys
 
-from drqp_brain.instance_guard import InstanceAlreadyRunningError, InstanceGuard
+from drqp_brain.instance_guard import domain_instance_guard, InstanceAlreadyRunningError
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
@@ -72,7 +72,7 @@ class RobotStateNode(Node):
 def main():
     node = None
     try:
-        with InstanceGuard('drqp_robot_state'):
+        with domain_instance_guard('drqp_robot_state'):
             rclpy.init()
             node = RobotStateNode()
             rclpy.spin(node)

--- a/packages/runtime/drqp_brain/test/test_brain_shutdown.py
+++ b/packages/runtime/drqp_brain/test/test_brain_shutdown.py
@@ -147,7 +147,7 @@ def test_main_exits_process_after_external_shutdown_cleanup():
             'drqp_brain.brain_node.rclpy.utilities.remove_ros_args',
             return_value=['drqp_brain'],
         ),
-        mock.patch('drqp_brain.brain_node.InstanceGuard'),
+        mock.patch('drqp_brain.brain_node.domain_instance_guard'),
         mock.patch('drqp_brain.brain_node.rclpy.init') as init,
         mock.patch('drqp_brain.brain_node.rclpy.create_node', return_value=guard_node),
         mock.patch('drqp_brain.brain_node._assert_no_existing_brain_node'),

--- a/packages/runtime/drqp_brain/test/test_instance_guard.py
+++ b/packages/runtime/drqp_brain/test/test_instance_guard.py
@@ -20,12 +20,16 @@
 
 from pathlib import Path
 
+import drqp_brain.instance_guard as instance_guard
 from drqp_brain.instance_guard import (
+    _acquire_launch_instance_guard,
+    _domain_scoped_guard_name,
     default_lock_dir,
     get_runtime_directory,
     InstanceAlreadyRunningError,
     InstanceGuard,
 )
+from launch.actions import EmitEvent, LogError
 import pytest
 
 
@@ -90,6 +94,16 @@ def test_instance_guard_rejects_duplicate_processes():
             duplicate_guard.acquire()
 
 
+def test_instance_guard_try_acquire_returns_false_for_duplicate_processes():
+    """Report lock contention without raising or waiting."""
+    lock_dir = Path('.tmp')
+
+    with InstanceGuard('test_drqp_brain_try_acquire', lock_dir=lock_dir):
+        duplicate_guard = InstanceGuard('test_drqp_brain_try_acquire', lock_dir=lock_dir)
+
+        assert not duplicate_guard.try_acquire()
+
+
 def test_instance_guard_allows_startup_after_release():
     """Release the singleton lock when the owning process exits."""
     lock_dir = Path('.tmp')
@@ -99,3 +113,46 @@ def test_instance_guard_allows_startup_after_release():
 
     with InstanceGuard('test_drqp_brain_released', lock_dir=lock_dir):
         pass
+
+
+@pytest.mark.parametrize(
+    ('ros_domain_id', 'expected_name'),
+    [
+        ('0', 'drqp_gazebo_sim-domain-0'),
+        ('42', 'drqp_gazebo_sim-domain-42'),
+    ],
+)
+def test_launch_instance_guard_name_is_scoped_by_ros_domain(ros_domain_id, expected_name):
+    """Give each ROS domain an independent launch-instance guard."""
+    assert _domain_scoped_guard_name('drqp_gazebo_sim', ros_domain_id) == expected_name
+
+
+def test_domain_scoped_instance_guards_allow_parallel_domains():
+    """Allow independent launch-instance guards in separate ROS domains."""
+    lock_dir = Path('.tmp')
+
+    with InstanceGuard(_domain_scoped_guard_name('test_stack', '1'), lock_dir=lock_dir):
+        with InstanceGuard(_domain_scoped_guard_name('test_stack', '2'), lock_dir=lock_dir):
+            pass
+
+
+def test_launch_instance_guard_shuts_down_when_lock_is_held(monkeypatch):
+    """Stop the launch cleanly instead of raising when the guard is held."""
+
+    class ContendedGuard:
+        name = 'drqp_gazebo_sim-domain-42'
+
+        def try_acquire(self):
+            return False
+
+    guard = ContendedGuard()
+    monkeypatch.setattr(instance_guard, 'InstanceGuard', lambda _name: guard)
+
+    context = type('LaunchContext', (), {'environment': {'ROS_DOMAIN_ID': '42'}})()
+    actions = _acquire_launch_instance_guard(context, 'drqp_gazebo_sim')
+
+    assert isinstance(actions[0], LogError)
+    assert isinstance(actions[1], EmitEvent)
+    assert actions[1].event.reason == (
+        'drqp_gazebo_sim-domain-42 is already running; refusing duplicate launch.'
+    )

--- a/packages/runtime/drqp_brain/test/test_instance_guard.py
+++ b/packages/runtime/drqp_brain/test/test_instance_guard.py
@@ -23,8 +23,9 @@ from pathlib import Path
 import drqp_brain.instance_guard as instance_guard
 from drqp_brain.instance_guard import (
     _acquire_launch_instance_guard,
-    _domain_scoped_guard_name,
     default_lock_dir,
+    domain_instance_guard,
+    domain_scoped_guard_name,
     get_runtime_directory,
     InstanceAlreadyRunningError,
     InstanceGuard,
@@ -124,15 +125,30 @@ def test_instance_guard_allows_startup_after_release():
 )
 def test_launch_instance_guard_name_is_scoped_by_ros_domain(ros_domain_id, expected_name):
     """Give each ROS domain an independent launch-instance guard."""
-    assert _domain_scoped_guard_name('drqp_gazebo_sim', ros_domain_id) == expected_name
+    assert domain_scoped_guard_name('drqp_gazebo_sim', ros_domain_id) == expected_name
 
 
 def test_domain_scoped_instance_guards_allow_parallel_domains():
     """Allow independent launch-instance guards in separate ROS domains."""
     lock_dir = Path('.tmp')
 
-    with InstanceGuard(_domain_scoped_guard_name('test_stack', '1'), lock_dir=lock_dir):
-        with InstanceGuard(_domain_scoped_guard_name('test_stack', '2'), lock_dir=lock_dir):
+    with InstanceGuard(domain_scoped_guard_name('test_stack', '1'), lock_dir=lock_dir):
+        with InstanceGuard(domain_scoped_guard_name('test_stack', '2'), lock_dir=lock_dir):
+            pass
+
+
+def test_domain_instance_guard_uses_current_ros_domain(monkeypatch):
+    """Give process entrypoints independent locks in separate ROS domains."""
+    lock_dir = Path('.tmp')
+    monkeypatch.setenv('ROS_DOMAIN_ID', '17')
+
+    with domain_instance_guard('test_runtime_node', lock_dir=lock_dir):
+        duplicate_guard = domain_instance_guard('test_runtime_node', lock_dir=lock_dir)
+        with pytest.raises(InstanceAlreadyRunningError):
+            duplicate_guard.acquire()
+
+        monkeypatch.setenv('ROS_DOMAIN_ID', '18')
+        with domain_instance_guard('test_runtime_node', lock_dir=lock_dir):
             pass
 
 

--- a/packages/runtime/drqp_brain/test/test_robot_state_node.py
+++ b/packages/runtime/drqp_brain/test/test_robot_state_node.py
@@ -23,7 +23,7 @@
 from pathlib import Path
 import time
 
-from drqp_brain.instance_guard import InstanceGuard
+from drqp_brain.instance_guard import domain_instance_guard
 from drqp_brain.robot_state import robot_state_node
 from drqp_launch_testing import assert_processes_exited_cleanly, track_process_exit_codes
 from launch import LaunchDescription
@@ -43,7 +43,7 @@ def test_robot_state_main_refuses_duplicate_instance(monkeypatch):
     """Refuse startup when another robot state node owns the instance lock."""
     monkeypatch.setenv('ROS_HOME', str(Path.cwd() / '.tmp' / 'ros_home'))
 
-    with InstanceGuard('drqp_robot_state'):
+    with domain_instance_guard('drqp_robot_state'):
         assert robot_state_node.main() == 1
 
 

--- a/packages/runtime/drqp_moveit/CMakeLists.txt
+++ b/packages/runtime/drqp_moveit/CMakeLists.txt
@@ -14,6 +14,12 @@ if(BUILD_TESTING)
   find_package(ament_cmake_ros REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
 
+  ament_add_pytest_test(
+    test_moveit_launch_config
+    test/test_moveit_launch_config.py
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/test
+  )
+
   # MoveIt launch tests spin up a full simulator/move_group stack and can
   # legitimately take several minutes, so allow at least 5 minutes before
   # timing out.

--- a/packages/runtime/drqp_moveit/CMakeLists.txt
+++ b/packages/runtime/drqp_moveit/CMakeLists.txt
@@ -19,6 +19,11 @@ if(BUILD_TESTING)
     test/test_moveit_launch_config.py
     APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/test
   )
+  ament_add_pytest_test(
+    test_moveit_launch_smoke_test_support
+    test/test_moveit_launch_smoke_test_support.py
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/test
+  )
 
   # MoveIt launch tests spin up a full simulator/move_group stack and can
   # legitimately take several minutes, so allow at least 5 minutes before

--- a/packages/runtime/drqp_moveit/launch/move_group.launch.py
+++ b/packages/runtime/drqp_moveit/launch/move_group.launch.py
@@ -34,6 +34,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
@@ -41,11 +42,16 @@ def generate_launch_description():
     if launch_dir not in sys.path:
         sys.path.insert(0, launch_dir)
 
-    from moveit_launch_utils import get_move_group_params
+    from moveit_launch_utils import get_move_group_params, load_yaml
 
     pkg = get_package_share_path('drqp_moveit')
     use_gazebo = LaunchConfiguration('use_gazebo')
     hardware_device_address = LaunchConfiguration('hardware_device_address')
+    wait_for_initial_state_timeout = LaunchConfiguration('wait_for_initial_state_timeout')
+    move_group_config = load_yaml(pkg / 'config' / 'move_group.yaml')
+    default_initial_state_timeout = move_group_config['planning_scene_monitor_options'][
+        'wait_for_initial_state_timeout'
+    ]
 
     move_group_node = Node(
         package='moveit_ros_move_group',
@@ -54,7 +60,17 @@ def generate_launch_description():
         parameters=get_move_group_params(
             pkg, use_gazebo=use_gazebo, hardware_device_address=hardware_device_address
         )
-        + [{'use_sim_time': use_gazebo}],
+        + [
+            {'use_sim_time': use_gazebo},
+            {
+                'planning_scene_monitor_options': {
+                    'wait_for_initial_state_timeout': ParameterValue(
+                        wait_for_initial_state_timeout,
+                        value_type=float,
+                    )
+                }
+            },
+        ],
     )
 
     return LaunchDescription(
@@ -72,6 +88,11 @@ def generate_launch_description():
                     'Hardware device address for ros2_control in URDF. '
                     'Use "mock_servo" for fake hardware.'
                 ),
+            ),
+            DeclareLaunchArgument(
+                'wait_for_initial_state_timeout',
+                default_value=str(default_initial_state_timeout),
+                description=('Seconds move_group waits for its initial complete robot state'),
             ),
             move_group_node,
         ]

--- a/packages/runtime/drqp_moveit/test/moveit_launch_smoke_test_support.py
+++ b/packages/runtime/drqp_moveit/test/moveit_launch_smoke_test_support.py
@@ -30,6 +30,22 @@ from launch_ros.substitutions import FindPackageShare
 from moveit_msgs.srv import GetMotionPlan
 import rclpy
 
+# Non-simulator smoke launches have no simulation clock to use for readiness.
+# Keep one bounded wall-clock watchdog for every smoke launch, including the
+# Gazebo demo, while allowing CPU-heavy MoveIt startup to make progress when
+# all CTest workers are active. The move_group initial-state timeout must match
+# so it cannot abort before this watchdog.
+READY_TIMEOUT = 180.0
+
+
+def build_smoke_launch_arguments(
+    launch_arguments: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Add the smoke-test move_group timeout to outer launch arguments."""
+    smoke_launch_arguments = dict(launch_arguments or {})
+    smoke_launch_arguments['wait_for_initial_state_timeout'] = str(READY_TIMEOUT)
+    return smoke_launch_arguments
+
 
 def build_test_gz_partition(test_name: str) -> str:
     domain_id = os.environ.get('ROS_DOMAIN_ID', '0')
@@ -52,17 +68,11 @@ def build_smoke_test_description(
         [
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(launch_path),
-                launch_arguments=(launch_arguments or {}).items(),
+                launch_arguments=build_smoke_launch_arguments(launch_arguments).items(),
             ),
             TimerAction(period=ready_delay, actions=[ReadyToTest()]),
         ]
     )
-
-
-# These smoke launches do not run a simulator, so there is no simulation clock
-# to use for readiness. Keep a wall-clock watchdog, but allow CPU-heavy MoveIt
-# startup to make progress when all CTest workers are active.
-READY_TIMEOUT = 180.0
 
 
 def assert_move_group_ready(timeout: float = READY_TIMEOUT) -> None:

--- a/packages/runtime/drqp_moveit/test/moveit_launch_smoke_test_support.py
+++ b/packages/runtime/drqp_moveit/test/moveit_launch_smoke_test_support.py
@@ -59,7 +59,10 @@ def build_smoke_test_description(
     )
 
 
-READY_TIMEOUT = 60.0
+# These smoke launches do not run a simulator, so there is no simulation clock
+# to use for readiness. Keep a wall-clock watchdog, but allow CPU-heavy MoveIt
+# startup to make progress when all CTest workers are active.
+READY_TIMEOUT = 180.0
 
 
 def assert_move_group_ready(timeout: float = READY_TIMEOUT) -> None:

--- a/packages/runtime/drqp_moveit/test/moveit_launch_smoke_test_support.py
+++ b/packages/runtime/drqp_moveit/test/moveit_launch_smoke_test_support.py
@@ -20,6 +20,7 @@
 
 import os
 import re
+import time
 
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription, TimerAction
@@ -29,6 +30,7 @@ from launch_pytest.actions import ReadyToTest
 from launch_ros.substitutions import FindPackageShare
 from moveit_msgs.srv import GetMotionPlan
 import rclpy
+from rclpy.node import Node
 
 # Non-simulator smoke launches have no simulation clock to use for readiness.
 # Keep one bounded wall-clock watchdog for every smoke launch, including the
@@ -36,6 +38,7 @@ import rclpy
 # all CTest workers are active. The move_group initial-state timeout must match
 # so it cannot abort before this watchdog.
 READY_TIMEOUT = 180.0
+NODE_POLL_INTERVAL = 0.1
 
 
 def build_smoke_launch_arguments(
@@ -75,18 +78,39 @@ def build_smoke_test_description(
     )
 
 
-def assert_move_group_ready(timeout: float = READY_TIMEOUT) -> None:
+def _remaining_time(deadline: float) -> float:
+    """Return the non-negative wall time remaining before ``deadline``."""
+    return max(0.0, deadline - time.monotonic())
+
+
+def _assert_node_ready(node: Node, node_name: str, deadline: float) -> None:
+    """Poll the ROS graph for ``node_name`` until the shared wall deadline."""
+    while True:
+        if node_name in node.get_node_names():
+            return
+
+        remaining = _remaining_time(deadline)
+        if remaining <= 0.0:
+            raise AssertionError(f'{node_name} node is not available')
+        time.sleep(min(NODE_POLL_INTERVAL, remaining))
+
+
+def assert_moveit_stack_ready(timeout: float = READY_TIMEOUT) -> None:
     """
-    Assert the MoveIt motion-plan service comes up within ``timeout`` seconds.
+    Assert the MoveIt service and drqp_brain node are ready within ``timeout``.
 
     Requires ``rclpy`` to already be initialized (see the ``move_group`` fixture).
+    A monotonic wall deadline is shared by service and graph readiness because
+    non-simulator launches do not have a simulation clock.
     """
+    deadline = time.monotonic() + timeout
     node = rclpy.create_node('moveit_launch_smoke_test')
     motion_plan_client = node.create_client(GetMotionPlan, '/plan_kinematic_path')
     try:
-        assert motion_plan_client.wait_for_service(timeout_sec=timeout), (
+        assert motion_plan_client.wait_for_service(timeout_sec=_remaining_time(deadline)), (
             '/plan_kinematic_path service is not available'
         )
+        _assert_node_ready(node, 'drqp_brain', deadline)
     finally:
         motion_plan_client.destroy()
         node.destroy_node()

--- a/packages/runtime/drqp_moveit/test/test_demo_gazebo_launch_smoke.py
+++ b/packages/runtime/drqp_moveit/test/test_demo_gazebo_launch_smoke.py
@@ -23,7 +23,7 @@
 from drqp_launch_testing import assert_processes_exited_cleanly, track_process_exit_codes
 import launch_pytest
 from moveit_launch_smoke_test_support import (
-    assert_move_group_ready,
+    assert_moveit_stack_ready,
     build_smoke_test_description,
     build_test_gz_partition,
 )
@@ -50,10 +50,10 @@ def generate_test_description():
 @pytest.mark.flaky(retries=3)
 def test_launch_reaches_ready_state(move_group, generate_test_description):  # noqa: ARG001
     # Retries via pytest-retry: the post-yield shutdown exit-code check below is
-    # intermittently flaky (see issue #408). assert_move_group_ready() failures
+    # intermittently flaky (see issue #408). Stack readiness failures
     # are genuine regressions and reproduce identically on every retry, so they
     # still fail the build.
-    assert_move_group_ready()
+    assert_moveit_stack_ready()
     # Function-scoped generator: the stack tears down at the yield, then the
     # post-yield body verifies every non-simulator process exited cleanly.
     yield

--- a/packages/runtime/drqp_moveit/test/test_demo_launch_smoke.py
+++ b/packages/runtime/drqp_moveit/test/test_demo_launch_smoke.py
@@ -23,7 +23,7 @@
 from drqp_launch_testing import assert_processes_exited_cleanly, track_process_exit_codes
 import launch_pytest
 from moveit_launch_smoke_test_support import (
-    assert_move_group_ready,
+    assert_moveit_stack_ready,
     build_smoke_test_description,
 )
 import pytest
@@ -42,7 +42,7 @@ def generate_test_description():
 
 @pytest.mark.launch(fixture=generate_test_description)
 def test_launch_reaches_ready_state(move_group, generate_test_description):  # noqa: ARG001
-    assert_move_group_ready()
+    assert_moveit_stack_ready()
     # Function-scoped generator: the stack tears down at the yield, then the
     # post-yield body verifies every non-simulator process exited cleanly.
     yield

--- a/packages/runtime/drqp_moveit/test/test_move_group_launch_smoke.py
+++ b/packages/runtime/drqp_moveit/test/test_move_group_launch_smoke.py
@@ -28,7 +28,10 @@ from launch.substitutions import PathJoinSubstitution
 import launch_pytest
 from launch_pytest.actions import ReadyToTest
 from launch_ros.substitutions import FindPackageShare
-from moveit_launch_smoke_test_support import assert_move_group_ready
+from moveit_launch_smoke_test_support import (
+    assert_move_group_ready,
+    build_smoke_launch_arguments,
+)
 import pytest
 
 
@@ -46,7 +49,9 @@ def generate_test_description():
         [
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(move_group_launch),
-                launch_arguments={'hardware_device_address': 'mock_servo'}.items(),
+                launch_arguments=build_smoke_launch_arguments(
+                    {'hardware_device_address': 'mock_servo'}
+                ).items(),
             ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(bringup_launch),

--- a/packages/runtime/drqp_moveit/test/test_move_group_launch_smoke.py
+++ b/packages/runtime/drqp_moveit/test/test_move_group_launch_smoke.py
@@ -29,7 +29,7 @@ import launch_pytest
 from launch_pytest.actions import ReadyToTest
 from launch_ros.substitutions import FindPackageShare
 from moveit_launch_smoke_test_support import (
-    assert_move_group_ready,
+    assert_moveit_stack_ready,
     build_smoke_launch_arguments,
 )
 import pytest
@@ -72,7 +72,7 @@ def generate_test_description():
 
 @pytest.mark.launch(fixture=generate_test_description)
 def test_launch_reaches_ready_state(move_group, generate_test_description):  # noqa: ARG001
-    assert_move_group_ready()
+    assert_moveit_stack_ready()
     # Function-scoped generator: the stack tears down at the yield, then the
     # post-yield body verifies every non-simulator process exited cleanly.
     yield

--- a/packages/runtime/drqp_moveit/test/test_moveit_launch_config.py
+++ b/packages/runtime/drqp_moveit/test/test_moveit_launch_config.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Tests for MoveIt launch argument ownership and smoke-test overrides."""
+
+import importlib.util
+from pathlib import Path
+
+from launch import LaunchContext
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    LogInfo,
+)
+from launch.utilities import perform_substitutions
+from moveit_launch_smoke_test_support import (
+    build_smoke_test_description,
+    READY_TIMEOUT,
+)
+
+
+def _load_move_group_launch_module():
+    launch_path = Path(__file__).parents[1] / 'launch' / 'move_group.launch.py'
+    spec = importlib.util.spec_from_file_location('move_group_launch', launch_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_move_group_launch_owns_initial_state_timeout() -> None:
+    """Keep the production timeout configurable with its existing default."""
+    module = _load_move_group_launch_module()
+    captured_parameters = {}
+
+    def capture_node(**kwargs):
+        """Capture the final nested override instead of starting move_group."""
+        captured_parameters.update(kwargs['parameters'][-1])
+        return LogInfo(msg='Captured move_group node parameters')
+
+    module.Node = capture_node
+    launch_description = module.generate_launch_description()
+    timeout_argument = next(
+        entity
+        for entity in launch_description.entities
+        if isinstance(entity, DeclareLaunchArgument)
+        and entity.name == 'wait_for_initial_state_timeout'
+    )
+
+    assert perform_substitutions(LaunchContext(), timeout_argument.default_value) == '10.0'
+
+    context = LaunchContext()
+    context.launch_configurations['wait_for_initial_state_timeout'] = str(READY_TIMEOUT)
+    timeout_parameter = captured_parameters['planning_scene_monitor_options'][
+        'wait_for_initial_state_timeout'
+    ]
+    assert timeout_parameter.evaluate(context) == READY_TIMEOUT
+
+
+def test_smoke_description_matches_move_group_timeout_to_watchdog() -> None:
+    """Allow move_group to wait as long as the smoke readiness watchdog."""
+    launch_description = build_smoke_test_description(
+        'demo.launch.py',
+        launch_arguments={'show_rviz': 'false'},
+    )
+    include = next(
+        entity
+        for entity in launch_description.entities
+        if isinstance(entity, IncludeLaunchDescription)
+    )
+
+    launch_arguments = dict(include.launch_arguments)
+    assert launch_arguments['show_rviz'] == 'false'
+    assert launch_arguments['wait_for_initial_state_timeout'] == str(READY_TIMEOUT)

--- a/packages/runtime/drqp_moveit/test/test_moveit_launch_smoke_test_support.py
+++ b/packages/runtime/drqp_moveit/test/test_moveit_launch_smoke_test_support.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Anton Matosov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Unit tests for MoveIt smoke-test graph readiness."""
+
+from unittest.mock import MagicMock
+
+import moveit_launch_smoke_test_support as smoke_support
+import pytest
+
+
+class FakeMonotonicClock:
+    """Controllable wall clock for deadline and polling assertions."""
+
+    def __init__(self) -> None:
+        self.now = 100.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        """Return the current fake monotonic time."""
+        return self.now
+
+    def sleep(self, duration: float) -> None:
+        """Advance fake time while recording the requested sleep."""
+        self.sleeps.append(duration)
+        self.now += duration
+
+
+def test_stack_readiness_polls_for_brain_with_shared_deadline(monkeypatch) -> None:
+    """Wait for drqp_brain after the MoveIt service becomes ready."""
+    clock = FakeMonotonicClock()
+    client = MagicMock()
+    node = MagicMock()
+    node.create_client.return_value = client
+    node.get_node_names.side_effect = [[], ['drqp_brain']]
+
+    def wait_for_service(*, timeout_sec: float) -> bool:
+        """Consume part of the shared deadline before service readiness."""
+        assert timeout_sec == pytest.approx(5.0)
+        clock.now += 2.0
+        return True
+
+    client.wait_for_service.side_effect = wait_for_service
+    monkeypatch.setattr(smoke_support.time, 'monotonic', clock.monotonic)
+    monkeypatch.setattr(smoke_support.time, 'sleep', clock.sleep)
+    monkeypatch.setattr(smoke_support.rclpy, 'create_node', lambda _name: node)
+
+    smoke_support.assert_moveit_stack_ready(timeout=5.0)
+
+    assert clock.sleeps == [smoke_support.NODE_POLL_INTERVAL]
+    client.destroy.assert_called_once_with()
+    node.destroy_node.assert_called_once_with()
+
+
+def test_stack_readiness_bounds_node_polling_by_remaining_time(monkeypatch) -> None:
+    """Fail on the wall deadline without oversleeping for graph discovery."""
+    clock = FakeMonotonicClock()
+    client = MagicMock()
+    node = MagicMock()
+    node.create_client.return_value = client
+    node.get_node_names.return_value = []
+
+    def wait_for_service(*, timeout_sec: float) -> bool:
+        """Leave less than one poll interval in the shared budget."""
+        assert timeout_sec == pytest.approx(1.0)
+        clock.now += 0.95
+        return True
+
+    client.wait_for_service.side_effect = wait_for_service
+    monkeypatch.setattr(smoke_support.time, 'monotonic', clock.monotonic)
+    monkeypatch.setattr(smoke_support.time, 'sleep', clock.sleep)
+    monkeypatch.setattr(smoke_support.rclpy, 'create_node', lambda _name: node)
+
+    with pytest.raises(AssertionError, match='drqp_brain node is not available'):
+        smoke_support.assert_moveit_stack_ready(timeout=1.0)
+
+    assert clock.sleeps == [pytest.approx(0.05)]
+    client.destroy.assert_called_once_with()
+    node.destroy_node.assert_called_once_with()

--- a/packages/simulation/drqp_gazebo/test/CMakeLists.txt
+++ b/packages/simulation/drqp_gazebo/test/CMakeLists.txt
@@ -29,22 +29,15 @@ if("$ENV{DRQP_TEST_MODE}" STREQUAL "slow")
   list(APPEND drqp_gazebo_launch_tests ${drqp_gazebo_full_launch_tests})
 endif()
 
-# Each balance-mode parameter starts a separate Gazebo simulation. The full
-# direction matrix therefore needs more time than the other launch tests.
-set(drqp_gazebo_balance_mode_test_timeout 480)
-set(drqp_gazebo_test_timeout 300)
-
 foreach(test_file IN LISTS drqp_gazebo_launch_tests)
-  set(test_timeout ${drqp_gazebo_test_timeout})
-  if(test_file STREQUAL "test_robot_control_balance_mode.py")
-    set(test_timeout ${drqp_gazebo_balance_mode_test_timeout})
-  endif()
-
-  # Each launch test boots Gazebo and exercises several robot/board scenarios, so
-  # it needs well over the 60s add_launch_test default before completing.
+  # Physics and behavior deadlines are enforced by simulation time in the test
+  # harness. A CTest wall timeout would make the result depend on Gazebo's
+  # real-time factor under parallel load, so disable that outer deadline.
   drqp_add_ros_isolated_launch_test(
     ${test_file}
-    TIMEOUT ${test_timeout}
-    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}
+    APPEND_ENV
+      PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}
   )
+  cmake_path(GET test_file STEM test_name)
+  set_tests_properties(${test_name} PROPERTIES TIMEOUT 0)
 endforeach()

--- a/packages/simulation/drqp_gazebo/test/conftest.py
+++ b/packages/simulation/drqp_gazebo/test/conftest.py
@@ -26,14 +26,26 @@ from robot_control_test_support import GazeboRobotControlBase
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Skip slow tests unless DRQP_TEST_MODE=slow is set."""
-    if os.environ.get('DRQP_TEST_MODE') == 'slow':
-        return
-
+    """Configure slow-test selection and retries for isolated launch tests."""
+    run_slow_tests = os.environ.get('DRQP_TEST_MODE') == 'slow'
     skip_slow = pytest.mark.skip(reason='Slow test excluded from default CI run')
     for item in items:
-        if 'slow' in item.keywords:
+        # Every launch fixture in this package is function-scoped, so pytest-retry
+        # can relaunch it after transient discovery or shutdown failures.
+        if 'launch' in item.keywords and 'flaky' not in item.keywords:
+            item.add_marker(pytest.mark.flaky(retries=3))
+        if not run_slow_tests and 'slow' in item.keywords:
             item.add_marker(skip_slow)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_call(item: pytest.Item) -> None:
+    """Surface harness setup failures where pytest-retry can relaunch them."""
+    for fixture_name in ('robot', 'board'):
+        harness = item.funcargs.get(fixture_name)
+        setup_error = getattr(harness, 'setup_error', None)
+        if setup_error is not None:
+            raise setup_error
 
 
 @pytest.fixture
@@ -52,7 +64,18 @@ def robot(generate_test_description):  # noqa: ARG001 (drives launch + sim readi
     """
     rclpy.init()
     harness = GazeboRobotControlBase()
-    harness.setup_node()
-    yield harness
-    harness.assert_no_moveit_ik_failures()
-    rclpy.try_shutdown()
+    harness.setup_error = None
+    try:
+        try:
+            harness.setup_node()
+        except Exception as error:  # noqa: BLE001 - re-raised by pytest_runtest_call
+            # pytest-retry cannot retry fixture-setup failures. Preserve the
+            # original exception and surface it in the call phase instead.
+            harness.setup_error = error
+        yield harness
+        if harness.setup_error is None:
+            harness.assert_no_moveit_ik_failures()
+    finally:
+        if hasattr(harness, 'node') and rclpy.ok():
+            harness.node.destroy_node()
+        rclpy.try_shutdown()

--- a/packages/simulation/drqp_gazebo/test/fixtures/clock_bridge.yml
+++ b/packages/simulation/drqp_gazebo/test/fixtures/clock_bridge.yml
@@ -1,0 +1,5 @@
+- ros_topic_name: '/clock'
+  gz_topic_name: '/clock'
+  ros_type_name: 'rosgraph_msgs/msg/Clock'
+  gz_type_name: 'gz.msgs.Clock'
+  direction: GZ_TO_ROS

--- a/packages/simulation/drqp_gazebo/test/robot_control_test_support.py
+++ b/packages/simulation/drqp_gazebo/test/robot_control_test_support.py
@@ -32,7 +32,7 @@ import time
 
 import builtin_interfaces
 import builtin_interfaces.msg
-from controller_manager.test_utils import check_controllers_running, check_node_running
+from controller_manager.test_utils import check_controllers_running
 from drqp_brain.balance_controller import body_tilt_from_imu
 from drqp_interfaces.msg import MovementCommand, MovementCommandConstants
 from drqp_launch_testing import track_process_exit_codes
@@ -44,12 +44,12 @@ from launch.substitutions import PathJoinSubstitution
 import launch_pytest
 from launch_pytest.actions import ReadyToTest
 from launch_ros.substitutions import FindPackageShare
-from launch_testing_ros import WaitForTopics
 from nav_msgs.msg import Odometry
 import pytest
 from rcl_interfaces.msg import Log
 import rclpy
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile
+from ros_gz_bridge.actions import RosGzBridge
 from rosgraph_msgs.msg import Clock
 from sensor_msgs.msg import Imu
 import std_msgs.msg
@@ -125,7 +125,7 @@ def create_board_only_launch_description() -> LaunchDescription:
     Used to characterise the board fixture in isolation: it verifies the tilting
     mechanism reaches its commanded angles without any coupling from the robot.
     """
-    return create_simulation_launch_description(
+    launch_description = create_simulation_launch_description(
         launch_arguments={
             'world_sdf': BALANCE_BOARD_WORLD_PATH,
             'spawn_robot': 'false',
@@ -134,6 +134,18 @@ def create_board_only_launch_description() -> LaunchDescription:
             'sim_gui': 'false',
         }
     )
+    # The production spawn_robot:=false path intentionally starts no ROS bridge.
+    # This test still needs /clock so physics waits use simulation time.
+    launch_description.add_action(
+        RosGzBridge(
+            bridge_name='drqp_board_test_clock_bridge',
+            config_file=str(Path(__file__).resolve().parent / 'fixtures' / 'clock_bridge.yml'),
+            use_composition='false',
+            create_own_container='true',
+            container_name='drqp_board_test_clock_container',
+        )
+    )
+    return launch_description
 
 
 @launch_pytest.fixture
@@ -151,13 +163,13 @@ class GazeboRobotControlBase:
     __test__ = False  # Prevent pytest from collecting this base class as a test case.
 
     # Configurable timeouts.
-    READY_TIMEOUT = 90.0
+    READY_TIMEOUT = 180.0
     SPAWN_TIMEOUT = 90.0
     STATE_TRANSITION_TIMEOUT = 90.0
     MOVEMENT_TIMEOUT = 30.0
-    CLOCK_TIMEOUT = 30.0
-    CONTROLLER_TIMEOUT = 60.0
-    SIM_TIME_TIMEOUT = 60.0
+    CLOCK_TIMEOUT = 180.0
+    CONTROLLER_TIMEOUT = 180.0
+    SIM_CLOCK_STALL_TIMEOUT = 60.0
     GZ_COMMAND_TIMEOUT = 10.0
     # Non-blocking spin_once() calls per _spin_until() poll cycle, to drain a
     # burst of ready callbacks (see _spin_until docstring) instead of
@@ -181,6 +193,7 @@ class GazeboRobotControlBase:
     # Republish a few times so a single drop does not leave an axis uncommanded.
     BOARD_TILT_PUBLISH_ATTEMPTS = 3
     BOARD_TILT_PUBLISH_INTERVAL = 0.15
+    BOARD_TILT_REPUBLISH_SIM_INTERVAL = 1.0
 
     # Absolute tolerance (radians) for the board reaching a commanded angle.
     BOARD_TILT_TOLERANCE = 0.03
@@ -263,7 +276,7 @@ class GazeboRobotControlBase:
     def _wait_for_simulation_ready(self) -> None:
         self.assert_nodes_and_clock()
         self.assert_controllers_are_active()
-        self._spin_until(
+        self._spin_until_sim_time(
             lambda: (
                 self.event_pub.get_subscription_count() > 0
                 and self.movement_pub.get_subscription_count() > 0
@@ -275,7 +288,7 @@ class GazeboRobotControlBase:
             ('torque_off',),  # robot initial state
             self.SPAWN_TIMEOUT,
         )
-        self._wait_for_sim_time(self.POSE_SETTLE_DURATION, wall_timeout_sec=self.CLOCK_TIMEOUT)
+        self._wait_for_sim_time(self.POSE_SETTLE_DURATION)
         self._wait_for_pose()
 
     def _robot_state_callback(self, msg: std_msgs.msg.String) -> None:
@@ -333,6 +346,59 @@ class GazeboRobotControlBase:
             time.sleep(0.1)
         raise TimeoutError(error_message)
 
+    def _spin_until_sim_time(
+        self,
+        condition_fn: Callable[[], bool],
+        timeout_sec: float,
+        error_message: str | Callable[[], str],
+        *,
+        start_time_ns: int | None = None,
+    ) -> bool:
+        """Spin until a condition or a simulation-time deadline is reached."""
+        self._spin_until(
+            lambda: self.current_clock is not None,
+            self.CLOCK_TIMEOUT,
+            'Did not receive /clock from Gazebo bridge',
+        )
+        if start_time_ns is None:
+            start_time_ns = self._current_sim_time_ns()
+        if start_time_ns is None:
+            raise RuntimeError('Simulation clock became unavailable before timed wait')
+
+        deadline_ns = start_time_ns + int(timeout_sec * 1_000_000_000)
+        latest_sim_time_ns = start_time_ns
+        last_clock_progress = time.monotonic()
+
+        def format_error_message() -> str:
+            if callable(error_message):
+                return error_message()
+            return error_message
+
+        while True:
+            for _ in range(self.SPIN_DRAIN_ITERATIONS):
+                rclpy.spin_once(self.node, timeout_sec=0.0)
+
+            current_sim_time_ns = self._current_sim_time_ns()
+            if condition_fn():
+                return True
+
+            if current_sim_time_ns is not None:
+                if current_sim_time_ns >= deadline_ns:
+                    raise TimeoutError(
+                        f'{format_error_message()} after {timeout_sec:.1f}s of simulation time'
+                    )
+                if current_sim_time_ns != latest_sim_time_ns:
+                    latest_sim_time_ns = current_sim_time_ns
+                    last_clock_progress = time.monotonic()
+
+            stalled_for = time.monotonic() - last_clock_progress
+            if stalled_for >= self.SIM_CLOCK_STALL_TIMEOUT:
+                raise TimeoutError(
+                    f'{format_error_message()}; /clock did not advance for '
+                    f'{stalled_for:.1f}s of wall time'
+                )
+            time.sleep(0.1)
+
     def _publish_event(self, event_name: str) -> None:
         msg = std_msgs.msg.String()
         msg.data = event_name
@@ -341,7 +407,7 @@ class GazeboRobotControlBase:
         rclpy.spin_once(self.node, timeout_sec=0.1)
 
     def _wait_for_state(self, expected_state: str, timeout_sec: float) -> None:
-        self._spin_until(
+        self._spin_until_sim_time(
             lambda: self.current_robot_state == expected_state,
             timeout_sec,
             f'Robot did not reach state "{expected_state}" within {timeout_sec}s. '
@@ -353,7 +419,7 @@ class GazeboRobotControlBase:
         expected_states: tuple[str, ...],
         timeout_sec: float,
     ) -> None:
-        self._spin_until(
+        self._spin_until_sim_time(
             lambda: self.current_robot_state in expected_states,
             timeout_sec,
             f'Robot did not reach any expected state {expected_states} '
@@ -369,8 +435,6 @@ class GazeboRobotControlBase:
         self,
         start_time_ns: int,
         duration_sec: float,
-        *,
-        wall_timeout_sec: float | None = None,
     ) -> None:
         target_time_ns = start_time_ns + int(duration_sec * 1_000_000_000)
 
@@ -378,21 +442,16 @@ class GazeboRobotControlBase:
             current_time_ns = self._current_sim_time_ns()
             return current_time_ns is not None and current_time_ns >= target_time_ns
 
-        timeout_sec = wall_timeout_sec or max(self.SIM_TIME_TIMEOUT, duration_sec * 12.0)
-        self._spin_until(
+        self._spin_until_sim_time(
             reached_target_time,
-            timeout_sec,
-            (
-                f'Simulation time did not advance by {duration_sec:.1f}s '
-                f'within {timeout_sec:.1f}s of wall time'
-            ),
+            duration_sec,
+            f'Simulation time did not advance by {duration_sec:.1f}s',
+            start_time_ns=start_time_ns,
         )
 
     def _wait_for_sim_time(
         self,
         duration_sec: float,
-        *,
-        wall_timeout_sec: float | None = None,
     ) -> None:
         self._spin_until(
             lambda: self.current_clock is not None,
@@ -407,18 +466,17 @@ class GazeboRobotControlBase:
         self._wait_for_sim_time_since(
             start_time_ns,
             duration_sec,
-            wall_timeout_sec=wall_timeout_sec,
         )
 
     def _wait_for_pose(self) -> None:
-        self._spin_until(
+        self._spin_until_sim_time(
             lambda: self.robot_pose is not None,
             self.MOVEMENT_TIMEOUT,
             f'Did not receive {ODOM_TOPIC} from Gazebo bridge',
         )
 
     def _wait_for_new_pose(self, previous_pose_stamp_ns: int | None) -> None:
-        self._spin_until(
+        self._spin_until_sim_time(
             lambda: (
                 self.robot_pose is not None
                 and self.robot_pose_stamp_ns is not None
@@ -432,7 +490,7 @@ class GazeboRobotControlBase:
         )
 
     def _wait_for_new_imu(self, previous_imu_stamp_ns: int | None) -> None:
-        self._spin_until(
+        self._spin_until_sim_time(
             lambda: (
                 self.current_imu_message is not None
                 and self.current_imu_stamp_ns is not None
@@ -566,7 +624,7 @@ class GazeboRobotControlBase:
         return completed.stdout
 
     def _set_balance_mode(self, enabled: bool) -> None:
-        self._spin_until(
+        self._spin_until_sim_time(
             lambda: self.balance_mode_pub.get_subscription_count() > 0,
             self.READY_TIMEOUT,
             'Timed out waiting for /robot/balance_mode subscribers',
@@ -594,25 +652,29 @@ class GazeboRobotControlBase:
         make ``_wait_for_board_tilt`` time out. Publish each target a few times to
         make delivery reliable.
         """
+        for _ in range(self.BOARD_TILT_PUBLISH_ATTEMPTS):
+            self._publish_board_tilt_targets(roll=roll, pitch=pitch)
+            time.sleep(self.BOARD_TILT_PUBLISH_INTERVAL)
+
+    def _publish_board_tilt_targets(self, *, roll: float, pitch: float) -> None:
+        """Publish one roll/pitch target pair to Gazebo transport."""
         for topic, value, context in (
             (BALANCE_BOARD_ROLL_TOPIC, roll, 'Setting balance board roll target'),
             (BALANCE_BOARD_PITCH_TOPIC, pitch, 'Setting balance board pitch target'),
         ):
-            for _ in range(self.BOARD_TILT_PUBLISH_ATTEMPTS):
-                self._run_gz_command(
-                    [
-                        'gz',
-                        'topic',
-                        '-t',
-                        topic,
-                        '-m',
-                        'gz.msgs.Double',
-                        '-p',
-                        f'data: {value}',
-                    ],
-                    error_context=context,
-                )
-                time.sleep(self.BOARD_TILT_PUBLISH_INTERVAL)
+            self._run_gz_command(
+                [
+                    'gz',
+                    'topic',
+                    '-t',
+                    topic,
+                    '-m',
+                    'gz.msgs.Double',
+                    '-p',
+                    f'data: {value}',
+                ],
+                error_context=context,
+            )
 
     def _sample_entity_pose_from_gazebo(self, entity_name: str) -> Pose:
         """
@@ -675,23 +737,45 @@ class GazeboRobotControlBase:
             Observed board roll and pitch in radians.
 
         """
-        deadline = time.monotonic() + self.MOVEMENT_TIMEOUT
         last_roll = 0.0
         last_pitch = 0.0
-        while time.monotonic() < deadline:
+        last_publish_sim_time_ns = self._current_sim_time_ns()
+
+        def board_reached_tilt() -> bool:
+            nonlocal last_pitch, last_publish_sim_time_ns, last_roll
+
             board_pose = self._sample_entity_pose_from_gazebo(BALANCE_BOARD_BOARD_LINK_NAME)
             last_roll, last_pitch = self._roll_pitch_from_quaternion(board_pose.orientation)
-            if (
+            reached_target = (
                 abs(last_roll - expected_roll) <= tolerance
                 and abs(last_pitch - expected_pitch) <= tolerance
+            )
+            if reached_target:
+                return True
+
+            current_sim_time_ns = self._current_sim_time_ns()
+            republish_interval_ns = int(self.BOARD_TILT_REPUBLISH_SIM_INTERVAL * 1_000_000_000)
+            if current_sim_time_ns is not None and (
+                last_publish_sim_time_ns is None
+                or current_sim_time_ns - last_publish_sim_time_ns >= republish_interval_ns
             ):
-                return last_roll, last_pitch
-            time.sleep(0.2)
-        raise TimeoutError(
-            'Gazebo board tilt did not reach the expected pose. '
-            f'Expected roll={expected_roll:.3f}, pitch={expected_pitch:.3f}; '
-            f'last roll={last_roll:.3f}, pitch={last_pitch:.3f}'
+                self._publish_board_tilt_targets(
+                    roll=expected_roll,
+                    pitch=expected_pitch,
+                )
+                last_publish_sim_time_ns = current_sim_time_ns
+            return False
+
+        self._spin_until_sim_time(
+            board_reached_tilt,
+            self.MOVEMENT_TIMEOUT,
+            lambda: (
+                'Gazebo board tilt did not reach the expected pose. '
+                f'Expected roll={expected_roll:.3f}, pitch={expected_pitch:.3f}; '
+                f'last roll={last_roll:.3f}, pitch={last_pitch:.3f}'
+            ),
         )
+        return last_roll, last_pitch
 
     def _sample_board_tilt(self) -> tuple[float, float]:
         """Return the board's current roll and pitch in radians from Gazebo."""
@@ -860,14 +944,29 @@ class GazeboRobotControlBase:
 
     def assert_nodes_and_clock(self) -> None:
         """Verify simulation nodes are running and clock is available."""
-        for node_name in ('robot_state_publisher', 'drqp_brain', 'drqp_robot_state'):
-            check_node_running(self.node, node_name, timeout=self.CLOCK_TIMEOUT)
-
-        with WaitForTopics([('/clock', Clock)], timeout=self.CLOCK_TIMEOUT) as wait:
-            assert wait.wait(), 'Did not receive /clock from Gazebo bridge'
+        # A wall-clock watchdog is unavoidable until the first clock sample
+        # exists. Once Gazebo is advancing, graph discovery must tolerate a low
+        # real-time factor just like the physics assertions do.
+        self._spin_until(
+            lambda: self.current_clock is not None,
+            self.CLOCK_TIMEOUT,
+            'Did not receive /clock from Gazebo bridge',
+        )
+        expected_nodes = ('robot_state_publisher', 'drqp_brain', 'drqp_robot_state')
+        self._spin_until_sim_time(
+            lambda: all(node_name in self.node.get_node_names() for node_name in expected_nodes),
+            self.READY_TIMEOUT,
+            lambda: (
+                f'Did not discover simulation nodes {expected_nodes}; '
+                f'seeing {self.node.get_node_names()}'
+            ),
+        )
 
     def assert_controllers_are_active(self) -> None:
         """Verify ros2_control controllers are alive inside Gazebo."""
+        # controller_manager's test helper performs synchronous service waits and
+        # exposes only a wall-clock timeout. Keep this as a startup watchdog; all
+        # subsequent simulation behavior is measured against /clock.
         check_controllers_running(
             self.node,
             [
@@ -879,13 +978,16 @@ class GazeboRobotControlBase:
 
     def assert_imu_data(self) -> None:
         """Verify the simulated IMU publishes on /imu/data via the Gazebo bridge."""
-        with WaitForTopics([('/imu/data', Imu)], timeout=self.CLOCK_TIMEOUT) as wait:
-            assert wait.wait(), 'Did not receive /imu/data from Gazebo IMU sensor'
+        self._spin_until_sim_time(
+            lambda: self.current_imu_message is not None,
+            self.CLOCK_TIMEOUT,
+            'Did not receive /imu/data from Gazebo IMU sensor',
+        )
 
     def assert_imu_data_reports_orientation(self) -> None:
         """Issue 356: Gazebo IMU data should publish body attitude for ROS consumers."""
         self.assert_imu_data()
-        self._spin_until(
+        self._spin_until_sim_time(
             lambda: self.current_imu_message is not None,
             self.CLOCK_TIMEOUT,
             'Did not capture /imu/data after Gazebo IMU topic became available',
@@ -915,11 +1017,15 @@ class GazeboRobotControlBase:
     def assert_robot_spawned(self) -> None:
         """Verify robot model is spawned and state machine publishes state."""
         try:
-            check_node_running(self.node, 'robot_state_publisher', timeout=self.SPAWN_TIMEOUT)
+            self._spin_until_sim_time(
+                lambda: 'robot_state_publisher' in self.node.get_node_names(),
+                self.SPAWN_TIMEOUT,
+                'Robot model failed to spawn: robot_state_publisher not running',
+            )
         except (AssertionError, RuntimeError, TimeoutError) as error:
             raise RuntimeError(
                 'Robot model failed to spawn: robot_state_publisher not running within '
-                f'{self.SPAWN_TIMEOUT}s'
+                f'{self.SPAWN_TIMEOUT}s of simulation time'
             ) from error
 
         self._wait_for_any_state(
@@ -1243,7 +1349,12 @@ class GazeboRobotControlBase:
         board_r, board_p = self._wait_for_board_tilt(
             expected_roll=board_roll, expected_pitch=board_pitch
         )
-        self._wait_for_stable_body_level(initial_roll, initial_pitch)
+        self._wait_for_stable_body_level(
+            initial_roll,
+            initial_pitch,
+            board_r,
+            board_p,
+        )
         balanced_roll, balanced_pitch = self._sample_base_roll_pitch(
             settle_sim_time_sec=self.POSE_SETTLE_DURATION
         )
@@ -1288,8 +1399,10 @@ class GazeboRobotControlBase:
         self,
         initial_roll: float,
         initial_pitch: float,
+        board_roll: float,
+        board_pitch: float,
     ) -> None:
-        """Wait for a post-tilt pose that remains within the tilt tolerance."""
+        """Wait for a post-tilt pose that stably meets compensation criteria."""
         previous_pose_stamp_ns = self.robot_pose_stamp_ns
         self._wait_for_new_pose(previous_pose_stamp_ns)
         self._wait_for_sim_time(self.BALANCE_RESPONSE_DURATION)
@@ -1306,6 +1419,8 @@ class GazeboRobotControlBase:
             is_level = (
                 abs(roll - initial_roll) <= self.BALANCED_BODY_TILT_TOLERANCE
                 and abs(pitch - initial_pitch) <= self.BALANCED_BODY_TILT_TOLERANCE
+                and (abs(board_roll) <= 0.05 or abs(board_roll - roll) > 0.05)
+                and (abs(board_pitch) <= 0.05 or abs(board_pitch - pitch) > 0.05)
             )
             if not is_level:
                 aligned_since_ns = None
@@ -1321,7 +1436,7 @@ class GazeboRobotControlBase:
                 self.POSE_SETTLE_DURATION * 1_000_000_000
             )
 
-        self._spin_until(
+        self._spin_until_sim_time(
             body_has_stably_leveled,
             self.MOVEMENT_TIMEOUT,
             'Balance correction did not stabilize the body within the tilt tolerance',
@@ -1333,28 +1448,51 @@ class BalanceBoardWorldBase(GazeboRobotControlBase):
     Harness for testing the balance board fixture in isolation (no robot).
 
     Reuses the board-driving helpers from :class:`GazeboRobotControlBase` but
-    launches Gazebo with ``spawn_robot:=false``, so there is no robot, ROS bridge,
-    or control stack. The board helpers talk to Gazebo over the ``gz`` CLI and need
-    no ROS node, so the test fixture only waits for the world to start serving
-    poses via :meth:`wait_for_board_world_ready`.
+    launches Gazebo with ``spawn_robot:=false``, so there is no robot or control
+    stack. The board helpers talk to Gazebo over the ``gz`` CLI; a test-only clock
+    bridge and ROS node provide simulation-time deadlines for physics behavior.
     """
 
     __test__ = False  # Prevent pytest from collecting this base class as a test case.
 
+    def setup_clock_node(self) -> None:
+        """Create the board-test node and wait for the test-only clock bridge."""
+        self.node = rclpy.create_node('test_gazebo_balance_board_world')
+        self.current_clock = None
+        self.clock_sub = self.node.create_subscription(
+            Clock,
+            '/clock',
+            self._clock_callback,
+            10,
+        )
+        self._spin_until(
+            lambda: self.current_clock is not None,
+            self.CLOCK_TIMEOUT,
+            'Did not receive /clock from the board test Gazebo bridge',
+        )
+
     def wait_for_board_world_ready(self) -> Pose:
         """Poll Gazebo until the board entity pose is served, tolerating startup errors."""
-        deadline = time.monotonic() + self.READY_TIMEOUT
         last_error = ''
-        while time.monotonic() < deadline:
+
+        def board_pose_is_available() -> bool:
+            nonlocal last_error
             try:
-                return self._sample_entity_pose_from_gazebo(BALANCE_BOARD_BOARD_LINK_NAME)
+                self.board_pose = self._sample_entity_pose_from_gazebo(
+                    BALANCE_BOARD_BOARD_LINK_NAME
+                )
+                return True
             except (AssertionError, RuntimeError) as error:
                 # gz CLI not up yet, or the world has not published poses; retry.
                 last_error = str(error)
-            time.sleep(0.5)
-        raise AssertionError(
-            f'Balance board world did not become ready within {self.READY_TIMEOUT}s: {last_error}'
+                return False
+
+        self._spin_until_sim_time(
+            board_pose_is_available,
+            self.READY_TIMEOUT,
+            lambda: f'Balance board world did not become ready: {last_error}',
         )
+        return self.board_pose
 
 
 def _parse_gazebo_pose_info(raw_output: str) -> list[dict[str, Pose | str]]:

--- a/packages/simulation/drqp_gazebo/test/test_balance_board_world.py
+++ b/packages/simulation/drqp_gazebo/test/test_balance_board_world.py
@@ -32,6 +32,7 @@ import math
 from drqp_launch_testing import assert_processes_exited_cleanly, track_process_exit_codes
 import launch_pytest
 import pytest
+import rclpy
 from robot_control_test_support import (
     BalanceBoardWorldBase,
     create_board_only_launch_description,
@@ -65,13 +66,24 @@ def board(generate_test_description):  # noqa: ARG001 (drives the launch)
     """
     Provide a board-only harness bound to the launched world.
 
-    The board-only launch starts no robot, ROS bridge, or control stack, and the
-    board helpers talk to Gazebo over the ``gz`` CLI, so no ``rclpy`` node is
-    needed; the fixture only waits for the board world to start serving poses.
+    The board-only launch starts no robot or control stack, and the board helpers
+    talk to Gazebo over the ``gz`` CLI. A small ROS node consumes the test-only
+    ``/clock`` bridge so physics waits use simulation time.
     """
     harness = BalanceBoardWorldBase()
-    harness.wait_for_board_world_ready()
-    yield harness
+    harness.setup_error = None
+    rclpy.init()
+    try:
+        try:
+            harness.setup_clock_node()
+            harness.wait_for_board_world_ready()
+        except Exception as error:  # noqa: BLE001 - re-raised by pytest_runtest_call
+            harness.setup_error = error
+        yield harness
+    finally:
+        if hasattr(harness, 'node') and rclpy.ok():
+            harness.node.destroy_node()
+        rclpy.try_shutdown()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
# Summary

Make isolated Gazebo launch tests resilient to uncapped parallel CTest execution by measuring simulation behavior against `/clock` while retaining bounded startup and clock-stall watchdogs. Scope runtime and launch instance guards to `ROS_DOMAIN_ID` and correct CI/devcontainer environment handling so parallel test processes can start independently.

## What Changed

- Scope brain, robot-state, and launch instance locks by ROS domain; duplicate launches now log an actionable error and request orderly shutdown rather than raising from the launch context. Add coverage for lock contention and domain isolation.
- Make Gazebo readiness, behavior, and balance assertions simulation-time aware; disable the outer CTest wall timeout, add a clock-only bridge for the board fixture, retry function-scoped launch tests, and republish board targets when discovery is delayed.
- Require stable balance compensation before accepting a scenario, retain wall-clock watchdogs before clock availability, and extend the non-simulated MoveIt smoke-test startup watchdog.
- Enable configured CTest parallelism in CI and the devcontainer, and pass the simulation-test-mode environment through the devcontainer as newline-delimited entries.

## Why

Under high parallel load, Gazebo can run below real time, so wall-clock deadlines caused false failures despite correct simulated behavior. Isolating guards by ROS domain prevents independently launched tests from blocking each other, while the environment fix ensures each CI matrix run receives its intended test mode.

## How to Test

1. Recorded full slow `drqp_gazebo` suite with default transports and uncapped `-j16`: 15/15 CTest entries passed.
2. Recorded board, IMU, and balance subset with uncapped `-j16`: 15/15 pytest cases passed.
3. Recorded uncapped `drqp_moveit` suite: 9/9 tests passed.
4. Ran Ruff, `ament_flake8`, `xmllint`, and `git diff --check`.
5. Ran `scripts/python-reformat.sh`, `scripts/notebooks-format.sh`, and `scripts/super-linter-local.sh`.

## Breaking Changes

- None.

## Migration

- None.
